### PR TITLE
Use Softone BARCODE for WooCommerce GTIN field and bump version

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -103,7 +103,8 @@ class Softone_API {
     public function sync_product_to_woocommerce($item) {
         softone_log('sync_product', print_r($item, true));
         try {
-            $sku = sanitize_text_field(mb_convert_encoding(trim($item['SKU']), 'UTF-8', 'UTF-8'));
+            $sku = sanitize_text_field(mb_convert_encoding(trim($item['CODE']), 'UTF-8', 'UTF-8'));
+            $barcode = !empty($item['BARCODE']) ? sanitize_text_field(mb_convert_encoding(trim($item['BARCODE']), 'UTF-8', 'UTF-8')) : '';
             $name = sanitize_text_field(mb_convert_encoding(trim($item['DESC']), 'UTF-8', 'UTF-8'));
             $price = isset($item['RETAILPRICE']) ? floatval($item['RETAILPRICE']) : 0;
             $qty = isset($item['Stock QTY']) ? intval($item['Stock QTY']) : 0;
@@ -113,6 +114,9 @@ class Softone_API {
             $product->set_regular_price($price);
             $product->set_price($price);
             $product->set_sku($sku);
+            if ($barcode && method_exists($product, 'set_global_unique_id')) {
+                $product->set_global_unique_id($barcode);
+            }
             $product->set_stock_quantity($qty);
             $product->set_manage_stock(true);
             if (!empty($item['CCCSOCYLODES'])) {
@@ -179,7 +183,7 @@ class Softone_API {
             if ($brand_term_id) { wp_set_object_terms($id, [$brand_term_id], 'product_brand'); }
             return ($existing_id ? "Updated" : "Added") . ": $sku (ID $id)";
         } catch (Throwable $e) {
-            return "❌ Failed to sync SKU {$item['SKU']}: " . $e->getMessage();
+            return "❌ Failed to sync SKU {$item['CODE']}: " . $e->getMessage();
         }
     }
 }
@@ -215,7 +219,7 @@ add_action('wp_ajax_softone_sync_products', function () {
             $log[] = "✅ [$offset+$i] $result";
         } catch (Throwable $e) {
             $failed++;
-            $log[] = "❌ [$offset+$i] Failed SKU: " . ($item['SKU'] ?? '[UNKNOWN]') . ' – Error: ' . $e->getMessage();
+            $log[] = "❌ [$offset+$i] Failed SKU: " . ($item['CODE'] ?? '[UNKNOWN]') . ' – Error: ' . $e->getMessage();
         }
     }
     $progress = min(100, round((($offset + $limit) / $total) * 100));

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.34\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.35\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.34
+Stable tag: 2.2.35
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,9 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.35 =
+* Map Softone CODE to WooCommerce SKU and BARCODE to GTIN field.
+
 = 2.2.34 =
 * Assign products to the category named in SEASON CODE_1 if provided.
 
@@ -119,6 +122,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.35 =
+* Uses Softone CODE as SKU and BARCODE for WooCommerce GTIN field.
 
 = 2.2.34 =
 * Assigns products to category from SEASON CODE_1 when available.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.34
+ * Version: 2.2.35
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- Map Softone BARCODE to WooCommerce global unique ID field (GTIN, UPC, EAN, ISBN)
- Use Softone CODE as product SKU
- Bump plugin version to 2.2.35 and document changes

## Testing
- `php -l includes/api.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5c090b4c08327be156c3f9d5bfc73