### PR TITLE
Add configurable SoftOne country mapping support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -90,6 +90,22 @@ The plugin now bundles [yahnis-elsts/plugin-update-checker](https://github.com/Y
 1. Adjust the repository URL, branch or release asset usage using the `softone_woocommerce_integration_update_url`, `softone_woocommerce_integration_update_branch` and `softone_woocommerce_integration_use_release_assets` filters if needed.
 1. WordPress will automatically discover updates exposed by the configured repository and prompt you to update from the Plugins screen.
 
+== Country Mapping Configuration ==
+
+SoftOne installations typically expect a numeric country identifier instead of WooCommerce ISO codes. Use the **Country Mappings** textarea located under **Softone Integration → Settings** to provide the mapping. Enter one mapping per line using the format `GR:123`, where the part before the colon is the ISO 3166-1 alpha-2 code and the part after the colon is the numeric SoftOne identifier. The plugin automatically normalises the input and ignores empty lines.
+
+Developers can further adjust the mapping in code by filtering the array exposed via the `softone_wc_integration_country_mappings` hook or by overriding individual results with the `softone_wc_integration_country_id` filter.
+
+== Manual QA ==
+
+Use the following smoke test to verify country mapping behaviour:
+
+1. Navigate to **Softone Integration → Settings** and populate the **Country Mappings** textarea with a sample mapping such as `GR:101`. Save the settings.
+1. Create a WooCommerce customer (or place a guest order) using Greece as the billing country.
+1. Confirm that the SoftOne payload written to the debug log or sent to the API contains `COUNTRY => 101` instead of the ISO code. If the mapping is missing, the plugin now logs an error mentioning the ISO code and skips the payload so the missing configuration can be corrected.
+
+Repeat the steps for each supported country to ensure the expected numeric IDs are emitted.
+
 == Arbitrary section ==
 
 You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated

--- a/includes/softone-woocommerce-integration-settings.php
+++ b/includes/softone-woocommerce-integration-settings.php
@@ -30,6 +30,7 @@ if ( ! function_exists( 'softone_wc_integration_get_settings' ) ) {
             'refid'                 => '',
             'default_saldoc_series' => '',
             'warehouse'             => '',
+            'country_mappings'      => array(),
             'timeout'               => Softone_API_Client::DEFAULT_TIMEOUT,
             'client_id_ttl'         => Softone_API_Client::DEFAULT_CLIENT_ID_TTL,
         );
@@ -122,5 +123,22 @@ if ( ! function_exists( 'softone_wc_integration_get_default_saldoc_series' ) ) {
 if ( ! function_exists( 'softone_wc_integration_get_warehouse' ) ) {
     function softone_wc_integration_get_warehouse() {
         return (string) softone_wc_integration_get_setting( 'warehouse', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_country_mappings' ) ) {
+    /**
+     * Retrieve the configured ISO-to-SoftOne country mapping table.
+     *
+     * @return array<string,string>
+     */
+    function softone_wc_integration_get_country_mappings() {
+        $mappings = softone_wc_integration_get_setting( 'country_mappings', array() );
+
+        if ( ! is_array( $mappings ) ) {
+            return array();
+        }
+
+        return $mappings;
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable helper to convert WooCommerce ISO country codes into SoftOne IDs and use it during customer creation
- surface a Country Mappings setting (with filters) so store owners can manage the SoftOne ID table
- update documentation with manual QA guidance covering the new workflow

## Testing
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l includes/class-softone-customer-sync.php
- php -l includes/class-softone-order-sync.php
- php -l includes/softone-woocommerce-integration-settings.php

------
https://chatgpt.com/codex/tasks/task_e_69027dae9f0483279159cd2b2328c5d7