### PR TITLE
Fix duplicate Menu Sync menu item and bump version

### DIFF
--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -142,19 +142,6 @@ function softone_run_auto_sync_product_menu() {
 }
 add_action('softone_debounced_auto_sync_product_menu', 'softone_run_auto_sync_product_menu');
 
-// Admin page to manually trigger sync under the Softone menu
-function softone_register_product_menu_sync_page() {
-    add_submenu_page(
-        'softone-settings',
-        'Sync Product Categories',
-        'Menu Sync',
-        'manage_options',
-        'softone-sync-product-menu',
-        'softone_render_sync_product_menu_page'
-    );
-}
-add_action('admin_menu', 'softone_register_product_menu_sync_page');
-
 function softone_render_sync_product_menu_page() {
     if (!current_user_can('manage_options')) {
         wp_die(__('You do not have sufficient permissions to access this page.', 'softone-woocommerce-integration'));

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.12\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.13\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.12
+Stable tag: 2.2.13
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.12
+ * Version: 2.2.13
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- remove redundant admin menu registration to avoid duplicate **Menu Sync** entry
- bump plugin version to 2.2.13

## Testing
- `npm test` *(fails: `package.json` not found)*
- `composer test` *(fails: `composer` not found)*
- `php -l includes/menu-sync.php` *(fails: `php` not found)*
- `php -l softone-woocommerce-integration.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685330764ea483279f169ab5c3f960fc