### PR TITLE
Improve documentation and bump version to 2.2.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
 # Softone WooCommerce Integration
 
-This plugin syncs WooCommerce with the Softone ERP system. Products and the navigation menu are updated every two minutes using WordPress cron jobs. Customers and orders are synchronized hourly.
+Softone WooCommerce Integration keeps your WooCommerce store in sync with the
+Softone ERP platform. The plugin communicates with the Softone API to transfer
+customer, product and order data between the two systems.
+
+## Features
+
+- **Automatic synchronization** – WordPress cron jobs run in the background to
+  fetch updates from Softone. Products and the navigation menu are refreshed
+  every two minutes while customers and orders are processed hourly.
+- **Manual sync tools** – Dedicated admin pages let you trigger customer,
+  product and order synchronisation on demand. Product sync runs via AJAX and
+  displays progress in real time.
+- **Menu synchronisation** – Product categories are mirrored in the main
+  WordPress menu so the store navigation always reflects the latest structure.
+- **Brand taxonomy** – The plugin creates a `product_brand` taxonomy and assigns
+  Softone brand information to your WooCommerce products.
+- **Logging** – All API interactions are recorded. A log viewer and a button to
+  clear logs are available in the WordPress admin area.
+- **Custom cron schedules** – Adds 2‑minute and 2‑hour schedules that other
+  tasks can use.
+
+## Installation
+
+1. Upload the plugin to `wp-content/plugins/softone-woocommerce-integration` or
+   install it through the WordPress plugin screen.
+2. Activate **Softone WooCommerce Integration**. WooCommerce must already be
+   active.
+3. Go to **Softone → Settings** in the WordPress dashboard and enter your API
+   credentials.
+
+Once configured, the plugin will automatically keep customers, products and
+orders in sync with Softone.

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.13\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.15\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.13
+Stable tag: 2.2.15
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -13,7 +13,19 @@ Integrates WooCommerce with Softone API for customer, product, and order synchro
 
 == Description ==
 
-The Softone WooCommerce Integration plugin allows you to synchronize your WooCommerce store with Softone ERP system. It provides functionalities to sync customers, products, and orders between WooCommerce and Softone.
+The Softone WooCommerce Integration plugin connects WooCommerce to the Softone
+ERP system and keeps both platforms in sync.
+
+* Synchronise customers, products and orders using the Softone API.
+* Automatic cron-based sync runs in the background (products and menu every two
+  minutes, customers and orders hourly).
+* Manual sync pages with progress indicators for customers, products and
+  orders.
+* Navigation menu sync mirrors the WooCommerce product category hierarchy under
+  your main menu.
+* Creates a **product_brand** taxonomy and assigns Softone brand data to
+  products.
+* Logs every API request with an admin page for reviewing and clearing logs.
 
 == Installation ==
 
@@ -41,6 +53,9 @@ The plugin uses WordPress cron jobs to sync data. Customers and orders are synce
 
 == Changelog ==
 
+= 2.2.15 =
+* Expanded documentation in both README files.
+
 = 1.0.0 =
 * Initial release.
 
@@ -48,6 +63,9 @@ The plugin uses WordPress cron jobs to sync data. Customers and orders are synce
 
 = 1.0.0 =
 * Initial release.
+
+= 2.2.15 =
+* Expanded documentation.
 
 = 2.0.0 =
 * Agains.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.14
+ * Version: 2.2.15
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- expand README with full feature list and installation guide
- update `readme.txt` description, changelog and upgrade notice
- bump plugin version to 2.2.15
- update translation header

## Testing
- `php -l softone-woocommerce-integration.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68533b626d74832790fcbfea2926a510