### PR TITLE
Add admin settings page for Softone integration

### DIFF
--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -13,8 +13,7 @@
 /**
  * The admin-specific functionality of the plugin.
  *
- * Defines the plugin name, version, and two examples hooks for how to
- * enqueue the admin-specific stylesheet and JavaScript.
+ * Defines the plugin name, version, and the admin settings page.
  *
  * @package    Softone_Woocommerce_Integration
  * @subpackage Softone_Woocommerce_Integration/admin
@@ -41,16 +40,353 @@ class Softone_Woocommerce_Integration_Admin {
 	private $version;
 
 	/**
+	 * Settings page slug.
+	 *
+	 * @var string
+	 */
+	private $menu_slug = 'softone-woocommerce-integration-settings';
+
+	/**
+	 * Capability required to manage plugin settings.
+	 *
+	 * @var string
+	 */
+	private $capability = 'manage_options';
+
+	/**
+	 * Base transient key for connection test notices.
+	 *
+	 * @var string
+	 */
+	private $test_notice_transient = 'softone_wc_integration_test_notice_';
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
-	 * @param      string    $plugin_name       The name of this plugin.
-	 * @param      string    $version    The version of this plugin.
+	 * @param string $plugin_name The name of this plugin.
+	 * @param string $version     The version of this plugin.
 	 */
 	public function __construct( $plugin_name, $version ) {
 
 		$this->plugin_name = $plugin_name;
-		$this->version = $version;
+		$this->version     = $version;
+
+	}
+
+	/**
+	 * Register the plugin submenu.
+	 */
+	public function register_menu() {
+
+		if ( ! current_user_can( $this->capability ) ) {
+			return;
+		}
+
+		$parent_slug = 'woocommerce';
+
+		add_submenu_page(
+			$parent_slug,
+			__( 'Softone Integration', 'softone-woocommerce-integration' ),
+			__( 'Softone Integration', 'softone-woocommerce-integration' ),
+			$this->capability,
+			$this->menu_slug,
+			array( $this, 'render_settings_page' )
+		);
+
+	}
+
+	/**
+	 * Register plugin settings and fields.
+	 */
+	public function register_settings() {
+
+		register_setting(
+			'softone_wc_integration',
+			Softone_API_Client::OPTION_SETTINGS_KEY,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize_settings' ),
+			)
+		);
+
+		add_settings_section(
+			'softone_wc_integration_api',
+			__( 'Softone API Credentials', 'softone-woocommerce-integration' ),
+			array( $this, 'render_settings_section_intro' ),
+			'softone_wc_integration'
+		);
+
+		$this->add_text_field( 'endpoint', __( 'Endpoint URL', 'softone-woocommerce-integration' ) );
+		$this->add_text_field( 'username', __( 'Username', 'softone-woocommerce-integration' ) );
+		$this->add_text_field( 'password', __( 'Password', 'softone-woocommerce-integration' ), 'password' );
+		$this->add_text_field( 'app_id', __( 'App ID', 'softone-woocommerce-integration' ) );
+		$this->add_text_field( 'company', __( 'Company', 'softone-woocommerce-integration' ) );
+		$this->add_text_field( 'branch', __( 'Branch', 'softone-woocommerce-integration' ) );
+		$this->add_text_field( 'module', __( 'Module', 'softone-woocommerce-integration' ) );
+		$this->add_text_field( 'refid', __( 'Ref ID', 'softone-woocommerce-integration' ) );
+		$this->add_text_field( 'default_saldoc_series', __( 'Default SALDOC Series', 'softone-woocommerce-integration' ) );
+		$this->add_text_field( 'warehouse', __( 'Default Warehouse', 'softone-woocommerce-integration' ) );
+
+	}
+
+	/**
+	 * Sanitize plugin settings.
+	 *
+	 * @param array $settings Raw settings array.
+	 *
+	 * @return array
+	 */
+	public function sanitize_settings( $settings ) {
+
+		$settings = is_array( $settings ) ? $settings : array();
+
+		$sanitized = array();
+
+		$sanitized['endpoint']              = isset( $settings['endpoint'] ) ? esc_url_raw( trim( (string) $settings['endpoint'] ) ) : '';
+		$sanitized['username']              = isset( $settings['username'] ) ? $this->sanitize_text_value( $settings['username'] ) : '';
+		$sanitized['password']              = isset( $settings['password'] ) ? $this->sanitize_text_value( $settings['password'] ) : '';
+		$sanitized['app_id']                = isset( $settings['app_id'] ) ? $this->sanitize_text_value( $settings['app_id'] ) : '';
+		$sanitized['company']               = isset( $settings['company'] ) ? $this->sanitize_text_value( $settings['company'] ) : '';
+		$sanitized['branch']                = isset( $settings['branch'] ) ? $this->sanitize_text_value( $settings['branch'] ) : '';
+		$sanitized['module']                = isset( $settings['module'] ) ? $this->sanitize_text_value( $settings['module'] ) : '';
+		$sanitized['refid']                 = isset( $settings['refid'] ) ? $this->sanitize_text_value( $settings['refid'] ) : '';
+		$sanitized['default_saldoc_series'] = isset( $settings['default_saldoc_series'] ) ? $this->sanitize_text_value( $settings['default_saldoc_series'] ) : '';
+		$sanitized['warehouse']             = isset( $settings['warehouse'] ) ? $this->sanitize_text_value( $settings['warehouse'] ) : '';
+
+		return $sanitized;
+
+	}
+
+	/**
+	 * Render section introduction text.
+	 */
+	public function render_settings_section_intro() {
+
+		echo '<p>' . esc_html__( 'Configure the credentials used to communicate with Softone.', 'softone-woocommerce-integration' ) . '</p>';
+
+	}
+
+	/**
+	 * Display the plugin settings page.
+	 */
+	public function render_settings_page() {
+
+		if ( ! current_user_can( $this->capability ) ) {
+			return;
+		}
+
+?>
+<div class="wrap">
+<h1><?php esc_html_e( 'Softone Integration', 'softone-woocommerce-integration' ); ?></h1>
+<?php $this->maybe_render_connection_notice(); ?>
+<?php settings_errors( 'softone_wc_integration' ); ?>
+<form action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>" method="post">
+<?php
+settings_fields( 'softone_wc_integration' );
+do_settings_sections( 'softone_wc_integration' );
+submit_button();
+?>
+</form>
+
+<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post" style="margin-top: 1.5em;">
+<?php wp_nonce_field( 'softone_wc_integration_test_connection' ); ?>
+<input type="hidden" name="action" value="softone_wc_integration_test_connection" />
+<?php submit_button( __( 'Test Connection', 'softone-woocommerce-integration' ), 'secondary', 'softone_wc_integration_test', false ); ?>
+</form>
+</div>
+<?php
+
+	}
+
+	/**
+	 * Handle connection test requests.
+	 */
+	public function handle_test_connection() {
+
+		if ( ! current_user_can( $this->capability ) ) {
+			wp_die( esc_html__( 'You do not have permission to perform this action.', 'softone-woocommerce-integration' ) );
+		}
+
+		check_admin_referer( 'softone_wc_integration_test_connection' );
+
+		$message = '';
+		$type    = 'success';
+
+		try {
+			$client = new Softone_API_Client();
+			$client->get_client_id( true );
+			$message = __( 'Successfully connected to Softone.', 'softone-woocommerce-integration' );
+		} catch ( Softone_API_Client_Exception $exception ) {
+			$type    = 'error';
+			$message = $exception->getMessage();
+		} catch ( Exception $exception ) {
+			$type    = 'error';
+			$message = $exception->getMessage();
+		}
+
+		$this->store_test_notice( $type, $message );
+
+		wp_safe_redirect( $this->get_settings_page_url() );
+		exit;
+
+	}
+
+	/**
+	 * Render a stored connection test notice when available.
+	 */
+	private function maybe_render_connection_notice() {
+
+		$notice = get_transient( $this->get_test_notice_key() );
+
+		if ( empty( $notice['message'] ) ) {
+			return;
+		}
+
+		delete_transient( $this->get_test_notice_key() );
+
+		$type    = isset( $notice['type'] ) && 'error' === $notice['type'] ? 'error' : 'success';
+		$classes = array( 'notice', 'notice-' . $type );
+
+		printf(
+			'<div class="%1$s"><p>%2$s</p></div>',
+			esc_attr( implode( ' ', $classes ) ),
+			esc_html( $notice['message'] )
+		);
+
+	}
+
+	/**
+	 * Store a connection test notice for the current user.
+	 *
+	 * @param string $type    Notice type.
+	 * @param string $message Notice message.
+	 */
+	private function store_test_notice( $type, $message ) {
+
+		set_transient(
+			$this->get_test_notice_key(),
+			array(
+				'type'    => $type,
+				'message' => $message,
+			),
+			MINUTE_IN_SECONDS
+		);
+
+	}
+
+	/**
+	 * Generate the transient key for the current user.
+	 *
+	 * @return string
+	 */
+	private function get_test_notice_key() {
+
+		$user_id = get_current_user_id();
+
+		return $this->test_notice_transient . ( $user_id ? $user_id : 'guest' );
+
+	}
+
+	/**
+	 * Retrieve the settings page URL.
+	 *
+	 * @return string
+	 */
+	private function get_settings_page_url() {
+
+		return add_query_arg( array( 'page' => $this->menu_slug ), admin_url( 'admin.php' ) );
+
+	}
+
+	/**
+	 * Register a text field with the Settings API.
+	 *
+	 * @param string $key   Setting key.
+	 * @param string $label Field label.
+	 * @param string $type  Input type.
+	 */
+	private function add_text_field( $key, $label, $type = 'text' ) {
+
+		add_settings_field(
+			'softone_wc_integration_' . $key,
+			$label,
+			array( $this, 'render_text_field' ),
+			'softone_wc_integration',
+			'softone_wc_integration_api',
+			array(
+				'key'  => $key,
+				'type' => $type,
+			)
+		);
+
+	}
+
+	/**
+	 * Render a generic text field.
+	 *
+	 * @param array $args Field arguments.
+	 */
+	public function render_text_field( $args ) {
+
+		$key  = isset( $args['key'] ) ? $args['key'] : '';
+		$type = isset( $args['type'] ) ? $args['type'] : 'text';
+
+		if ( '' === $key ) {
+			return;
+		}
+
+$lookup = array(
+'endpoint'              => 'softone_wc_integration_get_endpoint',
+'username'              => 'softone_wc_integration_get_username',
+'password'              => 'softone_wc_integration_get_password',
+'app_id'                => 'softone_wc_integration_get_app_id',
+'company'               => 'softone_wc_integration_get_company',
+'branch'                => 'softone_wc_integration_get_branch',
+'module'                => 'softone_wc_integration_get_module',
+'refid'                 => 'softone_wc_integration_get_refid',
+'default_saldoc_series' => 'softone_wc_integration_get_default_saldoc_series',
+'warehouse'             => 'softone_wc_integration_get_warehouse',
+);
+
+if ( isset( $lookup[ $key ] ) && is_callable( $lookup[ $key ] ) ) {
+$value = call_user_func( $lookup[ $key ] );
+} else {
+$value = '';
+}
+
+		$attributes = array(
+			'type'         => $type,
+			'id'           => 'softone_wc_integration_' . $key,
+			'name'         => Softone_API_Client::OPTION_SETTINGS_KEY . '[' . $key . ']',
+			'value'        => $value,
+			'class'        => 'regular-text',
+			'autocomplete' => 'off',
+		);
+
+		if ( 'password' === $type ) {
+			$attributes['autocomplete'] = 'current-password';
+		}
+
+		$attribute_string = '';
+		foreach ( $attributes as $attr_key => $attr_value ) {
+			$attribute_string .= sprintf( ' %1$s="%2$s"', esc_attr( $attr_key ), esc_attr( $attr_value ) );
+		}
+
+		echo '<input' . $attribute_string . ' />';
+
+	}
+
+	/**
+	 * Sanitize a generic text value.
+	 *
+	 * @param string $value Raw input value.
+	 *
+	 * @return string
+	 */
+	private function sanitize_text_value( $value ) {
+
+		return sanitize_text_field( wp_unslash( $value ) );
 
 	}
 
@@ -60,18 +396,6 @@ class Softone_Woocommerce_Integration_Admin {
 	 * @since    1.0.0
 	 */
 	public function enqueue_styles() {
-
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Softone_Woocommerce_Integration_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The Softone_Woocommerce_Integration_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
 
 		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/softone-woocommerce-integration-admin.css', array(), $this->version, 'all' );
 
@@ -84,20 +408,9 @@ class Softone_Woocommerce_Integration_Admin {
 	 */
 	public function enqueue_scripts() {
 
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Softone_Woocommerce_Integration_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The Softone_Woocommerce_Integration_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
-
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/softone-woocommerce-integration-admin.js', array( 'jquery' ), $this->version, false );
 
 	}
 
 }
+

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -94,6 +94,20 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
         protected $refid = '';
 
         /**
+         * Default SALDOC series.
+         *
+         * @var string
+         */
+        protected $default_saldoc_series = '';
+
+        /**
+         * Default warehouse code.
+         *
+         * @var string
+         */
+        protected $warehouse = '';
+
+        /**
          * Request timeout.
          *
          * @var int
@@ -131,6 +145,8 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             $this->branch   = isset( $this->settings['branch'] ) ? (string) $this->settings['branch'] : '';
             $this->module   = isset( $this->settings['module'] ) ? (string) $this->settings['module'] : '';
             $this->refid    = isset( $this->settings['refid'] ) ? (string) $this->settings['refid'] : '';
+            $this->default_saldoc_series = isset( $this->settings['default_saldoc_series'] ) ? (string) $this->settings['default_saldoc_series'] : '';
+            $this->warehouse             = isset( $this->settings['warehouse'] ) ? (string) $this->settings['warehouse'] : '';
 
             $timeout = isset( $this->settings['timeout'] ) ? absint( $this->settings['timeout'] ) : self::DEFAULT_TIMEOUT;
             $this->timeout = $timeout > 0 ? $timeout : self::DEFAULT_TIMEOUT;
@@ -567,6 +583,8 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 'branch'         => '',
                 'module'         => '',
                 'refid'          => '',
+                'default_saldoc_series' => '',
+                'warehouse'             => '',
                 'timeout'        => self::DEFAULT_TIMEOUT,
                 'client_id_ttl'  => self::DEFAULT_CLIENT_ID_TTL,
             );
@@ -589,6 +607,24 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
         protected function get_client_meta() {
             $meta = get_option( self::OPTION_CLIENT_ID_META_KEY, array() );
             return is_array( $meta ) ? $meta : array();
+        }
+
+        /**
+         * Retrieve the configured default SALDOC series.
+         *
+         * @return string
+         */
+        public function get_default_saldoc_series() {
+            return $this->default_saldoc_series;
+        }
+
+        /**
+         * Retrieve the configured default warehouse code.
+         *
+         * @return string
+         */
+        public function get_warehouse() {
+            return $this->warehouse;
         }
 
         /**

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -70,7 +70,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.1.0';
+                        $this->version = '1.2.0';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 
@@ -109,6 +109,11 @@ class Softone_Woocommerce_Integration {
                  * Service class for performing SoftOne API requests.
                  */
                 require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-api-client.php';
+
+                /**
+                 * Helper functions for accessing plugin settings.
+                 */
+                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/softone-woocommerce-integration-settings.php';
 
 		/**
 		 * The class responsible for defining internationalization functionality
@@ -156,12 +161,15 @@ class Softone_Woocommerce_Integration {
 	 * @access   private
 	 */
 	private function define_admin_hooks() {
-
-		$plugin_admin = new Softone_Woocommerce_Integration_Admin( $this->get_plugin_name(), $this->get_version() );
-
-		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
-		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
-
+	
+	$plugin_admin = new Softone_Woocommerce_Integration_Admin( $this->get_plugin_name(), $this->get_version() );
+	
+	$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+	$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+	$this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu' );
+	$this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
+	$this->loader->add_action( 'admin_post_softone_wc_integration_test_connection', $plugin_admin, 'handle_test_connection' );
+	
 	}
 
 	/**

--- a/includes/softone-woocommerce-integration-settings.php
+++ b/includes/softone-woocommerce-integration-settings.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Helper functions for Softone WooCommerce Integration settings.
+ *
+ * @package    Softone_Woocommerce_Integration
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_settings' ) ) {
+    /**
+     * Retrieve the plugin settings from the options table.
+     *
+     * @return array
+     */
+    function softone_wc_integration_get_settings() {
+        $stored = get_option( Softone_API_Client::OPTION_SETTINGS_KEY, array() );
+        $stored = is_array( $stored ) ? $stored : array();
+
+        $defaults = array(
+            'endpoint'              => '',
+            'username'              => '',
+            'password'              => '',
+            'app_id'                => '',
+            'company'               => '',
+            'branch'                => '',
+            'module'                => '',
+            'refid'                 => '',
+            'default_saldoc_series' => '',
+            'warehouse'             => '',
+            'timeout'               => Softone_API_Client::DEFAULT_TIMEOUT,
+            'client_id_ttl'         => Softone_API_Client::DEFAULT_CLIENT_ID_TTL,
+        );
+
+        $settings = wp_parse_args( $stored, $defaults );
+
+        /**
+         * Filter the plugin settings before they are returned.
+         *
+         * @param array $settings Plugin settings.
+         */
+        return apply_filters( 'softone_wc_integration_settings_raw', $settings );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_setting' ) ) {
+    /**
+     * Retrieve a specific plugin setting value.
+     *
+     * @param string $key     Setting key.
+     * @param mixed  $default Optional default value.
+     *
+     * @return mixed
+     */
+    function softone_wc_integration_get_setting( $key, $default = '' ) {
+        $settings = softone_wc_integration_get_settings();
+
+        if ( isset( $settings[ $key ] ) ) {
+            return $settings[ $key ];
+        }
+
+        return $default;
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_endpoint' ) ) {
+    function softone_wc_integration_get_endpoint() {
+        return (string) softone_wc_integration_get_setting( 'endpoint', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_username' ) ) {
+    function softone_wc_integration_get_username() {
+        return (string) softone_wc_integration_get_setting( 'username', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_password' ) ) {
+    function softone_wc_integration_get_password() {
+        return (string) softone_wc_integration_get_setting( 'password', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_app_id' ) ) {
+    function softone_wc_integration_get_app_id() {
+        return (string) softone_wc_integration_get_setting( 'app_id', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_company' ) ) {
+    function softone_wc_integration_get_company() {
+        return (string) softone_wc_integration_get_setting( 'company', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_branch' ) ) {
+    function softone_wc_integration_get_branch() {
+        return (string) softone_wc_integration_get_setting( 'branch', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_module' ) ) {
+    function softone_wc_integration_get_module() {
+        return (string) softone_wc_integration_get_setting( 'module', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_refid' ) ) {
+    function softone_wc_integration_get_refid() {
+        return (string) softone_wc_integration_get_setting( 'refid', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_default_saldoc_series' ) ) {
+    function softone_wc_integration_get_default_saldoc_series() {
+        return (string) softone_wc_integration_get_setting( 'default_saldoc_series', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_warehouse' ) ) {
+    function softone_wc_integration_get_warehouse() {
+        return (string) softone_wc_integration_get_setting( 'warehouse', '' );
+    }
+}

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.1.0
+ * Version:           1.2.0
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.1.0' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.2.0' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add a WooCommerce submenu with a Softone integration settings page
- persist Softone credentials and defaults through the Settings API with sanitization and helper accessors
- extend the API client with new configuration fields, add an optional connection test, and bump the plugin version to 1.2.0

## Testing
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l includes/class-softone-api-client.php
- php -l includes/softone-woocommerce-integration-settings.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l softone-woocommerce-integration.php

------
https://chatgpt.com/codex/tasks/task_e_690230845e448327955d23d771aeac99