### PR TITLE
Filter Softone product sync by BOOL01 flag

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -82,7 +82,18 @@ class Softone_API {
         $body = iconv('UTF-8', 'UTF-8//IGNORE', $body);
         if ($body === false) return [];
         $data = json_decode($body, true);
-        return isset($data['rows']) && is_array($data['rows']) ? $data['rows'] : [];
+        if (!isset($data['rows']) || !is_array($data['rows'])) {
+            return [];
+        }
+
+        $rows = array_filter(
+            $data['rows'],
+            static function ($item) {
+                return isset($item['BOOL01']) && intval($item['BOOL01']) === 1;
+            }
+        );
+
+        return array_values($rows);
     }
 
     public function get_customer_by_email($email) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.55
+Stable tag: 2.2.56
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,9 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.56 =
+* Retrieve only Softone products flagged for the web (BOOL01 = 1).
 
 = 2.2.55 =
 * Always use the Softone brand name fields when assigning product brands and ignore numeric brand IDs.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.55
+ * Version: 2.2.56
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- filter getItems responses to only return products where BOOL01 is set
- bump the plugin version to 2.2.56 and document the change in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3a0f04b688327bd385eab54639d47