### PR TITLE
Bump plugin version to 1.7.1

### DIFF
--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -88,12 +88,12 @@ class Softone_Woocommerce_Integration {
          * @since    1.0.0
          */
         public function __construct() {
-                if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-                        $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-                } else {
-                        $this->version = '1.7.0';
-                }
-                $this->plugin_name = 'softone-woocommerce-integration';
+		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+		} else {
+			$this->version = '1.7.1';
+		}
+		$this->plugin_name = 'softone-woocommerce-integration';
 
                 $this->load_dependencies();
                 $this->set_locale();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.7.0
+ * Version:           1.7.1
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.7.0' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.7.1' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- update the plugin header and version constant to 1.7.1
- align the constructor's fallback version with the new release number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690277d719248327800299b95d66f250