### PR TITLE
Fix mega menu class handling

### DIFF
--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -26,12 +26,15 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
                 // Ensure the parent menu item acts as a mega menu trigger
                 $classes = get_post_meta($product_root_id, '_menu_item_classes', true);
                 if (!is_array($classes)) {
-                    $classes = array_filter(array_map('trim', is_string($classes) ? explode(' ', $classes) : []));
+                    $classes = is_string($classes) ? explode(' ', $classes) : [];
                 }
+                $classes = array_unique(array_filter(array_map('trim', $classes)));
+
                 if (!in_array('mega-menu', $classes, true)) {
                     $classes[] = 'mega-menu';
-                    update_post_meta($product_root_id, '_menu_item_classes', $classes);
                 }
+
+                update_post_meta($product_root_id, '_menu_item_classes', $classes);
             }
             if ($item->type === 'taxonomy' && $item->object === 'product_cat') {
                 $existing_menu_items[$item->menu_item_parent][$item->object_id] = $item->ID;

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.17\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.18\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.17
+Stable tag: 2.2.18
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -53,6 +53,9 @@ The plugin uses WordPress cron jobs to sync data. Customers and orders are synce
 
 == Changelog ==
 
+= 2.2.18 =
+* Ensure mega-menu class is added without trailing spaces.
+
 = 2.2.17 =
 * Restore original product category ordering in the navigation menu.
 
@@ -72,6 +75,9 @@ The plugin uses WordPress cron jobs to sync data. Customers and orders are synce
 
 = 2.2.17 =
 * Restores WooCommerce category order in the menu.
+
+= 2.2.18 =
+* Prevent whitespace issues when setting mega-menu class.
 
 = 2.0.0 =
 * Agains.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.17
+ * Version: 2.2.18
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- avoid extra whitespace when adding `mega-menu` class
- bump plugin version to 2.2.18 and update docs

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534264374c8327938215c67016b541