### PR TITLE
Add seasonal category support and bump version 2.2.34

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -126,7 +126,19 @@ class Softone_API {
             $cat_path = [];
             if (!empty($item['COMMECATEGORY NAME'])) $cat_path[] = $item['COMMECATEGORY NAME'];
             if (!empty($item['SUBMECATEGORY NAME'])) $cat_path[] = $item['SUBMECATEGORY NAME'];
-            $product->set_category_ids($this->create_category_tree($cat_path));
+            $cat_ids = $this->create_category_tree($cat_path);
+            if (!empty($item['SEASON CODE_1'])) {
+                $extra_name = sanitize_text_field(mb_convert_encoding(trim($item['SEASON CODE_1']), 'UTF-8', 'UTF-8'));
+                $extra_term = term_exists($extra_name, 'product_cat');
+                if (!$extra_term) {
+                    $extra_term = wp_insert_term($extra_name, 'product_cat');
+                }
+                if (!is_wp_error($extra_term)) {
+                    $extra_id = is_array($extra_term) ? $extra_term['term_id'] : $extra_term;
+                    $cat_ids[] = $extra_id;
+                }
+            }
+            $product->set_category_ids($cat_ids);
             $brand_name = '';
             foreach (['BRAND NAME','BRANDNAME','MTRBRAND NAME','MTRBRANDS NAME'] as $bk) {
                 if (!empty($item[$bk])) {

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.33\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.34\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.33
+Stable tag: 2.2.34
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,9 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.34 =
+* Assign products to the category named in SEASON CODE_1 if provided.
+
 = 2.2.33 =
 * Ensure API Request Tester displays the full Softone response.
 
@@ -116,6 +119,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.34 =
+* Assigns products to category from SEASON CODE_1 when available.
 
 = 2.2.33 =
 * Shows the complete Softone response in the API Request Tester.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.33
+ * Version: 2.2.34
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- assign optional seasonal category from `SEASON CODE_1` and create term when missing
- bump plugin version to 2.2.34 and update docs

## Testing
- `php -l includes/api.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5bc10f86c83279fe915bd57e0ef2f