### PR TITLE
Add admin menu debug logging

### DIFF
--- a/includes/logging.php
+++ b/includes/logging.php
@@ -14,3 +14,16 @@ function softone_log($action, $message) {
     ];
     update_option('softone_api_logs', $logs);
 }
+
+/**
+ * Writes debugging information to the log and error log when WP_DEBUG is enabled.
+ *
+ * @param string $action  Context for the log entry.
+ * @param string $message Debug message.
+ */
+function softone_debug_log($action, $message) {
+    softone_log($action, $message);
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('[Softone] ' . $action . ': ' . $message);
+    }
+}

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.20\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.21\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.20
+Stable tag: 2.2.21
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,9 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.21 =
+* Add debug logging when registering admin menu pages.
+
 = 2.2.20 =
 * Prevent debug notice by avoiding early translation loading.
 
@@ -84,6 +87,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.21 =
+* Adds debugging logs for admin menu registration.
 
 = 2.2.20 =
 * Fixes translation loading warning on plugin activation.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.20
+ * Version: 2.2.21
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration
@@ -126,12 +126,66 @@ register_deactivation_hook(__FILE__, 'softone_clear_scheduled_cron_jobs');
 
 // Admin menu setup
 function softone_admin_menu() {
-    add_menu_page(__('Softone Integration', 'softone-woocommerce-integration'), __('Softone', 'softone-woocommerce-integration'), 'manage_options', 'softone-settings', 'softone_settings_page');
-    add_submenu_page('softone-settings', __('Customer Sync', 'softone-woocommerce-integration'), __('Customers', 'softone-woocommerce-integration'), 'manage_options', 'softone-customers', 'softone_customers_page');
-    add_submenu_page('softone-settings', __('Product Sync', 'softone-woocommerce-integration'), __('Products', 'softone-woocommerce-integration'), 'manage_options', 'softone-products', 'softone_products_page');
-    add_submenu_page('softone-settings', __('Order Sync', 'softone-woocommerce-integration'), __('Orders', 'softone-woocommerce-integration'), 'manage_options', 'softone-orders', 'softone_orders_page');
-    add_submenu_page('softone-settings', __('Live Logging', 'softone-woocommerce-integration'), __('Logs', 'softone-woocommerce-integration'), 'manage_options', 'softone-logs', 'softone_logs_page');
-    add_submenu_page('softone-settings', __('Menu Sync', 'softone-woocommerce-integration'), __('Menu Sync', 'softone-woocommerce-integration'), 'manage_options', 'softone-sync-product-menu', 'softone_render_sync_product_menu_page');
+    softone_debug_log('admin_menu', 'Registering admin menu.');
+
+    $main_hook = add_menu_page(
+        __('Softone Integration', 'softone-woocommerce-integration'),
+        __('Softone', 'softone-woocommerce-integration'),
+        'manage_options',
+        'softone-settings',
+        'softone_settings_page'
+    );
+    softone_debug_log('admin_menu', 'Main menu hook: ' . $main_hook);
+
+    $customer_hook = add_submenu_page(
+        'softone-settings',
+        __('Customer Sync', 'softone-woocommerce-integration'),
+        __('Customers', 'softone-woocommerce-integration'),
+        'manage_options',
+        'softone-customers',
+        'softone_customers_page'
+    );
+    softone_debug_log('admin_menu', 'Customer submenu hook: ' . $customer_hook);
+
+    $product_hook = add_submenu_page(
+        'softone-settings',
+        __('Product Sync', 'softone-woocommerce-integration'),
+        __('Products', 'softone-woocommerce-integration'),
+        'manage_options',
+        'softone-products',
+        'softone_products_page'
+    );
+    softone_debug_log('admin_menu', 'Product submenu hook: ' . $product_hook);
+
+    $order_hook = add_submenu_page(
+        'softone-settings',
+        __('Order Sync', 'softone-woocommerce-integration'),
+        __('Orders', 'softone-woocommerce-integration'),
+        'manage_options',
+        'softone-orders',
+        'softone_orders_page'
+    );
+    softone_debug_log('admin_menu', 'Order submenu hook: ' . $order_hook);
+
+    $log_hook = add_submenu_page(
+        'softone-settings',
+        __('Live Logging', 'softone-woocommerce-integration'),
+        __('Logs', 'softone-woocommerce-integration'),
+        'manage_options',
+        'softone-logs',
+        'softone_logs_page'
+    );
+    softone_debug_log('admin_menu', 'Logs submenu hook: ' . $log_hook);
+
+    $menu_hook = add_submenu_page(
+        'softone-settings',
+        __('Menu Sync', 'softone-woocommerce-integration'),
+        __('Menu Sync', 'softone-woocommerce-integration'),
+        'manage_options',
+        'softone-sync-product-menu',
+        'softone_render_sync_product_menu_page'
+    );
+    softone_debug_log('admin_menu', 'Menu sync submenu hook: ' . $menu_hook);
 }
 
 // Register settings


### PR DESCRIPTION
## Summary
- log new `softone_debug_log` entries with support for `WP_DEBUG`
- debug the entire admin menu creation process
- bump plugin version to 2.2.21
- document new version in readme and translation template

## Testing
- `php -l includes/logging.php`
- `php -l softone-woocommerce-integration.php`
- `find . -name '*.php' -print0 | xargs -0 -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6853ea3714d08327ae4a97b77ce7852a