### PR TITLE
Add live log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ customer, product and order data between the two systems.
   WordPress menu so the store navigation always reflects the latest structure.
 - **Brand taxonomy** – The plugin creates a `product_brand` taxonomy and assigns
   Softone brand information to your WooCommerce products.
-- **Logging** – All API interactions are recorded. A log viewer and a button to
-  clear logs are available in the WordPress admin area.
+- **Logging** – All API interactions are recorded. View logs live from the
+  WordPress admin and clear them with one click.
 - **Custom cron schedules** – Adds 2‑minute and 2‑hour schedules that other
   tasks can use.
 

--- a/admin/logs-page.php
+++ b/admin/logs-page.php
@@ -16,28 +16,32 @@ function softone_logs_page() {
             <input type="hidden" name="clear_logs" value="1">
             <?php submit_button(__('Clear Logs', 'softone-woocommerce-integration')); ?>
         </form>
-        <table class="widefat">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e('Timestamp', 'softone-woocommerce-integration'); ?></th>
-                    <th><?php esc_html_e('Action', 'softone-woocommerce-integration'); ?></th>
-                    <th><?php esc_html_e('Message', 'softone-woocommerce-integration'); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php
-                $logs = get_option('softone_api_logs', []);
-                if (!empty($logs)) {
-                    foreach ($logs as $log) {
-                        echo '<tr><td>' . esc_html($log['timestamp']) . '</td><td>' . esc_html($log['action']) . '</td><td>' . esc_html($log['message']) . '</td></tr>';
-                    }
-                } else {
-                    echo '<tr><td colspan="3">' . esc_html__('No logs available.', 'softone-woocommerce-integration') . '</td></tr>';
-                }
-                ?>
-            </tbody>
-        </table>
+        <pre id="softone-log-output" style="background:#111;color:#0f0;padding:10px;height:400px;overflow:auto;font-size:13px;"></pre>
     </div>
+    <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const logEl = document.getElementById('softone-log-output');
+        function fetchLogs() {
+            fetch(ajaxurl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: new URLSearchParams({
+                    action: 'softone_get_logs',
+                    _ajax_nonce: softone_logs.nonce
+                })
+            })
+            .then(res => res.json())
+            .then(data => {
+                if (Array.isArray(data)) {
+                    logEl.textContent = data.map(row => `[${row.timestamp}] ${row.action}: ${row.message}`).join('\n');
+                    logEl.scrollTop = logEl.scrollHeight;
+                }
+            });
+        }
+        fetchLogs();
+        setInterval(fetchLogs, 5000);
+    });
+    </script>
     <?php
 }
 ?>

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.21\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.22\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.21
+Stable tag: 2.2.22
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,9 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.22 =
+* Add live log viewer with automatic updates in the admin area.
+
 = 2.2.21 =
 * Add debug logging when registering admin menu pages.
 
@@ -87,6 +90,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.22 =
+* View logs live from the WordPress admin.
 
 = 2.2.21 =
 * Adds debugging logs for admin menu registration.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.21
+ * Version: 2.2.22
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration
@@ -446,9 +446,18 @@ function softone_sync_orders() {
     }
 }
 
+add_action('wp_ajax_softone_get_logs', 'softone_get_logs');
+function softone_get_logs() {
+    check_ajax_referer('softone_get_logs_nonce');
+    wp_send_json(get_option('softone_api_logs', []));
+}
+
 add_action('admin_enqueue_scripts', function () {
     wp_localize_script('jquery', 'softone_sync_products', [
         'nonce' => wp_create_nonce('softone_sync_products_nonce')
+    ]);
+    wp_localize_script('jquery', 'softone_logs', [
+        'nonce' => wp_create_nonce('softone_get_logs_nonce')
     ]);
 });
 


### PR DESCRIPTION
## Summary
- live log viewer refreshes every 5 seconds
- AJAX endpoint to fetch logs
- plugin version bumped to 2.2.22
- document new feature in README and readme.txt

## Testing
- `php -l softone-woocommerce-integration.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853eba615e883279099205ecf613f0e