### PR TITLE
Add brand taxonomy support, bump version

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -117,7 +117,19 @@ class Softone_API {
             if (!empty($item['COMMECATEGORY NAME'])) $cat_path[] = $item['COMMECATEGORY NAME'];
             if (!empty($item['SUBMECATEGORY NAME'])) $cat_path[] = $item['SUBMECATEGORY NAME'];
             $product->set_category_ids($this->create_category_tree($cat_path));
+            $brand_name = '';
+            foreach (['BRAND NAME','BRAND','BRANDNAME','MTRBRAND NAME','MTRBRANDS NAME'] as $bk) {
+                if (!empty($item[$bk])) { $brand_name = $item[$bk]; break; }
+            }
+            $brand_term_id = 0;
+            if ($brand_name) {
+                $brand_name = sanitize_text_field(mb_convert_encoding(trim($brand_name), 'UTF-8', 'UTF-8'));
+                $term = term_exists($brand_name, 'product_brand');
+                if (!$term) { $term = wp_insert_term($brand_name, 'product_brand'); }
+                if (!is_wp_error($term)) { $brand_term_id = is_array($term) ? $term['term_id'] : $term; }
+            }
             $id = $product->save();
+            if ($brand_term_id) { wp_set_object_terms($id, [$brand_term_id], 'product_brand'); }
             return ($existing_id ? "Updated" : "Added") . ": $sku (ID $id)";
         } catch (Throwable $e) {
             return "❌ Failed to sync SKU {$item['SKU']}: " . $e->getMessage();

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.10\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.11\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.10
+Stable tag: 2.2.11
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.10
+ * Version: 2.2.11
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration
@@ -68,6 +68,24 @@ function softone_load_textdomain() {
     load_plugin_textdomain('softone-woocommerce-integration', false, dirname(plugin_basename(__FILE__)) . '/languages');
 }
 add_action('plugins_loaded', 'softone_load_textdomain');
+
+// Register product brand taxonomy
+function softone_register_brand_taxonomy() {
+    $labels = [
+        'name' => _x('Brands', 'taxonomy general name', 'softone-woocommerce-integration'),
+        'singular_name' => _x('Brand', 'taxonomy singular name', 'softone-woocommerce-integration'),
+    ];
+    $args = [
+        'hierarchical' => true,
+        'labels' => $labels,
+        'show_ui' => true,
+        'show_admin_column' => true,
+        'query_var' => true,
+        'rewrite' => ['slug' => 'brand'],
+    ];
+    register_taxonomy('product_brand', ['product'], $args);
+}
+add_action('init', 'softone_register_brand_taxonomy');
 
 // Schedule cron jobs
 function softone_schedule_cron_jobs() {
@@ -260,7 +278,20 @@ function softone_sync_products() {
                         $product_obj->set_category_ids($category_ids);
                     }
 
+                    $brand_name = '';
+                    foreach (['BRAND NAME','BRAND','BRANDNAME','MTRBRAND NAME','MTRBRANDS NAME'] as $bk) {
+                        if (!empty($product[$bk])) { $brand_name = $product[$bk]; break; }
+                    }
+                    $brand_term_id = 0;
+                    if ($brand_name) {
+                        $brand_name = sanitize_text_field($brand_name);
+                        $term = term_exists($brand_name, 'product_brand');
+                        if (!$term) { $term = wp_insert_term($brand_name, 'product_brand'); }
+                        if (!is_wp_error($term)) { $brand_term_id = is_array($term) ? $term['term_id'] : $term; }
+                    }
+
                     $product_obj->save();
+                    if ($brand_term_id) { wp_set_object_terms($existing_product_id, [$brand_term_id], 'product_brand'); }
                 } else {
                     // Create new product
                     $new_product = new WC_Product();
@@ -301,7 +332,20 @@ function softone_sync_products() {
                         $new_product->set_category_ids($category_ids);
                     }
 
+                    $brand_name = '';
+                    foreach (['BRAND NAME','BRAND','BRANDNAME','MTRBRAND NAME','MTRBRANDS NAME'] as $bk) {
+                        if (!empty($product[$bk])) { $brand_name = $product[$bk]; break; }
+                    }
+                    $brand_term_id = 0;
+                    if ($brand_name) {
+                        $brand_name = sanitize_text_field($brand_name);
+                        $term = term_exists($brand_name, 'product_brand');
+                        if (!$term) { $term = wp_insert_term($brand_name, 'product_brand'); }
+                        if (!is_wp_error($term)) { $brand_term_id = is_array($term) ? $term['term_id'] : $term; }
+                    }
+
                     $new_product->save();
+                    if ($brand_term_id) { wp_set_object_terms($new_product->get_id(), [$brand_term_id], 'product_brand'); }
                 }
             }
             update_option('softone_synced_products', array_map('sanitize_text_field', $products['rows']));


### PR DESCRIPTION
## Summary
- register new `product_brand` taxonomy
- sync brand information from Softone products
- update plugin version to 2.2.11

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68532d825fc48327b74c3b4170e80b4e