### PR TITLE
Improve WPML compatibility and bump version

### DIFF
--- a/admin/customer-sync-page.php
+++ b/admin/customer-sync-page.php
@@ -8,30 +8,30 @@ function softone_customers_page() {
         if (is_array($result) && isset($result['success']) && $result['success']) {
             echo '<div class="notice notice-success"><p>' . esc_html($result['message']) . '</p></div>';
         } else {
-            echo '<div class="notice notice-error"><p>Failed to synchronize customers.</p></div>';
+            echo '<div class="notice notice-error"><p>' . esc_html__('Failed to synchronize customers.', 'softone-woocommerce-integration') . '</p></div>';
         }
     }
     ?>
     <div class="wrap">
-        <h1>Customer Sync</h1>
+        <h1><?php esc_html_e('Customer Sync', 'softone-woocommerce-integration'); ?></h1>
         <form method="post">
             <input type="hidden" name="sync_customers" value="1" />
-            <?php submit_button('Sync Customers'); ?>
+            <?php submit_button(__('Sync Customers', 'softone-woocommerce-integration')); ?>
         </form>
         <?php if (isset($result) && is_array($result) && isset($result['customers'])): ?>
-        <h2>Synchronized Customers</h2>
+        <h2><?php esc_html_e('Synchronized Customers', 'softone-woocommerce-integration'); ?></h2>
         <table class="widefat fixed" cellspacing="0">
             <thead>
                 <tr>
-                    <th>ID</th>
-                    <th>Code</th>
-                    <th>Name</th>
-                    <th>Email</th>
-                    <th>Address</th>
-                    <th>City</th>
-                    <th>Zip</th>
-                    <th>Country</th>
-                    <th>Phone</th>
+                    <th><?php esc_html_e('ID', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('Code', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('Name', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('Email', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('Address', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('City', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('Zip', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('Country', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('Phone', 'softone-woocommerce-integration'); ?></th>
                 </tr>
             </thead>
             <tbody>

--- a/admin/logs-page.php
+++ b/admin/logs-page.php
@@ -6,22 +6,22 @@ function softone_logs_page() {
     // Handle clear logs request
     if (isset($_POST['clear_logs']) && check_admin_referer('softone_clear_logs_action', 'softone_clear_logs_nonce')) {
         update_option('softone_api_logs', []);
-        echo '<div class="notice notice-success"><p>Logs cleared successfully.</p></div>';
+        echo '<div class="notice notice-success"><p>' . esc_html__('Logs cleared successfully.', 'softone-woocommerce-integration') . '</p></div>';
     }
     ?>
     <div class="wrap">
-        <h1>Softone API Logs</h1>
+        <h1><?php esc_html_e('Softone API Logs', 'softone-woocommerce-integration'); ?></h1>
         <form method="post">
             <?php wp_nonce_field('softone_clear_logs_action', 'softone_clear_logs_nonce'); ?>
             <input type="hidden" name="clear_logs" value="1">
-            <?php submit_button('Clear Logs'); ?>
+            <?php submit_button(__('Clear Logs', 'softone-woocommerce-integration')); ?>
         </form>
         <table class="widefat">
             <thead>
                 <tr>
-                    <th>Timestamp</th>
-                    <th>Action</th>
-                    <th>Message</th>
+                    <th><?php esc_html_e('Timestamp', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('Action', 'softone-woocommerce-integration'); ?></th>
+                    <th><?php esc_html_e('Message', 'softone-woocommerce-integration'); ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -32,7 +32,7 @@ function softone_logs_page() {
                         echo '<tr><td>' . esc_html($log['timestamp']) . '</td><td>' . esc_html($log['action']) . '</td><td>' . esc_html($log['message']) . '</td></tr>';
                     }
                 } else {
-                    echo '<tr><td colspan="3">No logs available.</td></tr>';
+                    echo '<tr><td colspan="3">' . esc_html__('No logs available.', 'softone-woocommerce-integration') . '</td></tr>';
                 }
                 ?>
             </tbody>

--- a/admin/order-sync-page.php
+++ b/admin/order-sync-page.php
@@ -5,30 +5,30 @@
 function softone_orders_page() {
     if (isset($_POST['sync_orders']) && check_admin_referer('softone_sync_orders_action', 'softone_sync_orders_nonce')) {
         $result = softone_sync_orders();
-        echo '<div class="notice notice-success"><p>' . $result . '</p></div>';
+        echo '<div class="notice notice-success"><p>' . esc_html($result) . '</p></div>';
     }
     ?>
     <div class="wrap">
-        <h1>Sync WooCommerce Orders to Softone</h1>
+        <h1><?php esc_html_e('Sync WooCommerce Orders to Softone', 'softone-woocommerce-integration'); ?></h1>
         <form method="post">
             <?php wp_nonce_field('softone_sync_orders_action', 'softone_sync_orders_nonce'); ?>
             <input type="hidden" name="sync_orders" value="1">
-            <?php submit_button('Sync Orders'); ?>
+            <?php submit_button(__('Sync Orders', 'softone-woocommerce-integration')); ?>
         </form>
         <?php
         // Assuming softone_get_orders() function retrieves orders from Softone
         $orders = softone_get_orders();
         if ($orders) {
             ?>
-            <h2>Synchronized Orders</h2>
+            <h2><?php esc_html_e('Synchronized Orders', 'softone-woocommerce-integration'); ?></h2>
             <table class="widefat fixed" cellspacing="0">
                 <thead>
                     <tr>
-                        <th>Order ID</th>
-                        <th>Customer</th>
-                        <th>Date</th>
-                        <th>Status</th>
-                        <th>Total</th>
+                        <th><?php esc_html_e('Order ID', 'softone-woocommerce-integration'); ?></th>
+                        <th><?php esc_html_e('Customer', 'softone-woocommerce-integration'); ?></th>
+                        <th><?php esc_html_e('Date', 'softone-woocommerce-integration'); ?></th>
+                        <th><?php esc_html_e('Status', 'softone-woocommerce-integration'); ?></th>
+                        <th><?php esc_html_e('Total', 'softone-woocommerce-integration'); ?></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/admin/product-sync-page.php
+++ b/admin/product-sync-page.php
@@ -5,8 +5,8 @@
 function softone_products_page() {
     ?>
     <div class="wrap">
-        <h1>Product Sync</h1>
-        <button id="sync-products-btn" class="button button-primary">Start Sync</button>
+        <h1><?php esc_html_e('Product Sync', 'softone-woocommerce-integration'); ?></h1>
+        <button id="sync-products-btn" class="button button-primary"><?php esc_html_e('Start Sync', 'softone-woocommerce-integration'); ?></button>
 
         <div id="sync-progress" style="margin-top: 20px; width: 100%; background: #eee; height: 20px; border-radius: 4px; overflow: hidden;">
             <div id="sync-bar" style="height: 100%; background: #0073aa; width: 0%; transition: width 0.3s;"></div>

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -8,7 +8,7 @@ function softone_settings_page() {
     $client_id = get_option('softone_client_id');
     ?>
     <div class="wrap">
-        <h1>Softone API Settings</h1>
+        <h1><?php esc_html_e('Softone API Settings', 'softone-woocommerce-integration'); ?></h1>
         <form method="post" action="options.php">
             <?php
             settings_fields('softone_settings_group');
@@ -23,11 +23,11 @@ function softone_settings_page() {
 add_action('admin_init', 'softone_admin_settings');
 function softone_admin_settings() {
     // Add settings section
-    add_settings_section('softone_settings_section', 'API Credentials', null, 'softone-settings');
+    add_settings_section('softone_settings_section', __('API Credentials', 'softone-woocommerce-integration'), null, 'softone-settings');
 
     // Add settings fields
-    add_settings_field('softone_api_username', 'API Username', 'softone_api_username_callback', 'softone-settings', 'softone_settings_section');
-    add_settings_field('softone_api_password', 'API Password', 'softone_api_password_callback', 'softone-settings', 'softone_settings_section');
+    add_settings_field('softone_api_username', __('API Username', 'softone-woocommerce-integration'), 'softone_api_username_callback', 'softone-settings', 'softone_settings_section');
+    add_settings_field('softone_api_password', __('API Password', 'softone-woocommerce-integration'), 'softone_api_password_callback', 'softone-settings', 'softone_settings_section');
 
     register_setting('softone_settings_group', 'softone_api_username');
     register_setting('softone_settings_group', 'softone_api_password');

--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -147,7 +147,7 @@ add_action('admin_menu', 'softone_register_product_menu_sync_page');
 
 function softone_render_sync_product_menu_page() {
     if (!current_user_can('manage_options')) {
-        wp_die(__('You do not have sufficient permissions to access this page.'));
+        wp_die(__('You do not have sufficient permissions to access this page.', 'softone-woocommerce-integration'));
     }
 
     $message = '';
@@ -160,17 +160,17 @@ function softone_render_sync_product_menu_page() {
             $result = softone_sync_woocommerce_product_categories_menu('Main Menu', 'Products');
             if ($result) {
                 update_option('softone_last_product_menu_sync', current_time('mysql'));
-                $message = '✅ Product categories synced successfully.';
+                $message = __('✅ Product categories synced successfully.', 'softone-woocommerce-integration');
                 $message_type = 'success';
             } else {
-                $message = '❌ There was an error syncing product categories. Check logs.';
+                $message = __('❌ There was an error syncing product categories. Check logs.', 'softone-woocommerce-integration');
                 $message_type = 'error';
             }
         }
     }
     ?>
     <div class="wrap">
-        <h1>Sync WooCommerce Product Categories</h1>
+        <h1><?php esc_html_e('Sync WooCommerce Product Categories', 'softone-woocommerce-integration'); ?></h1>
 
         <?php if ($message) : ?>
             <div class="notice notice-<?php echo esc_attr($message_type); ?>">
@@ -181,13 +181,13 @@ function softone_render_sync_product_menu_page() {
         <form method="POST">
             <?php wp_nonce_field('softone_sync_product_menu_action'); ?>
             <input type="hidden" name="softone_run_sync" value="1">
-            <?php submit_button('Sync Now'); ?>
+            <?php submit_button(__('Sync Now', 'softone-woocommerce-integration')); ?>
         </form>
 
         <hr>
 
-        <p><strong>Last sync:</strong> <?php echo esc_html(get_option('softone_last_product_menu_sync', 'Never')); ?></p>
-        <p><strong>Note:</strong> The sync runs automatically when product categories are added, edited, or deleted.</p>
+        <p><strong><?php esc_html_e('Last sync:', 'softone-woocommerce-integration'); ?></strong> <?php echo esc_html(get_option('softone_last_product_menu_sync', 'Never')); ?></p>
+        <p><strong><?php esc_html_e('Note:', 'softone-woocommerce-integration'); ?></strong> <?php esc_html_e('The sync runs automatically when product categories are added, edited, or deleted.', 'softone-woocommerce-integration'); ?></p>
     </div>
     <?php
 }

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Softone WooCommerce Integration 2.2.9\n"
+"POT-Creation-Date: 2024-05-01 00:00+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.8
+Stable tag: 2.2.9
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.8
+ * Version: 2.2.9
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration
@@ -17,7 +17,7 @@ if (!defined('ABSPATH')) {
 function softone_check_woocommerce() {
     if (!class_exists('WooCommerce')) {
         deactivate_plugins(plugin_basename(__FILE__));
-        wp_die('This plugin requires WooCommerce to be installed and active.');
+        wp_die(__('This plugin requires WooCommerce to be installed and active.', 'softone-woocommerce-integration'));
     }
 }
 register_activation_hook(__FILE__, 'softone_check_woocommerce');
@@ -64,6 +64,11 @@ function softone_woocommerce_integration_init() {
 }
 add_action('plugins_loaded', 'softone_woocommerce_integration_init');
 
+function softone_load_textdomain() {
+    load_plugin_textdomain('softone-woocommerce-integration', false, dirname(plugin_basename(__FILE__)) . '/languages');
+}
+add_action('plugins_loaded', 'softone_load_textdomain');
+
 // Schedule cron jobs
 function softone_schedule_cron_jobs() {
     if (!wp_next_scheduled('softone_cron_sync_customers')) {
@@ -87,12 +92,12 @@ register_deactivation_hook(__FILE__, 'softone_clear_scheduled_cron_jobs');
 
 // Admin menu setup
 function softone_admin_menu() {
-    add_menu_page('Softone Integration', 'Softone', 'manage_options', 'softone-settings', 'softone_settings_page');
-    add_submenu_page('softone-settings', 'Customer Sync', 'Customers', 'manage_options', 'softone-customers', 'softone_customers_page');
-    add_submenu_page('softone-settings', 'Product Sync', 'Products', 'manage_options', 'softone-products', 'softone_products_page');
-    add_submenu_page('softone-settings', 'Order Sync', 'Orders', 'manage_options', 'softone-orders', 'softone_orders_page');
-    add_submenu_page('softone-settings', 'Live Logging', 'Logs', 'manage_options', 'softone-logs', 'softone_logs_page');
-    add_submenu_page('softone-settings', 'Menu Sync', 'Menu Sync', 'manage_options', 'softone-sync-product-menu', 'softone_render_sync_product_menu_page');
+    add_menu_page(__('Softone Integration', 'softone-woocommerce-integration'), __('Softone', 'softone-woocommerce-integration'), 'manage_options', 'softone-settings', 'softone_settings_page');
+    add_submenu_page('softone-settings', __('Customer Sync', 'softone-woocommerce-integration'), __('Customers', 'softone-woocommerce-integration'), 'manage_options', 'softone-customers', 'softone_customers_page');
+    add_submenu_page('softone-settings', __('Product Sync', 'softone-woocommerce-integration'), __('Products', 'softone-woocommerce-integration'), 'manage_options', 'softone-products', 'softone_products_page');
+    add_submenu_page('softone-settings', __('Order Sync', 'softone-woocommerce-integration'), __('Orders', 'softone-woocommerce-integration'), 'manage_options', 'softone-orders', 'softone_orders_page');
+    add_submenu_page('softone-settings', __('Live Logging', 'softone-woocommerce-integration'), __('Logs', 'softone-woocommerce-integration'), 'manage_options', 'softone-logs', 'softone_logs_page');
+    add_submenu_page('softone-settings', __('Menu Sync', 'softone-woocommerce-integration'), __('Menu Sync', 'softone-woocommerce-integration'), 'manage_options', 'softone-sync-product-menu', 'softone_render_sync_product_menu_page');
 }
 
 // Register settings
@@ -144,11 +149,11 @@ add_filter('cron_schedules', 'softone_custom_cron_schedules');
 function softone_custom_cron_schedules($schedules) {
     $schedules['two_minutes'] = [
         'interval' => 120,
-        'display' => __('Every Two Minutes')
+        'display' => __('Every Two Minutes', 'softone-woocommerce-integration')
     ];
     $schedules['two_hours'] = [
         'interval' => 7200,
-        'display' => __('Every Two Hours')
+        'display' => __('Every Two Hours', 'softone-woocommerce-integration')
     ];
     return $schedules;
 }
@@ -199,11 +204,11 @@ function softone_sync_customers() {
                 }
             }
             update_option('softone_synced_customers', array_map('sanitize_text_field', $customers['rows']));
-            softone_log('sync_customers', 'Customers synchronized successfully.');
-            return ['success' => true, 'message' => 'Customers synchronized successfully.', 'customers' => $customers['rows']];
+            softone_log('sync_customers', __('Customers synchronized successfully.', 'softone-woocommerce-integration'));
+            return ['success' => true, 'message' => __('Customers synchronized successfully.', 'softone-woocommerce-integration'), 'customers' => $customers['rows']];
         } else {
-            softone_log('sync_customers', 'Failed to synchronize customers.');
-            return ['success' => false, 'message' => 'Failed to synchronize customers.'];
+            softone_log('sync_customers', __('Failed to synchronize customers.', 'softone-woocommerce-integration'));
+            return ['success' => false, 'message' => __('Failed to synchronize customers.', 'softone-woocommerce-integration')];
         }
     }
 }
@@ -300,14 +305,14 @@ function softone_sync_products() {
                 }
             }
             update_option('softone_synced_products', array_map('sanitize_text_field', $products['rows']));
-            softone_log('sync_products', 'Products synchronized successfully.');
+            softone_log('sync_products', __('Products synchronized successfully.', 'softone-woocommerce-integration'));
             if (function_exists('softone_sync_woocommerce_product_categories_menu')) {
                 softone_sync_woocommerce_product_categories_menu('Main Menu', 'Products');
             }
-            return ['success' => true, 'message' => 'Products synchronized successfully.', 'products' => $products['rows']];
+            return ['success' => true, 'message' => __('Products synchronized successfully.', 'softone-woocommerce-integration'), 'products' => $products['rows']];
         } else {
-            softone_log('sync_products', 'Failed to synchronize products.');
-            return ['success' => false, 'message' => 'Failed to synchronize products.'];
+            softone_log('sync_products', __('Failed to synchronize products.', 'softone-woocommerce-integration'));
+            return ['success' => false, 'message' => __('Failed to synchronize products.', 'softone-woocommerce-integration')];
         }
     }
 }
@@ -319,8 +324,8 @@ function softone_sync_orders() {
         foreach ($orders as $order) {
             $api->create_order($order);
         }
-        softone_log('sync_orders', 'Orders synchronized successfully.');
-        return 'Orders synchronized successfully.';
+        softone_log('sync_orders', __('Orders synchronized successfully.', 'softone-woocommerce-integration'));
+        return __('Orders synchronized successfully.', 'softone-woocommerce-integration');
     }
 }
 
@@ -344,7 +349,7 @@ add_action('template_redirect', function () {
         // SECURITY
         $expected_key = 'r8Kx12A9ZtX';
         if (!isset($_GET['key']) || $_GET['key'] !== $expected_key) {
-            wp_die('Invalid access key');
+            wp_die(__('Invalid access key', 'softone-woocommerce-integration'));
         }
 
         $offset = intval(get_option('softone_cron_offset', 0));

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,7 @@
+<wpml-config>
+    <admin-texts>
+        <key name="softone_api_username" />
+        <key name="softone_api_password" />
+        <key name="softone_client_id" />
+    </admin-texts>
+</wpml-config>


### PR DESCRIPTION
## Summary
- add WPML config and translations
- make all admin UI strings translatable
- load plugin text domain
- bump plugin version to 2.2.9

## Testing
- `php` command not available, so syntax check could not be run

------
https://chatgpt.com/codex/tasks/task_e_6852e4aa3b648327addf6ff10beb3ffa