### PR TITLE
Prefer long descriptions when importing Softone items

### DIFF
--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -350,7 +350,17 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 $product->set_name( $name );
             }
 
-            $description = $this->get_value( $data, array( 'remarks', 'remark', 'notes' ) );
+            $description = $this->get_value(
+                $data,
+                array(
+                    'long_description',
+                    'longdescription',
+                    'cccsocylodes',
+                    'remarks',
+                    'remark',
+                    'notes',
+                )
+            );
             if ( '' !== $description ) {
                 $product->set_description( $description );
             }


### PR DESCRIPTION
## Summary
- prefer long description fields from the Softone payload when setting the WooCommerce product description
- retain the existing remarks/notes fallbacks to support older payloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690368f0baec8327b747508e4566c3c3