### PR TITLE
Add configuration for SoftOne customer defaults

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -96,6 +96,16 @@ SoftOne installations typically expect a numeric country identifier instead of W
 
 Developers can further adjust the mapping in code by filtering the array exposed via the `softone_wc_integration_country_mappings` hook or by overriding individual results with the `softone_wc_integration_country_id` filter.
 
+== Customer Default Configuration ==
+
+Use the following settings located under **Softone Integration → Settings** to control the default values applied to new SoftOne customer records:
+
+* **Default AREAS** — populates the `AREAS` field when creating or updating customers.
+* **Default SOCURRENCY** — applied to the `SOCURRENCY` field to control the customer's currency.
+* **Default TRDCATEGORY** — sets the `TRDCATEGORY` field for the trading category code.
+
+Leave any field blank to skip sending the corresponding value. Developers can read the configured defaults programmatically via the `Softone_API_Client` accessors (`get_areas()`, `get_socurrency()`, and `get_trdcategory()`).
+
 == Manual QA ==
 
 Use the following smoke test to verify country mapping behaviour:
@@ -105,6 +115,11 @@ Use the following smoke test to verify country mapping behaviour:
 1. Confirm that the SoftOne payload written to the debug log or sent to the API contains `COUNTRY => 101` instead of the ISO code. If the mapping is missing, the plugin now logs an error mentioning the ISO code and skips the payload so the missing configuration can be corrected.
 
 Repeat the steps for each supported country to ensure the expected numeric IDs are emitted.
+
+Additional optional checks:
+
+1. Populate the **Default AREAS**, **Default SOCURRENCY**, and **Default TRDCATEGORY** fields with representative values and save the settings.
+1. Create a WooCommerce customer (or place a guest order) and confirm that the SoftOne payload now contains the configured defaults (for example `AREAS => 22`). Remove the values or adjust them to match the production environment once verified.
 
 == Arbitrary section ==
 

--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -191,6 +191,9 @@ class Softone_Woocommerce_Integration_Admin {
                 $this->add_text_field( 'refid', __( 'Ref ID', 'softone-woocommerce-integration' ) );
                 $this->add_text_field( 'default_saldoc_series', __( 'Default SALDOC Series', 'softone-woocommerce-integration' ) );
                 $this->add_text_field( 'warehouse', __( 'Default Warehouse', 'softone-woocommerce-integration' ) );
+                $this->add_text_field( 'areas', __( 'Default AREAS', 'softone-woocommerce-integration' ) );
+                $this->add_text_field( 'socurrency', __( 'Default SOCURRENCY', 'softone-woocommerce-integration' ) );
+                $this->add_text_field( 'trdcategory', __( 'Default TRDCATEGORY', 'softone-woocommerce-integration' ) );
                 add_settings_field(
                         'softone_wc_integration_country_mappings',
                         __( 'Country Mappings', 'softone-woocommerce-integration' ),
@@ -233,6 +236,9 @@ class Softone_Woocommerce_Integration_Admin {
                 $sanitized['refid']                 = isset( $settings['refid'] ) ? $this->sanitize_text_value( $settings['refid'] ) : '';
                 $sanitized['default_saldoc_series'] = isset( $settings['default_saldoc_series'] ) ? $this->sanitize_text_value( $settings['default_saldoc_series'] ) : '';
                 $sanitized['warehouse']             = isset( $settings['warehouse'] ) ? $this->sanitize_text_value( $settings['warehouse'] ) : '';
+                $sanitized['areas']                 = isset( $settings['areas'] ) ? $this->sanitize_text_value( $settings['areas'] ) : '';
+                $sanitized['socurrency']            = isset( $settings['socurrency'] ) ? $this->sanitize_text_value( $settings['socurrency'] ) : '';
+                $sanitized['trdcategory']           = isset( $settings['trdcategory'] ) ? $this->sanitize_text_value( $settings['trdcategory'] ) : '';
                 $sanitized['country_mappings']      = isset( $settings['country_mappings'] ) ? $this->sanitize_country_mappings( $settings['country_mappings'] ) : array();
 
                 return $sanitized;
@@ -334,6 +340,9 @@ submit_button( __( 'Run Item Import', 'softone-woocommerce-integration' ), 'seco
                         'refid'                 => __( 'Ref ID', 'softone-woocommerce-integration' ),
                         'default_saldoc_series' => __( 'Default SALDOC Series', 'softone-woocommerce-integration' ),
                         'warehouse'             => __( 'Default Warehouse', 'softone-woocommerce-integration' ),
+                        'areas'                 => __( 'Default AREAS', 'softone-woocommerce-integration' ),
+                        'socurrency'            => __( 'Default SOCURRENCY', 'softone-woocommerce-integration' ),
+                        'trdcategory'           => __( 'Default TRDCATEGORY', 'softone-woocommerce-integration' ),
                 );
 
                 $settings_summary = array();
@@ -1309,6 +1318,9 @@ public function handle_test_connection() {
                         'refid'                 => 'softone_wc_integration_get_refid',
                         'default_saldoc_series' => 'softone_wc_integration_get_default_saldoc_series',
                         'warehouse'             => 'softone_wc_integration_get_warehouse',
+                        'areas'                 => 'softone_wc_integration_get_areas',
+                        'socurrency'            => 'softone_wc_integration_get_socurrency',
+                        'trdcategory'           => 'softone_wc_integration_get_trdcategory',
                 );
 
                 if ( isset( $lookup[ $key ] ) && is_callable( $lookup[ $key ] ) ) {

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -142,6 +142,27 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
         protected $warehouse = '';
 
         /**
+         * Default customer area identifier.
+         *
+         * @var string
+         */
+        protected $areas = '';
+
+        /**
+         * Default customer currency identifier.
+         *
+         * @var string
+         */
+        protected $socurrency = '';
+
+        /**
+         * Default customer trading category.
+         *
+         * @var string
+         */
+        protected $trdcategory = '';
+
+        /**
          * Request timeout.
          *
          * @var int
@@ -181,6 +202,9 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             $this->refid    = isset( $this->settings['refid'] ) ? trim( (string) $this->settings['refid'] ) : '';
             $this->default_saldoc_series = isset( $this->settings['default_saldoc_series'] ) ? trim( (string) $this->settings['default_saldoc_series'] ) : '';
             $this->warehouse             = isset( $this->settings['warehouse'] ) ? trim( (string) $this->settings['warehouse'] ) : '';
+            $this->areas                 = isset( $this->settings['areas'] ) ? trim( (string) $this->settings['areas'] ) : '';
+            $this->socurrency            = isset( $this->settings['socurrency'] ) ? trim( (string) $this->settings['socurrency'] ) : '';
+            $this->trdcategory           = isset( $this->settings['trdcategory'] ) ? trim( (string) $this->settings['trdcategory'] ) : '';
 
             $timeout = isset( $this->settings['timeout'] ) ? absint( $this->settings['timeout'] ) : self::DEFAULT_TIMEOUT;
             $this->timeout = $timeout > 0 ? $timeout : self::DEFAULT_TIMEOUT;
@@ -725,6 +749,9 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 'refid'          => '',
                 'default_saldoc_series' => '',
                 'warehouse'             => '',
+                'areas'                 => '',
+                'socurrency'            => '',
+                'trdcategory'           => '',
                 'timeout'        => self::DEFAULT_TIMEOUT,
                 'client_id_ttl'  => self::DEFAULT_CLIENT_ID_TTL,
             );
@@ -765,6 +792,33 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
          */
         public function get_warehouse() {
             return $this->warehouse;
+        }
+
+        /**
+         * Retrieve the configured default customer area identifier.
+         *
+         * @return string
+         */
+        public function get_areas() {
+            return $this->areas;
+        }
+
+        /**
+         * Retrieve the configured default customer currency identifier.
+         *
+         * @return string
+         */
+        public function get_socurrency() {
+            return $this->socurrency;
+        }
+
+        /**
+         * Retrieve the configured default customer trading category.
+         *
+         * @return string
+         */
+        public function get_trdcategory() {
+            return $this->trdcategory;
         }
 
         /**

--- a/includes/class-softone-customer-sync.php
+++ b/includes/class-softone-customer-sync.php
@@ -427,16 +427,19 @@ if ( ! class_exists( 'Softone_Customer_Sync' ) ) {
             }
 
             $record = array(
-                'CODE'    => $this->generate_customer_code( $customer ),
-                'NAME'    => $name,
-                'EMAIL'   => $customer->get_email(),
-                'PHONE01' => $primary_phone,
-                'PHONE02' => $secondary,
-                'ADDRESS' => $address_1,
-                'ADDRESS2'=> $address_2,
-                'CITY'    => $city,
-                'ZIP'     => $postcode,
-                'COUNTRY' => $softone_country,
+                'CODE'        => $this->generate_customer_code( $customer ),
+                'NAME'        => $name,
+                'EMAIL'       => $customer->get_email(),
+                'PHONE01'     => $primary_phone,
+                'PHONE02'     => $secondary,
+                'ADDRESS'     => $address_1,
+                'ADDRESS2'    => $address_2,
+                'CITY'        => $city,
+                'ZIP'         => $postcode,
+                'COUNTRY'     => $softone_country,
+                'AREAS'       => $this->api_client->get_areas(),
+                'SOCURRENCY'  => $this->api_client->get_socurrency(),
+                'TRDCATEGORY' => $this->api_client->get_trdcategory(),
             );
 
             if ( null !== $trdr ) {

--- a/includes/class-softone-order-sync.php
+++ b/includes/class-softone-order-sync.php
@@ -314,15 +314,18 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
             }
 
             $record = array(
-                'CODE'    => sprintf( '%sG%06d', Softone_Customer_Sync::CODE_PREFIX, $order->get_id() ),
-                'NAME'    => $name,
-                'EMAIL'   => $order->get_billing_email(),
-                'PHONE01' => $order->get_billing_phone(),
-                'ADDRESS' => $order->get_billing_address_1(),
-                'ADDRESS2'=> $order->get_billing_address_2(),
-                'CITY'    => $order->get_billing_city(),
-                'ZIP'     => $order->get_billing_postcode(),
-                'COUNTRY' => $softone_country,
+                'CODE'        => sprintf( '%sG%06d', Softone_Customer_Sync::CODE_PREFIX, $order->get_id() ),
+                'NAME'        => $name,
+                'EMAIL'       => $order->get_billing_email(),
+                'PHONE01'     => $order->get_billing_phone(),
+                'ADDRESS'     => $order->get_billing_address_1(),
+                'ADDRESS2'    => $order->get_billing_address_2(),
+                'CITY'        => $order->get_billing_city(),
+                'ZIP'         => $order->get_billing_postcode(),
+                'COUNTRY'     => $softone_country,
+                'AREAS'       => $this->api_client->get_areas(),
+                'SOCURRENCY'  => $this->api_client->get_socurrency(),
+                'TRDCATEGORY' => $this->api_client->get_trdcategory(),
             );
 
             $record = array_filter( $record, array( $this, 'filter_empty_value' ) );

--- a/includes/softone-woocommerce-integration-settings.php
+++ b/includes/softone-woocommerce-integration-settings.php
@@ -30,6 +30,9 @@ if ( ! function_exists( 'softone_wc_integration_get_settings' ) ) {
             'refid'                 => '',
             'default_saldoc_series' => '',
             'warehouse'             => '',
+            'areas'                 => '',
+            'socurrency'            => '',
+            'trdcategory'           => '',
             'country_mappings'      => array(),
             'timeout'               => Softone_API_Client::DEFAULT_TIMEOUT,
             'client_id_ttl'         => Softone_API_Client::DEFAULT_CLIENT_ID_TTL,
@@ -123,6 +126,24 @@ if ( ! function_exists( 'softone_wc_integration_get_default_saldoc_series' ) ) {
 if ( ! function_exists( 'softone_wc_integration_get_warehouse' ) ) {
     function softone_wc_integration_get_warehouse() {
         return (string) softone_wc_integration_get_setting( 'warehouse', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_areas' ) ) {
+    function softone_wc_integration_get_areas() {
+        return (string) softone_wc_integration_get_setting( 'areas', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_socurrency' ) ) {
+    function softone_wc_integration_get_socurrency() {
+        return (string) softone_wc_integration_get_setting( 'socurrency', '' );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_trdcategory' ) ) {
+    function softone_wc_integration_get_trdcategory() {
+        return (string) softone_wc_integration_get_setting( 'trdcategory', '' );
     }
 }
 


### PR DESCRIPTION
## Summary
- extend the admin settings to capture default AREAS, SOCURRENCY, and TRDCATEGORY values alongside existing Softone credentials
- surface the new defaults via Softone_API_Client accessors and reuse them when building customer payloads
- document the new configuration options and manual QA covering the additional defaults

## Testing
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l includes/softone-woocommerce-integration-settings.php
- php -l includes/class-softone-api-client.php
- php -l includes/class-softone-customer-sync.php
- php -l includes/class-softone-order-sync.php

------
https://chatgpt.com/codex/tasks/task_e_69027f4316ec8327826ea1f43e1c7a45