### PR TITLE
Add preset request dropdown and bump version

### DIFF
--- a/admin/request-tester-page.php
+++ b/admin/request-tester-page.php
@@ -6,6 +6,48 @@ function softone_request_tester_page() {
     $response = null;
     $error = '';
 
+    $presets = array(
+        'get_products' => array(
+            'label'   => __('Get Products', 'softone-woocommerce-integration'),
+            'url'     => 'https://ptkids.oncloud.gr/s1services',
+            'method'  => 'POST',
+            'headers' => array('Content-Type' => 'application/json'),
+            'body'    => array(
+                'service'  => 'SqlData',
+                'clientid' => get_option('softone_api_session'),
+                'appId'    => 1000,
+                'SqlName'  => 'getItems',
+                'pMins'    => 99999,
+            ),
+        ),
+        'get_orders' => array(
+            'label'   => __('Get Orders', 'softone-woocommerce-integration'),
+            'url'     => 'https://ptkids.oncloud.gr/s1services',
+            'method'  => 'POST',
+            'headers' => array('Content-Type' => 'application/json'),
+            'body'    => array(
+                'service'  => 'SqlData',
+                'clientid' => get_option('softone_api_session'),
+                'appId'    => 1000,
+                'SqlName'  => 'getOrders',
+                'pMins'    => 99999,
+            ),
+        ),
+        'get_customers' => array(
+            'label'   => __('Get Customers', 'softone-woocommerce-integration'),
+            'url'     => 'https://ptkids.oncloud.gr/s1services',
+            'method'  => 'POST',
+            'headers' => array('Content-Type' => 'application/json'),
+            'body'    => array(
+                'service'  => 'SqlData',
+                'clientid' => get_option('softone_api_session'),
+                'appId'    => 1000,
+                'SqlName'  => 'getCustomers',
+                'pMins'    => 99999,
+            ),
+        ),
+    );
+
     if (isset($_POST['softone_request_tester_nonce']) && wp_verify_nonce($_POST['softone_request_tester_nonce'], 'softone_request_tester')) {
         $url    = isset($_POST['softone_request_tester_url']) ? esc_url_raw(wp_unslash($_POST['softone_request_tester_url'])) : '';
         $method = isset($_POST['softone_request_tester_method']) ? strtoupper(sanitize_text_field(wp_unslash($_POST['softone_request_tester_method']))) : 'GET';
@@ -42,6 +84,17 @@ function softone_request_tester_page() {
             <?php wp_nonce_field('softone_request_tester', 'softone_request_tester_nonce'); ?>
             <table class="form-table" role="presentation">
                 <tr>
+                    <th scope="row"><label for="softone_request_tester_preset"><?php esc_html_e('Preset', 'softone-woocommerce-integration'); ?></label></th>
+                    <td>
+                        <select id="softone_request_tester_preset">
+                            <option value=""><?php esc_html_e('Custom', 'softone-woocommerce-integration'); ?></option>
+                            <?php foreach ($presets as $key => $preset) : ?>
+                                <option value="<?php echo esc_attr($key); ?>"><?php echo esc_html($preset['label']); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
                     <th scope="row"><label for="softone_request_tester_url"><?php esc_html_e('Request URL', 'softone-woocommerce-integration'); ?></label></th>
                     <td><input name="softone_request_tester_url" type="text" id="softone_request_tester_url" value="<?php echo isset($_POST['softone_request_tester_url']) ? esc_attr(wp_unslash($_POST['softone_request_tester_url'])) : ''; ?>" class="regular-text" /></td>
                 </tr>
@@ -70,6 +123,24 @@ function softone_request_tester_page() {
             </table>
             <?php submit_button(__('Send Request', 'softone-woocommerce-integration')); ?>
         </form>
+        <script>
+        (function () {
+            const presets = <?php echo wp_json_encode($presets); ?>;
+            const presetSelect = document.getElementById('softone_request_tester_preset');
+            const urlField = document.getElementById('softone_request_tester_url');
+            const methodField = document.getElementById('softone_request_tester_method');
+            const headersField = document.getElementById('softone_request_tester_headers');
+            const bodyField = document.getElementById('softone_request_tester_body');
+            presetSelect.addEventListener('change', function(){
+                const p = presets[this.value];
+                if (!p) { return; }
+                urlField.value = p.url || '';
+                methodField.value = p.method || 'GET';
+                headersField.value = p.headers ? JSON.stringify(p.headers, null, 2) : '';
+                bodyField.value = p.body ? JSON.stringify(p.body, null, 2) : '';
+            });
+        })();
+        </script>
         <?php if (null !== $response) : ?>
             <h2><?php esc_html_e('Response', 'softone-woocommerce-integration'); ?></h2>
             <pre style="background:#111;color:#0f0;padding:10px;overflow:auto;max-height:500px;">

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.30\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.31\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.30
+Stable tag: 2.2.31
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,9 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.31 =
+* Add preset dropdown to API Request Tester.
+
 = 2.2.29 =
 * Map colour and size attributes and use RETAILPRICE for pricing.
 * Use CCCSOCYLODES as the product description and REMARKS as the short description.
@@ -107,6 +110,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.31 =
+* Adds preset dropdown to API Request Tester.
 
 = 2.2.29 =
 * Adds colour/size attributes and sets product descriptions from Softone fields.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.30
+ * Version: 2.2.31
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- add Softone API presets to the request tester for products, orders and customers
- bump plugin version to 2.2.31 with changelog and translation header

## Testing
- `php -l admin/request-tester-page.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5b3c959648327816ff95d9e26d738