### PR TITLE
Guard logger instanceof checks when WooCommerce is absent

### DIFF
--- a/includes/class-softone-customer-sync.php
+++ b/includes/class-softone-customer-sync.php
@@ -492,7 +492,7 @@ if ( ! class_exists( 'Softone_Customer_Sync' ) ) {
                 return;
             }
 
-            if ( $this->logger instanceof WC_Logger ) {
+            if ( class_exists( 'WC_Logger' ) && $this->logger instanceof WC_Logger ) {
                 $context['source'] = self::LOGGER_SOURCE;
             }
 

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -641,7 +641,7 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 return;
             }
 
-            if ( $this->logger instanceof WC_Logger ) {
+            if ( class_exists( 'WC_Logger' ) && $this->logger instanceof WC_Logger ) {
                 $context['source'] = self::LOGGER_SOURCE;
             }
 

--- a/includes/class-softone-order-sync.php
+++ b/includes/class-softone-order-sync.php
@@ -633,7 +633,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
                 return;
             }
 
-            if ( $this->logger instanceof WC_Logger ) {
+            if ( class_exists( 'WC_Logger' ) && $this->logger instanceof WC_Logger ) {
                 $context['source'] = self::LOGGER_SOURCE;
             }
 


### PR DESCRIPTION
## Summary
- guard the WC_Logger instanceof checks in sync services so they only run when WooCommerce is available

## Testing
- php -r 'define("ABSPATH", __DIR__); class Softone_API_Client {} class DummyLogger {public function log($level,$message,$context=array()){}} require "includes/class-softone-item-sync.php"; require "includes/class-softone-customer-sync.php"; require "includes/class-softone-order-sync.php"; $client = new Softone_API_Client(); $logger = new DummyLogger(); $item = new Softone_Item_Sync($client, $logger); $customer = new Softone_Customer_Sync($client, $logger); $order = new Softone_Order_Sync($client, $customer, $logger); foreach (array($item,$customer,$order) as $instance) { $ref = new ReflectionClass($instance); $method = $ref->getMethod("log"); $method->setAccessible(true); $method->invoke($instance, "info", "Test", array()); }'

------
https://chatgpt.com/codex/tasks/task_e_69024150b2ac8327aad5d23301851ad3