### PR TITLE
Fix menu ordering and bump version

### DIFF
--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -44,9 +44,6 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
             'taxonomy' => 'product_cat',
             'hide_empty' => false,
             'update_term_meta_cache' => false,
-            // Ensure categories are retrieved in alphabetical order
-            'orderby' => 'name',
-            'order'   => 'ASC',
         ]);
 
         if (is_wp_error($product_cats)) {

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.16\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.17\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.16
+Stable tag: 2.2.17
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -53,6 +53,9 @@ The plugin uses WordPress cron jobs to sync data. Customers and orders are synce
 
 == Changelog ==
 
+= 2.2.17 =
+* Restore original product category ordering in the navigation menu.
+
 = 2.2.16 =
 * Ensure product categories in the navigation menu are ordered alphabetically.
 
@@ -66,6 +69,9 @@ The plugin uses WordPress cron jobs to sync data. Customers and orders are synce
 
 = 2.2.16 =
 * Product categories are now ordered alphabetically in the menu.
+
+= 2.2.17 =
+* Restores WooCommerce category order in the menu.
 
 = 2.0.0 =
 * Agains.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.16
+ * Version: 2.2.17
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- restore WooCommerce default ordering for menu categories
- bump version to 2.2.17
- document change in readme and update POT file

## Testing
- `php -l includes/menu-sync.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685340aef000832789e79a3684301378