### PR TITLE
Restore plugin update checker dependency

### DIFF
--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -21,7 +21,7 @@
             },
             "time": "2025-05-20T12:29:01+00:00",
             "type": "library",
-            "installation-source": "source",
+            "installation-source": "dist",
             "autoload": {
                 "files": [
                     "load-v5p6.php"
@@ -54,6 +54,6 @@
             "install-path": "../yahnis-elsts/plugin-update-checker"
         }
     ],
-    "dev": true,
+    "dev": false,
     "dev-package-names": []
 }

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,19 +1,19 @@
 <?php return array(
     'root' => array(
         'name' => 'georgenicolaou/softone-woocommerce-integration',
-        'pretty_version' => 'dev-main',
-        'version' => 'dev-main',
-        'reference' => '7d455cb1973216b8cb05c1cb683101ae61fe3657',
+        'pretty_version' => 'dev-work',
+        'version' => 'dev-work',
+        'reference' => '620c18ecc2861d11868ecce287b1876bea8ec00f',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'dev' => true,
+        'dev' => false,
     ),
     'versions' => array(
         'georgenicolaou/softone-woocommerce-integration' => array(
-            'pretty_version' => 'dev-main',
-            'version' => 'dev-main',
-            'reference' => '7d455cb1973216b8cb05c1cb683101ae61fe3657',
+            'pretty_version' => 'dev-work',
+            'version' => 'dev-work',
+            'reference' => '620c18ecc2861d11868ecce287b1876bea8ec00f',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- reinstall the yahnis-elsts/plugin-update-checker dependency to restore the vendor files
- update Composer metadata to mark the package as installed from dist for production use

## Testing
- php -r "require 'vendor/autoload.php'; var_export(class_exists('\\YahnisElsts\\PluginUpdateChecker\\v5\\PucFactory')); echo PHP_EOL;"

------
https://chatgpt.com/codex/tasks/task_e_69021ddd400c8327b6b897e62bb0a96b