### PR TITLE
Fix plugin name typo and bump version to 1.0.1

### DIFF
--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -69,9 +69,9 @@ class Softone_Woocommerce_Integration {
 	public function __construct() {
 		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-		} else {
-			$this->version = '1.0.0';
-		}
+                } else {
+                        $this->version = '1.0.1';
+                }
 		$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -13,10 +13,10 @@
  * @package           Softone_Woocommerce_Integration
  *
  * @wordpress-plugin
- * Plugin Name:       Softon Woocommerce Integration
+ * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.0.0' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.0.1' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- correct the plugin header name to "Softone Woocommerce Integration"
- bump the plugin version constant and fallback to 1.0.1

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69022c22ad188327b6e3c1b063b3bc01