### PR TITLE
Prevent numeric SoftOne categories from syncing to WooCommerce

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.0
+Stable tag: 1.8.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -630,14 +630,14 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
 
             $category_parent = 0;
 
-            if ( '' !== $category_name ) {
+            if ( '' !== $category_name && ! $this->is_numeric_term_name( $category_name ) ) {
                 $category_parent = $this->ensure_term( $category_name, 'product_cat' );
                 if ( $category_parent ) {
                     $categories[] = $category_parent;
                 }
             }
 
-            if ( '' !== $subcategory_name ) {
+            if ( '' !== $subcategory_name && ! $this->is_numeric_term_name( $subcategory_name ) ) {
                 $subcategory_id = $this->ensure_term( $subcategory_name, 'product_cat', $category_parent );
                 if ( $subcategory_id ) {
                     $categories[] = $subcategory_id;
@@ -867,6 +867,23 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
             $this->attribute_term_cache[ $key ] = $term_id;
 
             return $term_id;
+        }
+
+        /**
+         * Determine whether a term name is numeric-only and should be skipped.
+         *
+         * @param string $name Term name.
+         *
+         * @return bool
+         */
+        protected function is_numeric_term_name( $name ) {
+            $name = trim( (string) $name );
+
+            if ( '' === $name ) {
+                return false;
+            }
+
+            return (bool) preg_match( '/^\d+$/', $name );
         }
 
         /**

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
 		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 		} else {
-                        $this->version = '1.8.0';
+                        $this->version = '1.8.1';
 		}
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.0
+ * Version:           1.8.1
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.0' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.1' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- skip creating WooCommerce product categories when the SoftOne category name is numeric-only
- add a helper for detecting numeric-only term names during item sync
- bump the plugin version to 1.8.1

## Testing
- composer validate --no-check-all --strict

------
https://chatgpt.com/codex/tasks/task_e_690371113ff88327baed6421e9266d22