### PR TITLE
Fix description mapping and bump version

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -269,13 +269,13 @@ class Softone_API {
             }
             $product->set_stock_quantity($qty);
             $product->set_manage_stock(true);
-            if (!empty($item['CCCSOCYLODES'])) {
-                $desc = mb_convert_encoding(trim($item['CCCSOCYLODES']), 'UTF-8', 'UTF-8');
+            if (!empty($item['Long Description']) || !empty($item['CCCSOCYLODES'])) {
+                $desc = mb_convert_encoding(trim($item['Long Description'] ?? $item['CCCSOCYLODES']), 'UTF-8', 'UTF-8');
                 // Softone long description -> WooCommerce product content
                 $product->set_description(wp_kses_post($desc));
             }
-            if (!empty($item['CCCSOCYSHDES'])) {
-                $short = mb_convert_encoding(trim($item['CCCSOCYSHDES']), 'UTF-8', 'UTF-8');
+            if (!empty($item['Short Description']) || !empty($item['CCCSOCYSHDES'])) {
+                $short = mb_convert_encoding(trim($item['Short Description'] ?? $item['CCCSOCYSHDES']), 'UTF-8', 'UTF-8');
                 // Softone short description -> WooCommerce short description
                 $product->set_short_description(wp_kses_post($short));
             }

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.44\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.49\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.48
+Stable tag: 2.2.49
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,9 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.49 =
+* Correct mapping of Softone long and short descriptions to WooCommerce.
 
 = 2.2.48 =
 * Map Softone long and short description fields to WooCommerce product content and short description.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.48
+ * Version: 2.2.49
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- Support Softone "Long Description" and "Short Description" fields when mapping to WooCommerce content and excerpt.
- Bump plugin to version 2.2.49 and document the change.

## Testing
- `php -l includes/api.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad608330a88327bd5afbedd96fd83a