### PR TITLE
Improve log memory usage and bump version to 2.2.47

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ customer, product and order data between the two systems.
 - **Custom cron schedules** – Adds 2‑minute and 2‑hour schedules that other
   tasks can use.
 - **Memory optimised sync** – Order synchronisation runs in small batches and
-  the log viewer returns only recent entries to keep memory usage low.
+  API logs are trimmed to the most recent entries to keep memory usage low.
 
 ## Installation
 

--- a/includes/logging.php
+++ b/includes/logging.php
@@ -15,6 +15,10 @@ function softone_log($action, $message) {
         'action'   => sanitize_text_field($action),
         'message'  => sanitize_textarea_field($message),
     ];
+    // Retain only the most recent 100 entries to avoid large options consuming memory
+    if (count($logs) > 100) {
+        $logs = array_slice($logs, -100);
+    }
     update_option('softone_api_logs', $logs);
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.46
+Stable tag: 2.2.47
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,9 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.47 =
+* Limit stored API logs to the most recent 100 entries for better memory efficiency.
 
 = 2.2.46 =
 * Free memory and flush caches during product sync for improved efficiency.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.46
+ * Version: 2.2.47
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- trim API logs to most recent 100 entries to reduce memory usage
- document memory-efficient logging and bump plugin version to 2.2.47

## Testing
- `php -l includes/logging.php softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad4a0115088327b636ac6ce9d1c98a