### PR TITLE
Add admin API tester and bump version

### DIFF
--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.5.1';
+                        $this->version = '1.6.0';
                 }
                 $this->plugin_name = 'softone-woocommerce-integration';
 
@@ -211,6 +211,7 @@ class Softone_Woocommerce_Integration {
         $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
         $this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu' );
         $this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
+        $this->loader->add_action( 'admin_post_softone_wc_integration_api_tester', $plugin_admin, 'handle_api_tester_request' );
         $this->loader->add_action( 'admin_post_softone_wc_integration_test_connection', $plugin_admin, 'handle_test_connection' );
         $this->loader->add_action( 'admin_post_' . Softone_Item_Sync::ADMIN_ACTION, $plugin_admin, 'handle_item_import' );
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.5.1
+ * Version:           1.6.0
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.5.1' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.6.0' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add an API Tester submenu and page that lets admins craft Softone API requests and review responses
- handle API tester submissions via admin_post, executing calls through Softone_API_Client and storing results for display
- bump the plugin version to 1.6.0 and register the new handler with the loader

## Testing
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l softone-woocommerce-integration.php

------
https://chatgpt.com/codex/tasks/task_e_6902630d7dd08327b68b5aec01256356