### PR TITLE
Skip Uncategorized when syncing menu

### DIFF
--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -45,6 +45,11 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
         $all_term_ids = [];
 
         foreach ($product_cats as $term) {
+            // Skip default "Uncategorized" category
+            if ($term->slug === 'uncategorized') {
+                continue;
+            }
+
             $term_map[$term->term_id] = $term;
             $term_children[$term->parent][] = $term->term_id;
             $all_term_ids[] = $term->term_id;
@@ -52,7 +57,7 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
 
         $new_menu_item_ids = [];
 
-        $add_recursive = function ($parent_term_id, $parent_menu_id) use (&$add_recursive, $term_children, $term_map, &$existing_menu_items, $menu_id, &$new_menu_item_ids) {
+        $add_recursive = function ($parent_term_id, $parent_menu_id) use (&$add_recursive, $term_children, $term_map, &$existing_menu_items, $menu_id, &$new_menu_item_ids, $product_root_id) {
             if (!isset($term_children[$parent_term_id])) return;
 
             foreach ($term_children[$parent_term_id] as $term_id) {
@@ -63,14 +68,22 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
                 }
 
                 $term = $term_map[$term_id];
-                $menu_item_id = wp_update_nav_menu_item($menu_id, 0, [
-                    'menu-item-title' => $term->name,
-                    'menu-item-object' => 'product_cat',
-                    'menu-item-object-id' => $term->term_id,
-                    'menu-item-type' => 'taxonomy',
-                    'menu-item-status' => 'publish',
-                    'menu-item-parent-id' => $parent_menu_id,
-                ]);
+
+                $args = [
+                    'menu-item-title'      => $term->name,
+                    'menu-item-object'     => 'product_cat',
+                    'menu-item-object-id'  => $term->term_id,
+                    'menu-item-type'       => 'taxonomy',
+                    'menu-item-status'     => 'publish',
+                    'menu-item-parent-id'  => $parent_menu_id,
+                ];
+
+                // Add mega menu class for top level categories when using Divi
+                if ($parent_menu_id == $product_root_id) {
+                    $args['menu-item-classes'] = 'mega-menu';
+                }
+
+                $menu_item_id = wp_update_nav_menu_item($menu_id, 0, $args);
 
                 if (is_wp_error($menu_item_id)) continue;
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.6
+Stable tag: 2.2.7
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.6
+ * Version: 2.2.7
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- ignore the `Uncategorized` category when generating the menu
- apply Divi `mega-menu` class to first‑level category links
- bump plugin version to 2.2.7

## Testing
- `true` *(command executed)*

------
https://chatgpt.com/codex/tasks/task_e_6852ded0ac9c83278d985a524475025e