### PR TITLE
Add short description handling to product import

### DIFF
--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -365,6 +365,17 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 $product->set_description( $description );
             }
 
+            $short_description = $this->get_value(
+                $data,
+                array(
+                    'short_description',
+                    'cccsocyshdes',
+                )
+            );
+            if ( '' !== $short_description ) {
+                $product->set_short_description( $short_description );
+            }
+
             $price = $this->get_value( $data, array( 'retailprice' ) );
             if ( '' !== $price ) {
                 $product->set_regular_price( wc_format_decimal( $price ) );


### PR DESCRIPTION
## Summary
- retrieve the short description value from incoming payloads using supported keys
- apply the short description to the WooCommerce product when present during import

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690369d94db48327afbb22156a4bc5c9