### PR TITLE
Improve connection test handshake sync and bump to 1.7.7

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.7.6
+Stable tag: 1.7.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -948,7 +948,25 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
 
             if ( ! empty( $this->login_handshake ) ) {
                 foreach ( $this->login_handshake as $key => $value ) {
-                    if ( array_key_exists( $key, $fields ) && '' === $fields[ $key ] && '' !== $value ) {
+                    if ( ! array_key_exists( $key, $fields ) ) {
+                        continue;
+                    }
+
+                    if ( '' === $value ) {
+                        continue;
+                    }
+
+                    $current = $fields[ $key ];
+
+                    if ( is_string( $current ) ) {
+                        $current = trim( $current );
+                    } elseif ( null === $current ) {
+                        $current = '';
+                    } else {
+                        $current = trim( (string) $current );
+                    }
+
+                    if ( '' === $current || (string) $current !== (string) $value ) {
                         $fields[ $key ] = $value;
                     }
                 }

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
 		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 		} else {
-                        $this->version = '1.7.6';
+                        $this->version = '1.7.7';
 		}
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.7.6
+ * Version:           1.7.7
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.7.6' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.7.7' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- ensure login handshake values override outdated SoftOne settings so the connection test reuses the authoritative metadata
- bump all plugin version references to 1.7.7

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69034a99f804832780f45cc6b3702690