### PR TITLE
Restrict Softone AJAX endpoints to administrators

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -376,6 +376,10 @@ class Softone_API {
 
 add_action('wp_ajax_softone_sync_products', function () {
     check_ajax_referer('softone_sync_products_nonce');
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('Unauthorized');
+        wp_die();
+    }
     $offset = isset($_POST['offset']) ? intval($_POST['offset']) : 0;
     $limit = 20;
     $api = new Softone_API();

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.52\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.53\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.52
+Stable tag: 2.2.53
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,9 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.53 =
+* Restrict product sync and log retrieval actions to administrators.
 
 = 2.2.52 =
 * Compare Softone and WooCommerce products by hidden MTRL attribute and log differences.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.52
+ * Version: 2.2.53
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration
@@ -453,6 +453,9 @@ function softone_sync_orders() {
 add_action('wp_ajax_softone_get_logs', 'softone_get_logs');
 function softone_get_logs() {
     check_ajax_referer('softone_get_logs_nonce');
+    if (!current_user_can('manage_options')) {
+        return wp_send_json_error('Unauthorized');
+    }
     $logs = get_option('softone_api_logs', []);
     if (!is_array($logs)) {
         $logs = [];


### PR DESCRIPTION
## Summary
- require `manage_options` capability for viewing logs
- require `manage_options` capability for product sync AJAX
- bump plugin version to 2.2.53

## Testing
- `php -l softone-woocommerce-integration.php`
- `php -l includes/api.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad6e8e0d348327b0134144f2ab2287