### PR TITLE
Map Softone SKU/CODE fields and add MTRL upsells

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -100,11 +100,22 @@ class Softone_API {
         return $term_ids;
     }
 
+    private function get_product_id_by_mtrl($mtrl) {
+        $products = get_posts([
+            'post_type'      => 'product',
+            'meta_key'       => 'attribute_mtrl',
+            'meta_value'     => $mtrl,
+            'fields'         => 'ids',
+            'posts_per_page' => 1,
+        ]);
+        return !empty($products) ? (int) $products[0] : 0;
+    }
+
     public function sync_product_to_woocommerce($item) {
         softone_log('sync_product', print_r($item, true));
         try {
-            $sku = sanitize_text_field(mb_convert_encoding(trim($item['CODE']), 'UTF-8', 'UTF-8'));
-            $barcode = !empty($item['BARCODE']) ? sanitize_text_field(mb_convert_encoding(trim($item['BARCODE']), 'UTF-8', 'UTF-8')) : '';
+            $sku = sanitize_text_field(mb_convert_encoding(trim($item['SKU']), 'UTF-8', 'UTF-8'));
+            $barcode = !empty($item['CODE']) ? sanitize_text_field(mb_convert_encoding(trim($item['CODE']), 'UTF-8', 'UTF-8')) : '';
             $name = sanitize_text_field(mb_convert_encoding(trim($item['DESC']), 'UTF-8', 'UTF-8'));
             $price = isset($item['RETAILPRICE']) ? floatval($item['RETAILPRICE']) : 0;
             $qty = isset($item['Stock QTY']) ? intval($item['Stock QTY']) : 0;
@@ -159,6 +170,16 @@ class Softone_API {
             }
 
             $attributes = [];
+            if (!empty($item['MTRL'])) {
+                $mtrl_value = sanitize_text_field(mb_convert_encoding(trim($item['MTRL']), 'UTF-8', 'UTF-8'));
+                $mtrl_attr = new WC_Product_Attribute();
+                $mtrl_attr->set_name('MTRL');
+                $mtrl_attr->set_options([$mtrl_value]);
+                $mtrl_attr->set_visible(false);
+                $mtrl_attr->set_variation(false);
+                $attributes[] = $mtrl_attr;
+                $product->update_meta_data('attribute_mtrl', $mtrl_value);
+            }
             if (!empty($item['COLOUR NAME'])) {
                 $colour_attr = new WC_Product_Attribute();
                 $colour_attr->set_name('Colour');
@@ -179,11 +200,19 @@ class Softone_API {
                 $product->set_attributes($attributes);
             }
 
+            if (!empty($item['Related_Item_MTRL'])) {
+                $related_mtrl = sanitize_text_field(mb_convert_encoding(trim($item['Related_Item_MTRL']), 'UTF-8', 'UTF-8'));
+                $related_id = $this->get_product_id_by_mtrl($related_mtrl);
+                if ($related_id) {
+                    $product->set_upsell_ids([$related_id]);
+                }
+            }
+
             $id = $product->save();
             if ($brand_term_id) { wp_set_object_terms($id, [$brand_term_id], 'product_brand'); }
             return ($existing_id ? "Updated" : "Added") . ": $sku (ID $id)";
         } catch (Throwable $e) {
-            return "❌ Failed to sync SKU {$item['CODE']}: " . $e->getMessage();
+            return "❌ Failed to sync SKU {$item['SKU']}: " . $e->getMessage();
         }
     }
 }
@@ -219,7 +248,7 @@ add_action('wp_ajax_softone_sync_products', function () {
             $log[] = "✅ [$offset+$i] $result";
         } catch (Throwable $e) {
             $failed++;
-            $log[] = "❌ [$offset+$i] Failed SKU: " . ($item['CODE'] ?? '[UNKNOWN]') . ' – Error: ' . $e->getMessage();
+            $log[] = "❌ [$offset+$i] Failed SKU: " . ($item['SKU'] ?? '[UNKNOWN]') . ' – Error: ' . $e->getMessage();
         }
     }
     $progress = min(100, round((($offset + $limit) / $total) * 100));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.35
+Stable tag: 2.2.36
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,11 @@ nested submenus for each level.
 
 == Changelog ==
 
+= 2.2.36 =
+* Map Softone SKU to WooCommerce SKU and Softone CODE to the barcode field.
+* Store Softone MTRL as a hidden product attribute and add upsells via Related_Item_MTRL.
+* Use COMMECATEGORY NAME for categories and SUBMECATEGORY NAME for subcategories.
+
 = 2.2.35 =
 * Map Softone CODE to WooCommerce SKU and BARCODE to GTIN field.
 
@@ -122,6 +127,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.36 =
+* Switches to Softone SKU for product SKUs, maps CODE to barcode, and links upsells via MTRL.
 
 = 2.2.35 =
 * Uses Softone CODE as SKU and BARCODE for WooCommerce GTIN field.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.35
+ * Version: 2.2.36
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- Use Softone SKU for WooCommerce SKU and map Softone CODE to product barcode
- Store Softone MTRL as hidden attribute and link Related_Item_MTRL as upsell
- Document new mapping and bump plugin version to 2.2.36

## Testing
- `php -l includes/api.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb8438748327832787e75b4aaa57