### PR TITLE
Use brand names for products and bump version

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -302,9 +302,12 @@ class Softone_API {
             }
             $product->set_category_ids($cat_ids);
             $brand_name = '';
-            // Use human-readable brand name fields and ignore brand codes.
-            foreach (['BRAND NAME','BRANDS NAME','MTRBRAND NAME','MTRBRANDS NAME'] as $bk) {
-                if (!empty($item[$bk])) {
+            // Use human-readable brand name fields and ignore brand codes or numeric values.
+            foreach (
+                ['BRAND NAME','BRANDS NAME','MTRBRAND NAME','MTRBRANDS NAME','BRAND','BRANDS','MTRBRAND','MTRBRANDS']
+                as $bk
+            ) {
+                if (!empty($item[$bk]) && !ctype_digit(trim($item[$bk]))) {
                     $brand_name = $item[$bk];
                     break;
                 }

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.49\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.50\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.49
+Stable tag: 2.2.50
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,9 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.50 =
+* Ignore numeric brand codes and use brand names only for product brands.
 
 = 2.2.49 =
 * Correct mapping of Softone long and short descriptions to WooCommerce.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.49
+ * Version: 2.2.50
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- Skip numeric brand codes and use human-readable names when assigning `product_brand`
- Bump plugin to version 2.2.50 and update documentation

## Testing
- `php -l includes/api.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad63bc4b5483278fd382ae3ead45b1