### PR TITLE
Set product brand meta during sync

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.1
+Stable tag: 1.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -396,6 +396,7 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 $product->set_category_ids( $category_ids );
             }
 
+            $brand_value           = trim( $this->get_value( $data, array( 'brand_name', 'brand' ) ) );
             $attribute_assignments = $this->prepare_attribute_assignments( $data, $product );
 
             if ( ! empty( $attribute_assignments['attributes'] ) ) {
@@ -426,6 +427,12 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
 
             foreach ( $attribute_assignments['clear'] as $taxonomy ) {
                 wp_set_object_terms( $product_id, array(), $taxonomy );
+            }
+
+            if ( '' !== $brand_value ) {
+                update_post_meta( $product_id, 'product_brand', $brand_value );
+            } else {
+                delete_post_meta( $product_id, 'product_brand' );
             }
 
             $action = $is_new ? 'created' : 'updated';
@@ -677,17 +684,17 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
             $attribute_map = array(
                 'colour' => array(
                     'label'    => __( 'Colour', 'softone-woocommerce-integration' ),
-                    'value'    => $this->get_value( $data, array( 'colour_name', 'color_name', 'colour' ) ),
+                    'value'    => trim( $this->get_value( $data, array( 'colour_name', 'color_name', 'colour' ) ) ),
                     'position' => 0,
                 ),
                 'size'   => array(
                     'label'    => __( 'Size', 'softone-woocommerce-integration' ),
-                    'value'    => $this->get_value( $data, array( 'size_name', 'size' ) ),
+                    'value'    => trim( $this->get_value( $data, array( 'size_name', 'size' ) ) ),
                     'position' => 1,
                 ),
                 'brand'  => array(
                     'label'    => __( 'Brand', 'softone-woocommerce-integration' ),
-                    'value'    => $this->get_value( $data, array( 'brand_name', 'brand' ) ),
+                    'value'    => trim( $this->get_value( $data, array( 'brand_name', 'brand' ) ) ),
                     'position' => 2,
                 ),
             );

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -88,11 +88,11 @@ class Softone_Woocommerce_Integration {
          * @since    1.0.0
          */
         public function __construct() {
-		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-		} else {
-                        $this->version = '1.8.1';
-		}
+                if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+                        $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+                } else {
+                        $this->version = '1.8.2';
+                }
 		$this->plugin_name = 'softone-woocommerce-integration';
 
                 $this->load_dependencies();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.1
+ * Version:           1.8.2
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.1' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.2' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- persist the Softone brand as the `product_brand` post meta during item sync
- normalise attribute values before assigning taxonomy terms
- bump the plugin version references to 1.8.2

## Testing
- php -l includes/class-softone-item-sync.php

------
https://chatgpt.com/codex/tasks/task_e_69037322fca88327925e4eae46a66ef4