### PR TITLE
Improve sync efficiency and bump version to 1.8.4

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.3
+Stable tag: 1.8.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -559,11 +559,12 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
 
             set_transient( self::TRANSIENT_CLIENT_ID_KEY, $client_id, $ttl );
 
+            $cached_at = time();
             $meta = array(
                 'client_id' => $client_id,
-                'cached_at' => time(),
+                'cached_at' => $cached_at,
                 'ttl'       => $ttl,
-                'expires_at' => time() + $ttl,
+                'expires_at' => $cached_at + $ttl,
             );
 
             update_option( self::OPTION_CLIENT_ID_META_KEY, $meta, false );

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -124,6 +124,11 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
          * @return void
          */
         public static function clear_scheduled_event() {
+            if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+                wp_clear_scheduled_hook( self::CRON_HOOK );
+                return;
+            }
+
             $timestamp = wp_next_scheduled( self::CRON_HOOK );
 
             while ( false !== $timestamp ) {

--- a/includes/class-softone-order-sync.php
+++ b/includes/class-softone-order-sync.php
@@ -139,7 +139,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
             $document_id = (string) $response['id'];
 
             $order->update_meta_data( self::ORDER_META_DOCUMENT_ID, $document_id );
-            $order->save();
+            $this->persist_order_meta( $order );
 
             $this->add_order_note( $order, sprintf( /* translators: %s: document identifier */ __( 'SoftOne document #%s created.', 'softone-woocommerce-integration' ), $document_id ) );
             $this->log( 'info', __( 'SoftOne document created successfully.', 'softone-woocommerce-integration' ), array(
@@ -184,7 +184,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
 
                 if ( '' !== $trdr ) {
                     $order->update_meta_data( self::ORDER_META_TRDR, $trdr );
-                    $order->save();
+                    $this->persist_order_meta( $order );
 
                     return $trdr;
                 }
@@ -197,7 +197,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
 
                 if ( '' !== $trdr ) {
                     $order->update_meta_data( self::ORDER_META_TRDR, $trdr );
-                    $order->save();
+                    $this->persist_order_meta( $order );
 
                     return $trdr;
                 }
@@ -208,7 +208,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
 
                 if ( '' !== $trdr ) {
                     $order->update_meta_data( self::ORDER_META_TRDR, $trdr );
-                    $order->save();
+                    $this->persist_order_meta( $order );
                 }
             }
 
@@ -641,6 +641,22 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
             }
 
             $order->add_order_note( $note );
+        }
+
+        /**
+         * Persist order meta changes using the most efficient method available.
+         *
+         * @param WC_Order $order WooCommerce order instance.
+         *
+         * @return void
+         */
+        protected function persist_order_meta( WC_Order $order ) {
+            if ( method_exists( $order, 'save_meta_data' ) ) {
+                $order->save_meta_data();
+                return;
+            }
+
+            $order->save();
         }
 
         /**

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.3';
+                        $this->version = '1.8.4';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.3
+ * Version:           1.8.4
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.3' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.4' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- bump the plugin version metadata to 1.8.4 and update the readme stable tag
- streamline cached client ID bookkeeping and cron cleanup to avoid redundant work
- persist SoftOne order metadata using the lighter save_meta_data API when available

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_690379ae0dcc8327985ea0534fc39829