### PR TITLE
Fix brand menu structure and bump version to 2.2.61

### DIFF
--- a/includes/menu-sync.php
+++ b/includes/menu-sync.php
@@ -143,36 +143,6 @@ function softone_sync_taxonomy_menu($taxonomy, $menu_name, $parent_title, $args 
 
         $add_recursive(0, $root_menu_id);
 
-        if (!empty($term_children[0])) {
-            foreach ($term_children[0] as $term_id) {
-                if (!isset($term_map[$term_id])) {
-                    continue;
-                }
-
-                $term = $term_map[$term_id];
-
-                $top_level_args = [
-                    'menu-item-title'      => $term->name,
-                    'menu-item-object'     => $taxonomy,
-                    'menu-item-object-id'  => $term->term_id,
-                    'menu-item-type'       => 'taxonomy',
-                    'menu-item-status'     => 'publish',
-                    'menu-item-parent-id'  => 0,
-                ];
-
-                $existing_id = $existing_menu_items[0][$term_id] ?? 0;
-
-                $menu_item_id = wp_update_nav_menu_item($menu_id, $existing_id, $top_level_args);
-
-                if (is_wp_error($menu_item_id)) {
-                    continue;
-                }
-
-                $existing_menu_items[0][$term_id] = $menu_item_id;
-                $new_menu_item_ids[] = $menu_item_id;
-            }
-        }
-
         foreach ($existing_menu_items as $parent_id => $items) {
             foreach ($items as $term_id => $item_id) {
                 if (!in_array($item_id, $new_menu_item_ids, true)) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: georgenicolaou
 Tags: woocommerce, integration, softone, api, synchronization
 Requires at least: 5.0
 Tested up to: 6.0
-Stable tag: 2.2.60
+Stable tag: 2.2.61
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Softone WooCommerce Integration
  * Plugin URI: https://wordpress.org/plugins/softone-woocommerce-integration/
  * Description: Integrates WooCommerce with Softone API for customer, product, and order synchronization.
- * Version: 2.2.60
+ * Version: 2.2.61
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/georgenicolaou/
  * Text Domain: softone-woocommerce-integration


### PR DESCRIPTION
## Summary
- keep synced taxonomy items nested beneath their configured parent menu entry
- ensure the Products menu retains its mega menu children without duplicating at the top level
- bump the plugin version to 2.2.61

## Testing
- php -l includes/menu-sync.php

------
https://chatgpt.com/codex/tasks/task_e_68e5166173f48327a67b9a066438f00f