### PR TITLE
Update menu sync and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ customer, product and order data between the two systems.
   displays progress in real time.
 - **Menu synchronisation** – Product categories are mirrored in the main
   WordPress menu so the store navigation always reflects the latest structure.
+  The default *Uncategorized* category is removed and top level entries are
+  flagged with Divi's `mega-menu` classes.
 - **Brand taxonomy** – The plugin creates a `product_brand` taxonomy and assigns
   Softone brand information to your WooCommerce products.
 - **Logging** – All API interactions are recorded. View logs live from the

--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -79,8 +79,12 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
         $all_term_ids = [];
 
         foreach ($product_cats as $term) {
-            // Skip default "Uncategorized" category
+            // Skip and remove the default "Uncategorized" category
             if ($term->slug === 'uncategorized') {
+                if (!empty($existing_menu_items[$term->parent][$term->term_id])) {
+                    wp_delete_post($existing_menu_items[$term->parent][$term->term_id], true);
+                    unset($existing_menu_items[$term->parent][$term->term_id]);
+                }
                 continue;
             }
 
@@ -111,12 +115,22 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
                 $existing_id = $existing_menu_items[$parent_menu_id][$term_id] ?? 0;
 
                 if ($parent_menu_id == $product_root_id) {
-                    $args['menu-item-classes'] = 'mega-menu mega-menu-parent mega-menu-parent-' . $top_level_index;
+                    $menu_classes = ['mega-menu', 'mega-menu-parent', 'mega-menu-parent-' . $top_level_index];
+                    $args['menu-item-classes'] = implode(' ', $menu_classes);
                 }
 
                 $menu_item_id = wp_update_nav_menu_item($menu_id, $existing_id, $args);
 
                 if (is_wp_error($menu_item_id)) continue;
+
+                if ($parent_menu_id == $product_root_id) {
+                    $existing_classes = get_post_meta($menu_item_id, '_menu_item_classes', true);
+                    if (!is_array($existing_classes)) {
+                        $existing_classes = is_string($existing_classes) ? explode(' ', $existing_classes) : [];
+                    }
+                    $existing_classes = array_unique(array_filter(array_map('trim', array_merge($existing_classes, $menu_classes))));
+                    update_post_meta($menu_item_id, '_menu_item_classes', $existing_classes);
+                }
 
                 $existing_menu_items[$parent_menu_id][$term_id] = $menu_item_id;
                 $new_menu_item_ids[] = $menu_item_id;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.24
+Stable tag: 2.2.25
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,10 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.25 =
+* Skip the "Uncategorized" product category when building the menu.
+* Apply Divi mega-menu classes to top level categories.
+
 = 2.2.22 =
 * Add live log viewer with automatic updates in the admin area.
 
@@ -90,6 +94,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.25 =
+* Menu sync skips "Uncategorized" and applies Divi mega-menu classes.
 
 = 2.2.22 =
 * View logs live from the WordPress admin.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.24
+ * Version: 2.2.25
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- remove default Uncategorized category from synced menus
- apply Divi mega‑menu classes to top level categories
- update documentation and bump plugin version to 2.2.25

## Testing
- `php -l softone-woocommerce-integration.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853f118ccec8327802e140e62a6a61b