### PR TITLE
Fix Divi mega menu classes

### DIFF
--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -41,6 +41,7 @@ function softone_ensure_menu_structure($menu_name = 'Main Menu', $parent_title =
     if (!in_array('mega-menu', $classes, true)) {
         $classes[] = 'mega-menu';
     }
+    // Divi uses the "mega-menu" class to enable mega menu functionality
     update_post_meta($product_root_id, '_menu_item_classes', $classes);
 
     return [$menu_id, $product_root_id];
@@ -95,12 +96,6 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
             if (!isset($term_children[$parent_term_id])) return;
 
             foreach ($term_children[$parent_term_id] as $term_id) {
-                if (isset($existing_menu_items[$parent_menu_id][$term_id])) {
-                    $new_menu_item_ids[] = $existing_menu_items[$parent_menu_id][$term_id];
-                    $add_recursive($term_id, $existing_menu_items[$parent_menu_id][$term_id]);
-                    continue;
-                }
-
                 $term = $term_map[$term_id];
 
                 $args = [
@@ -112,12 +107,14 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
                     'menu-item-parent-id'  => $parent_menu_id,
                 ];
 
+                $existing_id = $existing_menu_items[$parent_menu_id][$term_id] ?? 0;
+
                 // Add mega menu class for top level categories when using Divi
                 if ($parent_menu_id == $product_root_id) {
                     $args['menu-item-classes'] = 'mega-menu';
                 }
 
-                $menu_item_id = wp_update_nav_menu_item($menu_id, 0, $args);
+                $menu_item_id = wp_update_nav_menu_item($menu_id, $existing_id, $args);
 
                 if (is_wp_error($menu_item_id)) continue;
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.22
+Stable tag: 2.2.24
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.22
+ * Version: 2.2.24
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- simplify mega menu classes so Divi only sees `mega-menu`
- bump plugin version to 2.2.24

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853eda75ff483278697fec0cdd2ba0c