### PR TITLE
Bump plugin version to 1.6.1

### DIFF
--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.6.0';
+                        $this->version = '1.6.1';
                 }
                 $this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.6.0
+ * Version:           1.6.1
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.6.0' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.6.1' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'georgenicolaou/softone-woocommerce-integration',
         'pretty_version' => 'dev-work',
         'version' => 'dev-work',
-        'reference' => '5a884e3c95689c679c95303a8cfe20556634050d',
+        'reference' => '7662e87aa2b01e0e561096ec97311ca98d19dedf',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'georgenicolaou/softone-woocommerce-integration' => array(
             'pretty_version' => 'dev-work',
             'version' => 'dev-work',
-            'reference' => '5a884e3c95689c679c95303a8cfe20556634050d',
+            'reference' => '7662e87aa2b01e0e561096ec97311ca98d19dedf',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- update the plugin header and version constant to 1.6.1
- align the core class fallback version with the new release number
- regenerate Composer metadata to capture the release build

## Testing
- composer install

------
https://chatgpt.com/codex/tasks/task_e_6902688cd3bc8327bc1f59d78cf5bebd