### PR TITLE
Add API tester presets and bump version

### DIFF
--- a/admin/js/softone-woocommerce-integration-admin.js
+++ b/admin/js/softone-woocommerce-integration-admin.js
@@ -1,32 +1,78 @@
 (function( $ ) {
-	'use strict';
+        'use strict';
 
-	/**
-	 * All of the code for your admin-facing JavaScript source
-	 * should reside in this file.
-	 *
-	 * Note: It has been assumed you will write jQuery code here, so the
-	 * $ function reference has been prepared for usage within the scope
-	 * of this function.
-	 *
-	 * This enables you to define handlers, for when the DOM is ready:
-	 *
-	 * $(function() {
-	 *
-	 * });
-	 *
-	 * When the window is loaded:
-	 *
-	 * $( window ).load(function() {
-	 *
-	 * });
-	 *
-	 * ...and/or other possibilities.
-	 *
-	 * Ideally, it is not considered best practise to attach more than a
-	 * single DOM-ready or window-load handler for a particular page.
-	 * Although scripts in the WordPress core, Plugins and Themes may be
-	 * practising this, we should strive to set a better example in our own work.
-	 */
+        $( function() {
+                if ( 'undefined' === typeof window.softoneApiTester ) {
+                        return;
+                }
 
+                var config = window.softoneApiTester || {};
+                var presets = config.presets || {};
+                var $presetField = $( '#softone_api_preset' );
+
+                if ( ! $presetField.length ) {
+                        return;
+                }
+
+                var $serviceTypeField = $( '#softone_service_type' );
+                var $sqlNameField = $( '#softone_sql_name' );
+                var $objectField = $( '#softone_object' );
+                var $customServiceField = $( '#softone_custom_service' );
+                var $requiresClientField = $( '#softone_requires_client_id' );
+                var $payloadField = $( '#softone_payload' );
+                var $description = $( '#softone_api_preset_description' );
+                var defaultDescription = config.defaultDescription || ( $description.data( 'default-description' ) || '' );
+
+                var updateDescription = function( key ) {
+                        if ( ! $description.length ) {
+                                return;
+                        }
+
+                        if ( key && presets[ key ] && presets[ key ].description ) {
+                                $description.text( presets[ key ].description );
+                        } else {
+                                $description.text( defaultDescription );
+                        }
+                };
+
+                var applyPreset = function( key ) {
+                        updateDescription( key );
+
+                        if ( ! key || ! presets[ key ] ) {
+                                return;
+                        }
+
+                        var form = presets[ key ].form || {};
+
+                        if ( form.service_type ) {
+                                $serviceTypeField.val( form.service_type );
+                        }
+
+                        if ( typeof form.sql_name !== 'undefined' ) {
+                                $sqlNameField.val( form.sql_name );
+                        }
+
+                        if ( typeof form.object !== 'undefined' ) {
+                                $objectField.val( form.object );
+                        }
+
+                        if ( typeof form.custom_service !== 'undefined' ) {
+                                $customServiceField.val( form.custom_service );
+                        }
+
+                        if ( typeof form.requires_client_id !== 'undefined' ) {
+                                $requiresClientField.prop( 'checked', !! form.requires_client_id );
+                        }
+
+                        if ( typeof form.payload !== 'undefined' ) {
+                                $payloadField.val( form.payload );
+                        }
+                };
+
+                $presetField.on( 'change', function() {
+                        applyPreset( $( this ).val() );
+                } );
+
+                updateDescription( $presetField.val() );
+        } );
 })( jQuery );

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.6.1';
+                        $this->version = '1.7.0';
                 }
                 $this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.6.1
+ * Version:           1.7.0
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.6.1' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.7.0' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add preset selection to the Softone API tester and populate the form based on the chosen configuration
- expose preset metadata to the admin script and update the JavaScript to apply payloads and descriptions
- bump the plugin version to 1.7.0 throughout the codebase

## Testing
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l softone-woocommerce-integration.php

------
https://chatgpt.com/codex/tasks/task_e_690269bf2ef88327b11db80905e129f1