### PR TITLE
Place Special Offers last in menu and bump version

### DIFF
--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -77,6 +77,7 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
         $term_map = [];
         $term_children = [];
         $all_term_ids = [];
+        $special_offers_id = null;
 
         foreach ($product_cats as $term) {
             // Skip and remove the default "Uncategorized" category
@@ -88,9 +89,18 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
                 continue;
             }
 
+            if ($term->slug === 'special-offers') {
+                $special_offers_id = $term->term_id;
+            }
+
             $term_map[$term->term_id] = $term;
             $term_children[$term->parent][] = $term->term_id;
             $all_term_ids[] = $term->term_id;
+        }
+
+        if ($special_offers_id && isset($term_children[0])) {
+            $term_children[0] = array_values(array_diff($term_children[0], [$special_offers_id]));
+            $term_children[0][] = $special_offers_id;
         }
 
         $new_menu_item_ids = [];

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.35\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.37\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.36
+Stable tag: 2.2.37
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,9 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.37 =
+* Ensure "Special Offers" category is placed last in the mega menu.
 
 = 2.2.36 =
 * Map Softone SKU to WooCommerce SKU and Softone CODE to the barcode field.
@@ -127,6 +130,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.37 =
+* Adds "Special Offers" to the end of the mega menu.
 
 = 2.2.36 =
 * Switches to Softone SKU for product SKUs, maps CODE to barcode, and links upsells via MTRL.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.36
+ * Version: 2.2.37
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- Ensure the "Special Offers" product category is appended to the end of the Products mega menu
- Bump plugin to version 2.2.37

## Testing
- `php -l includes/menu-sync.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68a72d036f2c8327bdd5d2ec5d935c7b