### PR TITLE
Harden request tester and bump version

### DIFF
--- a/admin/request-tester-page.php
+++ b/admin/request-tester-page.php
@@ -3,8 +3,13 @@
  * Provides an interface to send arbitrary HTTP requests and display the response.
  */
 function softone_request_tester_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(__('You do not have permission to access this page.', 'softone-woocommerce-integration'));
+    }
+
     $response = null;
     $error = '';
+    $allowed_hosts = apply_filters('softone_request_tester_allowed_hosts', array('ptkids.oncloud.gr'));
 
     $presets = array(
         'get_products' => array(
@@ -70,13 +75,23 @@ function softone_request_tester_page() {
         }
 
         if (empty($error) && !empty($url)) {
-            $args = array(
-                'method'  => $method,
-                'headers' => $headers,
-                'body'    => $body,
-                'timeout' => 20,
-            );
-            $response = wp_remote_request($url, $args);
+            $validated_url = wp_http_validate_url($url);
+            if (false === $validated_url) {
+                $error = __('Invalid URL provided.', 'softone-woocommerce-integration');
+            } else {
+                $host = wp_parse_url($validated_url, PHP_URL_HOST);
+                if (!in_array($host, $allowed_hosts, true)) {
+                    $error = __('The provided host is not allowed.', 'softone-woocommerce-integration');
+                } else {
+                    $args = array(
+                        'method'  => $method,
+                        'headers' => $headers,
+                        'body'    => $body,
+                        'timeout' => 20,
+                    );
+                    $response = wp_remote_request($validated_url, $args);
+                }
+            }
         }
     }
     ?>

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,8 +1,20 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.52\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.53\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: admin/request-tester-page.php:7
+msgid "You do not have permission to access this page."
+msgstr ""
+
+#: admin/request-tester-page.php:80
+msgid "Invalid URL provided."
+msgstr ""
+
+#: admin/request-tester-page.php:84
+msgid "The provided host is not allowed."
+msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.52
+Stable tag: 2.2.53
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,9 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.53 =
+* Add capability and URL validation to the Request Tester tool.
 
 = 2.2.52 =
 * Compare Softone and WooCommerce products by hidden MTRL attribute and log differences.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.52
+ * Version: 2.2.53
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- restrict Request Tester access to admins and validate URLs/hosts
- bump plugin version to 2.2.53

## Testing
- `php -l admin/request-tester-page.php`
- `php -l softone-woocommerce-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad6e9aff6c8327bb17592c421da7d5