### PR TITLE
Improve API Request Tester formatting

### DIFF
--- a/admin/request-tester-page.php
+++ b/admin/request-tester-page.php
@@ -143,19 +143,26 @@ function softone_request_tester_page() {
         </script>
         <?php if (null !== $response) : ?>
             <h2><?php esc_html_e('Response', 'softone-woocommerce-integration'); ?></h2>
-            <pre style="background:#111;color:#0f0;padding:10px;overflow:auto;max-height:500px;">
-<?php
-if (is_wp_error($response)) {
-    echo esc_html($response->get_error_message());
-} else {
-    echo esc_html('Status: ' . $response['response']['code'] . ' ' . $response['response']['message'] . "\n\n");
-    foreach ($response['headers'] as $key => $value) {
-        echo esc_html($key . ': ' . $value . "\n");
-    }
-    echo esc_html("\n" . $response['body']);
-}
-?>
-            </pre>
+            <?php
+            $pre_style = 'background:#f5f5f5;color:#333;padding:10px;overflow:auto;max-height:500px;';
+            if (is_wp_error($response)) {
+                echo '<pre style="' . esc_attr($pre_style) . '">' . esc_html($response->get_error_message()) . '</pre>';
+            } else {
+                $output  = __('Status', 'softone-woocommerce-integration') . ': ' . $response['response']['code'] . ' ' . $response['response']['message'] . "\n\n";
+                $output .= __('Headers', 'softone-woocommerce-integration') . ":\n";
+                foreach ($response['headers'] as $key => $value) {
+                    $output .= $key . ': ' . $value . "\n";
+                }
+                $output .= "\n" . __('Body', 'softone-woocommerce-integration') . ":\n";
+                $decoded_body = json_decode($response['body'], true);
+                if (null !== $decoded_body) {
+                    $output .= wp_json_encode($decoded_body, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+                } else {
+                    $output .= $response['body'];
+                }
+                echo '<pre style="' . esc_attr($pre_style) . '">' . esc_html($output) . '</pre>';
+            }
+            ?>
         <?php endif; ?>
     </div>
     <?php

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.31\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.32\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.31
+Stable tag: 2.2.32
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,9 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.32 =
+* Improve API Request Tester response formatting.
+
 = 2.2.31 =
 * Add preset dropdown to API Request Tester.
 
@@ -110,6 +113,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.32 =
+* Makes API Request Tester responses easier to read.
 
 = 2.2.31 =
 * Adds preset dropdown to API Request Tester.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.31
+ * Version: 2.2.32
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- Format API Request Tester responses with status, headers, and pretty-printed body
- Bump plugin version to 2.2.32 and update docs

## Testing
- `php -l admin/request-tester-page.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5b5b69b448327a7427fb1a428a244