### PR TITLE
Show full Softone response in request tester

### DIFF
--- a/admin/request-tester-page.php
+++ b/admin/request-tester-page.php
@@ -154,11 +154,14 @@ function softone_request_tester_page() {
                     $output .= $key . ': ' . $value . "\n";
                 }
                 $output .= "\n" . __('Body', 'softone-woocommerce-integration') . ":\n";
-                $decoded_body = json_decode($response['body'], true);
+                $body = wp_remote_retrieve_body($response);
+                $body = mb_convert_encoding($body, 'UTF-8', 'ISO-8859-7,UTF-8');
+                $body = iconv('UTF-8', 'UTF-8//IGNORE', $body);
+                $decoded_body = json_decode($body, true);
                 if (null !== $decoded_body) {
-                    $output .= wp_json_encode($decoded_body, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+                    $output .= wp_json_encode($decoded_body, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
                 } else {
-                    $output .= $response['body'];
+                    $output .= $body;
                 }
                 echo '<pre style="' . esc_attr($pre_style) . '">' . esc_html($output) . '</pre>';
             }

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.32\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.33\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.32
+Stable tag: 2.2.33
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,9 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.33 =
+* Ensure API Request Tester displays the full Softone response.
+
 = 2.2.32 =
 * Improve API Request Tester response formatting.
 
@@ -113,6 +116,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.33 =
+* Shows the complete Softone response in the API Request Tester.
 
 = 2.2.32 =
 * Makes API Request Tester responses easier to read.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.32
+ * Version: 2.2.33
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- decode and display full Softone API responses in the Request Tester
- bump plugin version to 2.2.33 and document the change

## Testing
- `php -l softone-woocommerce-integration.php`
- `php -l admin/request-tester-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5b78674e88327943b9a3f65020a00