### PR TITLE
Add dedicated logs pages for orders and customers

### DIFF
--- a/admin/customer-logs-page.php
+++ b/admin/customer-logs-page.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Displays customer-related log entries for the Softone WooCommerce Integration.
+ */
+function softone_customer_logs_page() {
+    $logs = get_option('softone_api_logs', []);
+    $filtered = array_filter($logs, function ($log) {
+        return isset($log['action']) && false !== strpos($log['action'], 'customer');
+    });
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html__('Softone Customer Logs', 'softone-woocommerce-integration') . '</h1>';
+    echo '<pre style="background:#111;color:#0f0;padding:10px;height:400px;overflow:auto;font-size:13px;">';
+    foreach ($filtered as $row) {
+        $line = sprintf('[%s] %s: %s', $row['timestamp'], $row['action'], $row['message']);
+        echo esc_html($line) . "\n";
+    }
+    echo '</pre>';
+    echo '</div>';
+}

--- a/admin/order-logs-page.php
+++ b/admin/order-logs-page.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Displays order-related log entries for the Softone WooCommerce Integration.
+ */
+function softone_order_logs_page() {
+    $logs = get_option('softone_api_logs', []);
+    $filtered = array_filter($logs, function ($log) {
+        return isset($log['action']) && (false !== strpos($log['action'], 'order') || false !== strpos($log['action'], 'salesdoc'));
+    });
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html__('Softone Order Logs', 'softone-woocommerce-integration') . '</h1>';
+    echo '<pre style="background:#111;color:#0f0;padding:10px;height:400px;overflow:auto;font-size:13px;">';
+    foreach ($filtered as $row) {
+        $line = sprintf('[%s] %s: %s', $row['timestamp'], $row['action'], $row['message']);
+        echo esc_html($line) . "\n";
+    }
+    echo '</pre>';
+    echo '</div>';
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.42
+Stable tag: 2.2.43
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,9 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.43 =
+* Add admin pages to view order and customer logs.
 
 = 2.2.42 =
 * Add detailed logging for customer creation and sales document submission.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.42
+ * Version: 2.2.43
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration
@@ -34,6 +34,8 @@ require_once SOFTONE_PLUGIN_PATH . 'admin/customer-sync-page.php';
 require_once SOFTONE_PLUGIN_PATH . 'admin/product-sync-page.php';
 require_once SOFTONE_PLUGIN_PATH . 'admin/order-sync-page.php';
 require_once SOFTONE_PLUGIN_PATH . 'admin/logs-page.php';
+require_once SOFTONE_PLUGIN_PATH . 'admin/customer-logs-page.php';
+require_once SOFTONE_PLUGIN_PATH . 'admin/order-logs-page.php';
 require_once SOFTONE_PLUGIN_PATH . 'admin/request-tester-page.php';
 require_once SOFTONE_PLUGIN_PATH . 'admin/api-fields-page.php';
 require 'plugin-update-checker/plugin-update-checker.php';
@@ -178,6 +180,26 @@ function softone_admin_menu() {
         'softone_logs_page'
     );
     softone_debug_log('admin_menu', 'Logs submenu hook: ' . $log_hook);
+
+    $customer_logs_hook = add_submenu_page(
+        'softone-settings',
+        __('Customer Logs', 'softone-woocommerce-integration'),
+        __('Customer Logs', 'softone-woocommerce-integration'),
+        'manage_options',
+        'softone-customer-logs',
+        'softone_customer_logs_page'
+    );
+    softone_debug_log('admin_menu', 'Customer logs submenu hook: ' . $customer_logs_hook);
+
+    $order_logs_hook = add_submenu_page(
+        'softone-settings',
+        __('Order Logs', 'softone-woocommerce-integration'),
+        __('Order Logs', 'softone-woocommerce-integration'),
+        'manage_options',
+        'softone-order-logs',
+        'softone_order_logs_page'
+    );
+    softone_debug_log('admin_menu', 'Order logs submenu hook: ' . $order_logs_hook);
 
     $tester_hook = add_submenu_page(
         'softone-settings',


### PR DESCRIPTION
## Summary
- add admin submenu pages to view Softone customer and order logs
- filter log entries for customer and order events
- bump plugin to version 2.2.43

## Testing
- `php -l softone-woocommerce-integration.php`
- `php -l admin/customer-logs-page.php`
- `php -l admin/order-logs-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68a75531e5e08327abc1aeec58d34eb7