### PR TITLE
Ensure brand name used for product brands

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -155,7 +155,8 @@ class Softone_API {
             }
             $product->set_category_ids($cat_ids);
             $brand_name = '';
-            foreach (['BRAND NAME','BRANDNAME','MTRBRAND NAME','MTRBRANDS NAME'] as $bk) {
+            // Use human-readable brand name fields and ignore brand codes.
+            foreach (['BRAND NAME','BRANDS NAME','MTRBRAND NAME','MTRBRANDS NAME'] as $bk) {
                 if (!empty($item[$bk])) {
                     $brand_name = $item[$bk];
                     break;

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.37\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.38\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.37
+Stable tag: 2.2.38
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,9 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.38 =
+* Always use brand name instead of brand code for product brands.
 
 = 2.2.37 =
 * Ensure "Special Offers" category is placed last in the mega menu.
@@ -130,6 +133,9 @@ nested submenus for each level.
 * Initial release.
 
 == Upgrade Notice ==
+
+= 2.2.38 =
+* Uses brand name rather than brand code for product brands.
 
 = 2.2.37 =
 * Adds "Special Offers" to the end of the mega menu.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.37
+ * Version: 2.2.38
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- stop using brand code fields when assigning product brands
- bump plugin version to 2.2.38 and update docs

## Testing
- `php -l includes/api.php`
- `php -l softone-woocommerce-integration.php`
- `msgfmt --check -o /tmp/softone.pot.languages languages/softone-woocommerce-integration.pot` *(warnings: missing header fields)*

------
https://chatgpt.com/codex/tasks/task_e_68a72f6835a08327941f8de566c4ed20