### PR TITLE
Restore legacy SoftOne defaults for connection settings

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.7.5
+Stable tag: 1.7.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
 		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 		} else {
-                        $this->version = '1.7.5';
+                        $this->version = '1.7.6';
 		}
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/includes/softone-woocommerce-integration-settings.php
+++ b/includes/softone-woocommerce-integration-settings.php
@@ -20,14 +20,14 @@ if ( ! function_exists( 'softone_wc_integration_get_settings' ) ) {
         $stored = is_array( $stored ) ? $stored : array();
 
         $defaults = array(
-            'endpoint'              => '',
+            'endpoint'              => Softone_API_Client::LEGACY_DEFAULT_ENDPOINT,
             'username'              => '',
             'password'              => '',
-            'app_id'                => '',
-            'company'               => '',
-            'branch'                => '',
-            'module'                => '',
-            'refid'                 => '',
+            'app_id'                => Softone_API_Client::LEGACY_DEFAULT_APP_ID,
+            'company'               => Softone_API_Client::LEGACY_DEFAULT_COMPANY,
+            'branch'                => Softone_API_Client::LEGACY_DEFAULT_BRANCH,
+            'module'                => Softone_API_Client::LEGACY_DEFAULT_MODULE,
+            'refid'                 => Softone_API_Client::LEGACY_DEFAULT_REFID,
             'default_saldoc_series' => '',
             'warehouse'             => '',
             'areas'                 => '',
@@ -40,12 +40,64 @@ if ( ! function_exists( 'softone_wc_integration_get_settings' ) ) {
 
         $settings = wp_parse_args( $stored, $defaults );
 
+        foreach ( softone_wc_integration_get_legacy_defaults() as $key => $value ) {
+            if ( '' === softone_wc_integration_normalize_setting_value( $settings, $key ) ) {
+                $settings[ $key ] = $value;
+            }
+        }
+
         /**
          * Filter the plugin settings before they are returned.
          *
          * @param array $settings Plugin settings.
          */
         return apply_filters( 'softone_wc_integration_settings_raw', $settings );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_legacy_defaults' ) ) {
+    /**
+     * Retrieve the legacy PT Kids connection defaults.
+     *
+     * @return array<string,string>
+     */
+    function softone_wc_integration_get_legacy_defaults() {
+        return array(
+            'endpoint' => Softone_API_Client::LEGACY_DEFAULT_ENDPOINT,
+            'app_id'   => Softone_API_Client::LEGACY_DEFAULT_APP_ID,
+            'company'  => Softone_API_Client::LEGACY_DEFAULT_COMPANY,
+            'branch'   => Softone_API_Client::LEGACY_DEFAULT_BRANCH,
+            'module'   => Softone_API_Client::LEGACY_DEFAULT_MODULE,
+            'refid'    => Softone_API_Client::LEGACY_DEFAULT_REFID,
+        );
+    }
+}
+
+if ( ! function_exists( 'softone_wc_integration_normalize_setting_value' ) ) {
+    /**
+     * Normalise a stored setting value when checking for fallbacks.
+     *
+     * @param array  $settings Settings array.
+     * @param string $key      Setting key.
+     *
+     * @return string
+     */
+    function softone_wc_integration_normalize_setting_value( array $settings, $key ) {
+        if ( ! array_key_exists( $key, $settings ) ) {
+            return '';
+        }
+
+        $value = $settings[ $key ];
+
+        if ( is_string( $value ) ) {
+            return trim( $value );
+        }
+
+        if ( null === $value ) {
+            return '';
+        }
+
+        return trim( (string) $value );
     }
 }
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.7.5
+ * Version:           1.7.6
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.7.5' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.7.6' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- restore the legacy PT Kids connection defaults when options are empty so authentication requests include the required identifiers
- expose the same fallbacks through the settings helper functions to pre-populate the admin form
- bump the plugin metadata to version 1.7.6 to reflect the restored defaults

## Testing
- php -l includes/class-softone-api-client.php
- php -l includes/softone-woocommerce-integration-settings.php

------
https://chatgpt.com/codex/tasks/task_e_6903430b04508327873fa5e741b24c4d