### PR TITLE
Fix SoftOne login payload and release 1.7.2

### DIFF
--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -208,11 +208,19 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 'password' => $this->password,
             );
 
-            foreach ( $this->get_handshake_fields() as $key => $value ) {
-                if ( '' !== $value && ! array_key_exists( $key, $payload ) ) {
-                    $payload[ $key ] = $value;
-                }
-            }
+            /**
+             * Filter the login payload before dispatching the request.
+             *
+             * Historically the plugin forwarded the handshake fields (company, branch,
+             * module, refid) during the login request. SoftOne rejects those extra
+             * parameters for the PT Kids environment, so the default behaviour is to
+             * omit them. Sites that rely on the old behaviour can re-introduce the
+             * fields via this filter.
+             *
+             * @param array                   $payload Login payload.
+             * @param Softone_API_Client|null $client  API client instance.
+             */
+            $payload = apply_filters( 'softone_wc_integration_login_payload', $payload, $this );
 
             $response = $this->call_service( 'login', $payload, false );
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
 		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 		} else {
-			$this->version = '1.7.1';
+                        $this->version = '1.7.2';
 		}
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.7.1
+ * Version:           1.7.2
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.7.1' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.7.2' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- remove handshake fields from the SoftOne login payload to match the documented API expectations and add a filter for custom payloads
- bump the plugin version constant and bootstrap fallback to 1.7.2 for the new release

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_6902799f42fc83278c159540fc863407