### PR TITLE
Use HTTPS endpoint and bump version

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -3,7 +3,7 @@
  * Handles interactions with the Softone API and WooCommerce product sync.
  */
 class Softone_API {
-    private $endpoint = 'http://ptkids.oncloud.gr/s1services';
+    private $endpoint = 'https://ptkids.oncloud.gr/s1services';
     private $username;
     private $password;
     private $client_id;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.26
+Stable tag: 2.2.27
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,9 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.27 =
+* Switch API endpoint to HTTPS.
+
 = 2.2.26 =
 * Remove custom mega-menu classes from top level categories to rely on Divi's native styling.
 
@@ -97,6 +100,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.27 =
+* Switches API endpoint to HTTPS for secure communication.
 
 = 2.2.26 =
 * Removes unused mega-menu classes for better compatibility with Divi.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.26
+ * Version: 2.2.27
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- switch Softone API endpoint to HTTPS
- bump plugin to version 2.2.27 with changelog entry

## Testing
- `php -l includes/api.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68a41fdfab4c83278dcdb89590238172