### PR TITLE
Add automatic Main Menu sync for product brands

### DIFF
--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -5,7 +5,7 @@
  */
 
 // Ensure menu and root item exist
-function softone_ensure_menu_structure($menu_name = 'Main Menu', $parent_title = 'Products') {
+function softone_ensure_menu_structure($menu_name = 'Main Menu', $parent_title = 'Products', $add_mega_menu_class = true) {
     $menu = wp_get_nav_menu_object($menu_name);
     if (!$menu) {
         $menu_id = wp_create_nav_menu($menu_name);
@@ -33,55 +33,61 @@ function softone_ensure_menu_structure($menu_name = 'Main Menu', $parent_title =
         ]);
     }
 
-    $classes = get_post_meta($product_root_id, '_menu_item_classes', true);
-    if (!is_array($classes)) {
-        $classes = is_string($classes) ? explode(' ', $classes) : [];
+    if ($add_mega_menu_class) {
+        $classes = get_post_meta($product_root_id, '_menu_item_classes', true);
+        if (!is_array($classes)) {
+            $classes = is_string($classes) ? explode(' ', $classes) : [];
+        }
+        $classes = array_unique(array_filter(array_map('trim', $classes)));
+        if (!in_array('mega-menu', $classes, true)) {
+            $classes[] = 'mega-menu';
+        }
+        update_post_meta($product_root_id, '_menu_item_classes', $classes);
     }
-    $classes = array_unique(array_filter(array_map('trim', $classes)));
-    if (!in_array('mega-menu', $classes, true)) {
-        $classes[] = 'mega-menu';
-    }
-    update_post_meta($product_root_id, '_menu_item_classes', $classes);
 
     return [$menu_id, $product_root_id];
 }
 
-// Main sync function
-function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Menu', $parent_title = 'Products') {
-    static $running = false;
-    if ($running) return false;
-    $running = true;
+function softone_sync_taxonomy_menu($taxonomy, $menu_name, $parent_title, $args = []) {
+    static $running = [];
+    if (!empty($running[$taxonomy])) return false;
+    $running[$taxonomy] = true;
+
+    $args = wp_parse_args($args, [
+        'exclude_slugs'     => [],
+        'move_to_end_slugs' => [],
+        'add_mega_menu'     => true,
+    ]);
 
     try {
-        list($menu_id, $product_root_id) = softone_ensure_menu_structure($menu_name, $parent_title);
+        list($menu_id, $root_menu_id) = softone_ensure_menu_structure($menu_name, $parent_title, $args['add_mega_menu']);
 
         $menu_items = wp_get_nav_menu_items($menu_id, ['orderby' => 'menu_order']);
         $existing_menu_items = [];
 
         foreach ($menu_items as $item) {
-            if ($item->type === 'taxonomy' && $item->object === 'product_cat') {
+            if ($item->type === 'taxonomy' && $item->object === $taxonomy) {
                 $existing_menu_items[$item->menu_item_parent][$item->object_id] = $item->ID;
             }
         }
 
         $product_cats = get_terms([
-            'taxonomy' => 'product_cat',
+            'taxonomy' => $taxonomy,
             'hide_empty' => false,
             'update_term_meta_cache' => false,
         ]);
 
         if (is_wp_error($product_cats)) {
-            throw new Exception('Failed to get product categories: ' . $product_cats->get_error_message());
+            throw new Exception('Failed to get terms for ' . $taxonomy . ': ' . $product_cats->get_error_message());
         }
 
         $term_map = [];
         $term_children = [];
         $all_term_ids = [];
-        $special_offers_id = null;
+        $move_to_end_ids = [];
 
         foreach ($product_cats as $term) {
-            // Skip and remove the default "Uncategorized" category
-            if ($term->slug === 'uncategorized') {
+            if (in_array($term->slug, $args['exclude_slugs'], true)) {
                 if (!empty($existing_menu_items[$term->parent][$term->term_id])) {
                     wp_delete_post($existing_menu_items[$term->parent][$term->term_id], true);
                     unset($existing_menu_items[$term->parent][$term->term_id]);
@@ -89,23 +95,25 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
                 continue;
             }
 
-            if ($term->slug === 'special-offers') {
-                $special_offers_id = $term->term_id;
-            }
-
             $term_map[$term->term_id] = $term;
             $term_children[$term->parent][] = $term->term_id;
             $all_term_ids[] = $term->term_id;
+
+            if (in_array($term->slug, $args['move_to_end_slugs'], true)) {
+                $move_to_end_ids[] = $term->term_id;
+            }
         }
 
-        if ($special_offers_id && isset($term_children[0])) {
-            $term_children[0] = array_values(array_diff($term_children[0], [$special_offers_id]));
-            $term_children[0][] = $special_offers_id;
+        if (!empty($move_to_end_ids) && isset($term_children[0])) {
+            $term_children[0] = array_values(array_diff($term_children[0], $move_to_end_ids));
+            foreach ($move_to_end_ids as $term_id) {
+                $term_children[0][] = $term_id;
+            }
         }
 
         $new_menu_item_ids = [];
 
-        $add_recursive = function ($parent_term_id, $parent_menu_id) use (&$add_recursive, $term_children, $term_map, &$existing_menu_items, $menu_id, &$new_menu_item_ids, $product_root_id) {
+        $add_recursive = function ($parent_term_id, $parent_menu_id) use (&$add_recursive, $term_children, $term_map, &$existing_menu_items, $menu_id, &$new_menu_item_ids) {
             if (!isset($term_children[$parent_term_id])) return;
 
             foreach ($term_children[$parent_term_id] as $term_id) {
@@ -113,7 +121,7 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
 
                 $args = [
                     'menu-item-title'      => $term->name,
-                    'menu-item-object'     => 'product_cat',
+                    'menu-item-object'     => $taxonomy,
                     'menu-item-object-id'  => $term->term_id,
                     'menu-item-type'       => 'taxonomy',
                     'menu-item-status'     => 'publish',
@@ -133,7 +141,7 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
             }
         };
 
-        $add_recursive(0, $product_root_id);
+        $add_recursive(0, $root_menu_id);
 
         foreach ($existing_menu_items as $parent_id => $items) {
             foreach ($items as $term_id => $item_id) {
@@ -143,15 +151,42 @@ function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Men
             }
         }
 
-        update_option('softone_last_product_menu_sync', current_time('mysql'));
         return true;
 
     } catch (Exception $e) {
-        error_log('Product menu sync error: ' . $e->getMessage());
+        error_log('Menu sync error (' . $taxonomy . '): ' . $e->getMessage());
         return false;
     } finally {
-        $running = false;
+        $running[$taxonomy] = false;
     }
+}
+
+// Main sync function for product categories
+function softone_sync_woocommerce_product_categories_menu($menu_name = 'Main Menu', $parent_title = 'Products') {
+    $result = softone_sync_taxonomy_menu('product_cat', $menu_name, $parent_title, [
+        'exclude_slugs'     => ['uncategorized'],
+        'move_to_end_slugs' => ['special-offers'],
+        'add_mega_menu'     => true,
+    ]);
+
+    if ($result) {
+        update_option('softone_last_product_menu_sync', current_time('mysql'));
+    }
+
+    return $result;
+}
+
+// Sync function for product brands
+function softone_sync_woocommerce_product_brands_menu($menu_name = 'Main Menu', $parent_title = 'Brands') {
+    $result = softone_sync_taxonomy_menu('product_brand', $menu_name, $parent_title, [
+        'add_mega_menu' => false,
+    ]);
+
+    if ($result) {
+        update_option('softone_last_product_brand_menu_sync', current_time('mysql'));
+    }
+
+    return $result;
 }
 
 // Schedule auto sync on category changes (debounced 30s)
@@ -164,9 +199,19 @@ add_action('created_product_cat', 'softone_schedule_auto_sync_product_menu');
 add_action('edited_product_cat', 'softone_schedule_auto_sync_product_menu');
 add_action('delete_product_cat', 'softone_schedule_auto_sync_product_menu');
 
+function softone_schedule_auto_sync_product_brand_menu() {
+    softone_schedule_auto_sync_product_menu();
+}
+add_action('created_product_brand', 'softone_schedule_auto_sync_product_brand_menu');
+add_action('edited_product_brand', 'softone_schedule_auto_sync_product_brand_menu');
+add_action('delete_product_brand', 'softone_schedule_auto_sync_product_brand_menu');
+
 function softone_run_auto_sync_product_menu() {
     if (function_exists('softone_sync_woocommerce_product_categories_menu')) {
         softone_sync_woocommerce_product_categories_menu('Main Menu', 'Products');
+    }
+    if (function_exists('softone_sync_woocommerce_product_brands_menu')) {
+        softone_sync_woocommerce_product_brands_menu('Main Menu', 'Brands');
     }
 }
 add_action('softone_debounced_auto_sync_product_menu', 'softone_run_auto_sync_product_menu');
@@ -182,21 +227,22 @@ function softone_render_sync_product_menu_page() {
     if (isset($_POST['softone_run_sync'])) {
         check_admin_referer('softone_sync_product_menu_action');
 
-        if (function_exists('softone_sync_woocommerce_product_categories_menu')) {
-            $result = softone_sync_woocommerce_product_categories_menu('Main Menu', 'Products');
-            if ($result) {
-                update_option('softone_last_product_menu_sync', current_time('mysql'));
-                $message = __('✅ Product categories synced successfully.', 'softone-woocommerce-integration');
+        if (function_exists('softone_sync_woocommerce_product_categories_menu') && function_exists('softone_sync_woocommerce_product_brands_menu')) {
+            $categories_result = softone_sync_woocommerce_product_categories_menu('Main Menu', 'Products');
+            $brands_result = softone_sync_woocommerce_product_brands_menu('Main Menu', 'Brands');
+
+            if ($categories_result && $brands_result) {
+                $message = __('✅ Product categories and brands synced successfully.', 'softone-woocommerce-integration');
                 $message_type = 'success';
             } else {
-                $message = __('❌ There was an error syncing product categories. Check logs.', 'softone-woocommerce-integration');
+                $message = __('❌ There was an error syncing product categories or brands. Check logs.', 'softone-woocommerce-integration');
                 $message_type = 'error';
             }
         }
     }
     ?>
     <div class="wrap">
-        <h1><?php esc_html_e('Sync WooCommerce Product Categories', 'softone-woocommerce-integration'); ?></h1>
+        <h1><?php esc_html_e('Sync WooCommerce Product Categories and Brands', 'softone-woocommerce-integration'); ?></h1>
 
         <?php if ($message) : ?>
             <div class="notice notice-<?php echo esc_attr($message_type); ?>">
@@ -212,8 +258,9 @@ function softone_render_sync_product_menu_page() {
 
         <hr>
 
-        <p><strong><?php esc_html_e('Last sync:', 'softone-woocommerce-integration'); ?></strong> <?php echo esc_html(get_option('softone_last_product_menu_sync', 'Never')); ?></p>
-        <p><strong><?php esc_html_e('Note:', 'softone-woocommerce-integration'); ?></strong> <?php esc_html_e('The sync runs automatically when product categories are added, edited, or deleted.', 'softone-woocommerce-integration'); ?></p>
+        <p><strong><?php esc_html_e('Last product category sync:', 'softone-woocommerce-integration'); ?></strong> <?php echo esc_html(get_option('softone_last_product_menu_sync', 'Never')); ?></p>
+        <p><strong><?php esc_html_e('Last brand sync:', 'softone-woocommerce-integration'); ?></strong> <?php echo esc_html(get_option('softone_last_product_brand_menu_sync', 'Never')); ?></p>
+        <p><strong><?php esc_html_e('Note:', 'softone-woocommerce-integration'); ?></strong> <?php esc_html_e('The sync runs automatically when product categories or brands are added, edited, or deleted.', 'softone-woocommerce-integration'); ?></p>
     </div>
     <?php
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.57
+Stable tag: 2.2.58
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,10 @@ Sync tool mirrors this hierarchy under the **Products** menu item, creating
 nested submenus for each level.
 
 == Changelog ==
+
+= 2.2.58 =
+* Mirror WooCommerce product brands under a "Brands" item in the Main Menu.
+* Automatically keep the brands menu in sync when brands are created, updated, or deleted.
 
 = 2.2.57 =
 * Enforce brand selection to only use values that contain real names instead of numeric codes.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.57
+ * Version: 2.2.58
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration
@@ -123,6 +123,7 @@ add_action('init', 'softone_register_brand_taxonomy');
 add_action('init', function () {
     if (function_exists('softone_ensure_menu_structure')) {
         softone_ensure_menu_structure('Main Menu', 'Products');
+        softone_ensure_menu_structure('Main Menu', 'Brands', false);
     }
 }, 20);
 


### PR DESCRIPTION
## Summary
- generalise the menu sync helper so multiple taxonomies can be mirrored into navigation menus
- add a Brands root in the Main Menu that stays in sync with WooCommerce product brands and expose manual sync status in the admin page
- bump the plugin version to 2.2.58 and document the new behaviour in the changelog

## Testing
- php -l includes/menu-sync.php
- php -l softone-woocommerce-integration.php

------
https://chatgpt.com/codex/tasks/task_e_68e3a9967a7c8327a952fc959ddcebd2