### PR TITLE
Add menu sync submenu and bump plugin version

### DIFF
--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -119,16 +119,18 @@ function softone_run_auto_sync_product_menu() {
 }
 add_action('softone_debounced_auto_sync_product_menu', 'softone_run_auto_sync_product_menu');
 
-// Admin page to manually trigger
-add_action('admin_menu', function () {
-    add_management_page(
+// Admin page to manually trigger sync under the Softone menu
+function softone_register_product_menu_sync_page() {
+    add_submenu_page(
+        'softone-settings',
         'Sync Product Categories',
-        'Sync Product Menu',
+        'Menu Sync',
         'manage_options',
         'softone-sync-product-menu',
         'softone_render_sync_product_menu_page'
     );
-});
+}
+add_action('admin_menu', 'softone_register_product_menu_sync_page');
 
 function softone_render_sync_product_menu_page() {
     if (!current_user_can('manage_options')) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.5
+Stable tag: 2.2.6
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.5
+ * Version: 2.2.6
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration
@@ -92,6 +92,7 @@ function softone_admin_menu() {
     add_submenu_page('softone-settings', 'Product Sync', 'Products', 'manage_options', 'softone-products', 'softone_products_page');
     add_submenu_page('softone-settings', 'Order Sync', 'Orders', 'manage_options', 'softone-orders', 'softone_orders_page');
     add_submenu_page('softone-settings', 'Live Logging', 'Logs', 'manage_options', 'softone-logs', 'softone_logs_page');
+    add_submenu_page('softone-settings', 'Menu Sync', 'Menu Sync', 'manage_options', 'softone-sync-product-menu', 'softone_render_sync_product_menu_page');
 }
 
 // Register settings


### PR DESCRIPTION
## Summary
- register product category menu sync page under Softone menu
- expose the new menu option in admin menu
- bump plugin version to 2.2.6

## Testing
- `php -l includes/menu-sync.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dca8d2108327add45514c4dfe5df