### PR TITLE
Secure API credential handling and documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ customer, product and order data between the two systems.
    install it through the WordPress plugin screen.
 2. Activate **Softone WooCommerce Integration**. WooCommerce must already be
    active.
-3. Go to **Softone → Settings** in the WordPress dashboard and enter your API
-   credentials.
+3. After activation, go to **Softone → Settings** in the WordPress dashboard
+   and enter your real API username, password and client ID.
 
 Once configured, the plugin will automatically keep customers, products and
 orders in sync with Softone.

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -3,9 +3,6 @@
  * Displays the settings page for the Softone WooCommerce Integration.
  */
 function softone_settings_page() {
-    $username = get_option('softone_api_username');
-    $password = get_option('softone_api_password');
-    $client_id = get_option('softone_client_id');
     ?>
     <div class="wrap">
         <h1><?php esc_html_e('Softone API Settings', 'softone-woocommerce-integration'); ?></h1>
@@ -34,7 +31,7 @@ function softone_admin_settings() {
     add_settings_field('softone_missing_product_action', __('Missing Products Action', 'softone-woocommerce-integration'), 'softone_missing_product_action_callback', 'softone-settings', 'softone_product_settings_section');
 
     register_setting('softone_settings_group', 'softone_api_username');
-    register_setting('softone_settings_group', 'softone_api_password');
+    register_setting('softone_settings_group', 'softone_api_password', 'softone_sanitize_api_password');
     register_setting('softone_settings_group', 'softone_missing_product_action');
 }
 
@@ -45,7 +42,7 @@ function softone_api_username_callback() {
 }
 
 function softone_api_password_callback() {
-    $password = get_option('softone_api_password');
+    $password = softone_decrypt(get_option('softone_api_password'));
     echo '<input type="password" id="softone_api_password" name="softone_api_password" value="' . esc_attr($password) . '" />';
 }
 

--- a/includes/api.php
+++ b/includes/api.php
@@ -11,7 +11,8 @@ class Softone_API {
 
     public function __construct() {
         $this->username = get_option('softone_api_username');
-        $this->password = get_option('softone_api_password');
+        $encrypted      = get_option('softone_api_password');
+        $this->password = $encrypted ? softone_decrypt($encrypted) : '';
         $this->client_id = get_option('softone_client_id');
         $this->session = get_option('softone_api_session');
         $expires = get_option('softone_api_session_expires');

--- a/languages/softone-woocommerce-integration.pot
+++ b/languages/softone-woocommerce-integration.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Softone WooCommerce Integration 2.2.52\n"
+"Project-Id-Version: Softone WooCommerce Integration 2.2.53\n"
 "POT-Creation-Date: 2024-05-01 00:00+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.52
+Stable tag: 2.2.53
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -31,7 +31,7 @@ ERP system and keeps both platforms in sync.
 
 1. Upload the plugin files to the `/wp-content/plugins/softone-woocommerce-integration` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Use the Settings->Softone screen to configure the plugin.
+3. After activation, go to **Settings → Softone** and enter your real API username, password and client ID.
 
 == Frequently Asked Questions ==
 
@@ -64,6 +64,10 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.53 =
+* Encrypt stored API password using WordPress AUTH_KEY and remove default credentials on activation.
+* Administrators must enter their real API username, password and client ID after activating the plugin.
 
 = 2.2.52 =
 * Compare Softone and WooCommerce products by hidden MTRL attribute and log differences.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.52
+ * Version: 2.2.53
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration
@@ -24,6 +24,29 @@ register_activation_hook(__FILE__, 'softone_check_woocommerce');
 
 // Define plugin path
 define('SOFTONE_PLUGIN_PATH', plugin_dir_path(__FILE__));
+
+// Helper functions for encrypting and decrypting the API password
+function softone_encrypt($data) {
+    if ($data === '') {
+        return '';
+    }
+    $key = hash('sha256', AUTH_KEY);
+    $iv  = substr($key, 0, 16);
+    return base64_encode(openssl_encrypt($data, 'AES-256-CBC', $key, 0, $iv));
+}
+
+function softone_decrypt($data) {
+    if ($data === '' || $data === false) {
+        return '';
+    }
+    $key = hash('sha256', AUTH_KEY);
+    $iv  = substr($key, 0, 16);
+    return openssl_decrypt(base64_decode($data), 'AES-256-CBC', $key, 0, $iv);
+}
+
+function softone_sanitize_api_password($password) {
+    return $password ? softone_encrypt($password) : '';
+}
 
 // Include necessary files
 require_once SOFTONE_PLUGIN_PATH . 'includes/api.php';
@@ -235,21 +258,12 @@ function softone_admin_menu() {
 // Register settings
 function softone_register_settings() {
     register_setting('softone_settings_group', 'softone_api_username', 'sanitize_text_field');
-    register_setting('softone_settings_group', 'softone_api_password', 'sanitize_text_field');
+    register_setting('softone_settings_group', 'softone_api_password', 'softone_sanitize_api_password');
 }
 
 // Activation hook to set default options
 function softone_activate() {
     // Set default values for the options if they don't exist
-    if (get_option('softone_api_username') === false) {
-        update_option('softone_api_username', 'default_username');
-    }
-    if (get_option('softone_api_password') === false) {
-        update_option('softone_api_password', 'default_password');
-    }
-    if (get_option('softone_client_id') === false) {
-        update_option('softone_client_id', 'default_client_id');
-    }
     if (get_option('softone_synced_customers') === false) {
         update_option('softone_synced_customers', []);
     }


### PR DESCRIPTION
## Summary
- Encrypt and decrypt stored API password using WordPress AUTH_KEY and add sanitize callback during settings save.
- Remove placeholder credentials from activation and decrypt password in `Softone_API` constructor.
- Update documentation to instruct administrators to manually enter API credentials after activation and bump plugin version.

## Testing
- `php -l softone-woocommerce-integration.php`
- `php -l includes/api.php`
- `php -l admin/settings-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad6eb455988327bebafff1339d166b