### PR TITLE
Add dynamic menu population helper for brands and categories

### DIFF
--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -1,0 +1,454 @@
+<?php
+/**
+ * Helper for dynamically populating the navigation menu with Softone data.
+ *
+ * @package Softone_Woocommerce_Integration
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Populates the public navigation menu with product brands and categories.
+ */
+class Softone_Menu_Populator {
+
+        /**
+         * Cache for product brand terms.
+         *
+         * @var array<int, WP_Term>|array<int, object>|false|null
+         */
+        private $brand_terms = null;
+
+        /**
+         * Cache for grouped product category terms keyed by parent term ID.
+         *
+         * @var array<int, array<int, WP_Term|object>>|false|null
+         */
+        private $category_terms = null;
+
+        /**
+         * Counter for generating temporary menu item IDs.
+         *
+         * @var int
+         */
+        private $id_counter = 0;
+
+        /**
+         * Filter callback that injects product brands and categories into the navigation menu.
+         *
+         * @param array<int, WP_Post|object> $menu_items Existing menu items.
+         * @param stdClass|array             $args       Menu arguments.
+         *
+         * @return array<int, WP_Post|object>
+         */
+        public function filter_menu_items( $menu_items, $args ) {
+                if ( ! is_array( $menu_items ) || empty( $menu_items ) ) {
+                        return $menu_items;
+                }
+
+                if ( ! $this->is_main_menu( $args ) ) {
+                        return $menu_items;
+                }
+
+                $menu_items = $this->strip_dynamic_items( $menu_items );
+
+                $brands_menu_item   = $this->find_menu_item_by_title( $menu_items, 'Brands' );
+                $products_menu_item = $this->find_menu_item_by_title( $menu_items, 'Products' );
+
+                $brand_terms     = $this->get_brand_terms();
+                $category_groups = $this->get_category_terms();
+
+                if ( false === $brand_terms || false === $category_groups ) {
+                        return $menu_items;
+                }
+
+                $max_menu_order = $this->get_max_menu_order( $menu_items );
+
+                if ( $brands_menu_item && ! empty( $brand_terms ) ) {
+                        foreach ( $brand_terms as $term ) {
+                                $new_item = $this->create_menu_item_from_term( $term, $brands_menu_item, ++$max_menu_order );
+
+                                if ( $new_item ) {
+                                        $menu_items[] = $new_item;
+                                }
+                        }
+                }
+
+                if ( $products_menu_item && ! empty( $category_groups ) ) {
+                        list( $menu_items, $max_menu_order ) = $this->append_category_items( $menu_items, $products_menu_item, $category_groups, $max_menu_order );
+                }
+
+                return $menu_items;
+        }
+
+        /**
+         * Determine whether the current menu is the main menu.
+         *
+         * @param stdClass|array $args Menu arguments.
+         *
+         * @return bool
+         */
+        private function is_main_menu( $args ) {
+                $menu_name = '';
+
+                if ( is_object( $args ) && isset( $args->menu ) ) {
+                        if ( is_object( $args->menu ) && isset( $args->menu->name ) ) {
+                                $menu_name = (string) $args->menu->name;
+                        } elseif ( isset( $args->menu ) && function_exists( 'wp_get_nav_menu_object' ) ) {
+                                $menu_obj = wp_get_nav_menu_object( $args->menu );
+                                if ( $menu_obj && isset( $menu_obj->name ) ) {
+                                        $menu_name = (string) $menu_obj->name;
+                                }
+                        }
+                } elseif ( is_array( $args ) && isset( $args['menu'] ) ) {
+                        if ( is_object( $args['menu'] ) && isset( $args['menu']->name ) ) {
+                                $menu_name = (string) $args['menu']->name;
+                        } elseif ( function_exists( 'wp_get_nav_menu_object' ) ) {
+                                $menu_obj = wp_get_nav_menu_object( $args['menu'] );
+                                if ( $menu_obj && isset( $menu_obj->name ) ) {
+                                        $menu_name = (string) $menu_obj->name;
+                                }
+                        }
+                }
+
+                if ( '' === $menu_name && is_object( $args ) && isset( $args->menu_id ) && function_exists( 'wp_get_nav_menu_object' ) ) {
+                        $menu_obj = wp_get_nav_menu_object( (int) $args->menu_id );
+                        if ( $menu_obj && isset( $menu_obj->name ) ) {
+                                $menu_name = (string) $menu_obj->name;
+                        }
+                }
+
+                return 'Main Menu' === $menu_name;
+        }
+
+        /**
+         * Remove previously generated dynamic menu items.
+         *
+         * @param array<int, WP_Post|object> $menu_items Menu items.
+         *
+         * @return array<int, WP_Post|object>
+         */
+        private function strip_dynamic_items( array $menu_items ) {
+                $filtered = array();
+
+                foreach ( $menu_items as $item ) {
+                        $classes = array();
+                        if ( isset( $item->classes ) ) {
+                                if ( is_array( $item->classes ) ) {
+                                        $classes = $item->classes;
+                                } elseif ( is_string( $item->classes ) ) {
+                                        $classes = array( $item->classes );
+                                }
+                        }
+
+                        if ( in_array( 'softone-dynamic-menu-item', $classes, true ) ) {
+                                continue;
+                        }
+
+                        $filtered[] = $item;
+                }
+
+                return $filtered;
+        }
+
+        /**
+         * Find a menu item by its displayed title.
+         *
+         * @param array<int, WP_Post|object> $menu_items Menu items.
+         * @param string                     $title      Target title.
+         *
+         * @return WP_Post|object|null
+         */
+        private function find_menu_item_by_title( array $menu_items, $title ) {
+                foreach ( $menu_items as $item ) {
+                        $item_title = '';
+
+                        if ( isset( $item->title ) ) {
+                                $item_title = (string) $item->title;
+                        } elseif ( isset( $item->post_title ) ) {
+                                $item_title = (string) $item->post_title;
+                        }
+
+                        if ( 0 === strcasecmp( $item_title, $title ) ) {
+                                return $item;
+                        }
+                }
+
+                return null;
+        }
+
+        /**
+         * Retrieve cached product brand terms.
+         *
+         * @return array<int, WP_Term|object>|false
+         */
+        private function get_brand_terms() {
+                if ( null !== $this->brand_terms ) {
+                        return $this->brand_terms;
+                }
+
+                if ( ! function_exists( 'taxonomy_exists' ) || ! taxonomy_exists( 'product_brand' ) ) {
+                        $this->brand_terms = false;
+                        return $this->brand_terms;
+                }
+
+                if ( ! function_exists( 'get_terms' ) ) {
+                        $this->brand_terms = array();
+                        return $this->brand_terms;
+                }
+
+                $terms = get_terms(
+                        array(
+                                'taxonomy'   => 'product_brand',
+                                'hide_empty' => false,
+                                'orderby'    => 'name',
+                                'order'      => 'ASC',
+                        )
+                );
+
+                if ( $this->is_wp_error( $terms ) ) {
+                        $this->brand_terms = array();
+                        return $this->brand_terms;
+                }
+
+                if ( ! is_array( $terms ) ) {
+                        $this->brand_terms = array();
+                        return $this->brand_terms;
+                }
+
+                usort(
+                        $terms,
+                        static function ( $a, $b ) {
+                                $name_a = isset( $a->name ) ? (string) $a->name : '';
+                                $name_b = isset( $b->name ) ? (string) $b->name : '';
+
+                                return strcasecmp( $name_a, $name_b );
+                        }
+                );
+
+                $this->brand_terms = $terms;
+
+                return $this->brand_terms;
+        }
+
+        /**
+         * Retrieve cached grouped product category terms.
+         *
+         * @return array<int, array<int, WP_Term|object>>|false
+         */
+        private function get_category_terms() {
+                if ( null !== $this->category_terms ) {
+                        return $this->category_terms;
+                }
+
+                if ( ! function_exists( 'taxonomy_exists' ) || ! taxonomy_exists( 'product_cat' ) ) {
+                        $this->category_terms = false;
+                        return $this->category_terms;
+                }
+
+                if ( ! function_exists( 'get_terms' ) ) {
+                        $this->category_terms = array();
+                        return $this->category_terms;
+                }
+
+                $terms = get_terms(
+                        array(
+                                'taxonomy'   => 'product_cat',
+                                'hide_empty' => false,
+                                'orderby'    => 'name',
+                                'order'      => 'ASC',
+                        )
+                );
+
+                if ( $this->is_wp_error( $terms ) || ! is_array( $terms ) ) {
+                        $this->category_terms = array();
+                        return $this->category_terms;
+                }
+
+                $grouped = array();
+
+                foreach ( $terms as $term ) {
+                        $parent_id = isset( $term->parent ) ? (int) $term->parent : 0;
+                        if ( ! isset( $grouped[ $parent_id ] ) ) {
+                                $grouped[ $parent_id ] = array();
+                        }
+                        $grouped[ $parent_id ][] = $term;
+                }
+
+                $this->category_terms = $grouped;
+
+                return $this->category_terms;
+        }
+
+        /**
+         * Append category menu items preserving hierarchy.
+         *
+         * @param array<int, WP_Post|object>                 $menu_items     Existing menu items.
+         * @param WP_Post|object                             $products_item  Parent products menu item.
+         * @param array<int, array<int, WP_Term|object>>     $category_terms Grouped category terms.
+         * @param int                                        $menu_order     Current menu order counter.
+         *
+         * @return array<int, WP_Post|object>
+         */
+        private function append_category_items( array $menu_items, $products_item, array $category_terms, $menu_order ) {
+                if ( empty( $category_terms ) || ! isset( $category_terms[0] ) ) {
+                        return array( $menu_items, $menu_order );
+                }
+
+                foreach ( $category_terms[0] as $term ) {
+                        list( $menu_items, $menu_order ) = $this->add_category_term( $menu_items, $term, $products_item, $category_terms, $menu_order );
+                }
+
+                return array( $menu_items, $menu_order );
+        }
+
+        /**
+         * Recursively append category menu items for a given term and its descendants.
+         *
+         * @param array<int, WP_Post|object>             $menu_items     Existing menu items.
+         * @param WP_Term|object                         $term           Current category term.
+         * @param WP_Post|object                         $parent_item    Parent menu item.
+         * @param array<int, array<int, WP_Term|object>> $category_terms Grouped category terms.
+         * @param int                                    $menu_order     Current menu order counter.
+         *
+         * @return array{0: array<int, WP_Post|object>, 1: int}
+         */
+        private function add_category_term( array $menu_items, $term, $parent_item, array $category_terms, $menu_order ) {
+                $new_item = $this->create_menu_item_from_term( $term, $parent_item, $menu_order + 1 );
+
+                if ( ! $new_item ) {
+                        return array( $menu_items, $menu_order );
+                }
+
+                $menu_order++;
+                $menu_items[] = $new_item;
+
+                $term_id = isset( $term->term_id ) ? (int) $term->term_id : 0;
+
+                if ( $term_id && isset( $category_terms[ $term_id ] ) ) {
+                        foreach ( $category_terms[ $term_id ] as $child_term ) {
+                                list( $menu_items, $menu_order ) = $this->add_category_term( $menu_items, $child_term, $new_item, $category_terms, $menu_order );
+                        }
+                }
+
+                return array( $menu_items, $menu_order );
+        }
+
+        /**
+         * Create a new menu item from a taxonomy term.
+         *
+         * @param WP_Term|object $term          Source term.
+         * @param WP_Post|object $parent_item   Parent menu item.
+         * @param int            $menu_order    Menu order value.
+         *
+         * @return WP_Post|object|null
+         */
+        private function create_menu_item_from_term( $term, $parent_item, $menu_order ) {
+                if ( ! isset( $term->taxonomy, $term->term_id, $term->name ) ) {
+                        return null;
+                }
+
+                if ( ! function_exists( 'get_term_link' ) ) {
+                        return null;
+                }
+
+                $url = get_term_link( $term );
+
+                if ( $this->is_wp_error( $url ) || ! is_string( $url ) ) {
+                        return null;
+                }
+
+                $item = clone $parent_item;
+
+                $item->ID                 = $this->next_id();
+                $item->db_id              = $item->ID;
+                $item->menu_item_parent   = isset( $parent_item->db_id ) ? (int) $parent_item->db_id : ( isset( $parent_item->ID ) ? (int) $parent_item->ID : 0 );
+                $item->object             = (string) $term->taxonomy;
+                $item->object_id          = (int) $term->term_id;
+                $item->type               = 'taxonomy';
+                $item->type_label         = 'Taxonomy';
+                $item->title              = (string) $term->name;
+                $item->post_title         = (string) $term->name;
+                $item->post_name          = $this->generate_post_name( $term );
+                $item->url                = $url;
+                $item->classes            = array( 'softone-dynamic-menu-item' );
+                $item->xfn                = '';
+                $item->target             = '';
+                $item->attr_title         = '';
+                $item->description        = '';
+                $item->menu_order         = (int) $menu_order;
+                $item->post_parent        = isset( $parent_item->post_parent ) ? (int) $parent_item->post_parent : 0;
+                $item->post_status        = 'publish';
+                $item->post_type          = 'nav_menu_item';
+
+                return $item;
+        }
+
+        /**
+         * Generate a sanitized post name for the new menu item.
+         *
+         * @param WP_Term|object $term Term reference.
+         *
+         * @return string
+         */
+        private function generate_post_name( $term ) {
+                $value = isset( $term->slug ) ? (string) $term->slug : ( ( isset( $term->name ) ? (string) $term->name : '' ) );
+
+                if ( function_exists( 'sanitize_title' ) ) {
+                        return sanitize_title( $value );
+                }
+
+                $value = strtolower( $value );
+                $value = preg_replace( '/[^a-z0-9\-]+/', '-', $value );
+                $value = trim( $value, '-' );
+
+                return $value;
+        }
+
+        /**
+         * Retrieve the maximum menu order from the existing items.
+         *
+         * @param array<int, WP_Post|object> $menu_items Menu items.
+         *
+         * @return int
+         */
+        private function get_max_menu_order( array $menu_items ) {
+                $max = 0;
+
+                foreach ( $menu_items as $item ) {
+                        if ( isset( $item->menu_order ) ) {
+                                $max = max( $max, (int) $item->menu_order );
+                        }
+                }
+
+                return $max;
+        }
+
+        /**
+         * Generate the next temporary ID.
+         *
+         * @return int
+         */
+        private function next_id() {
+                $this->id_counter--;
+
+                return $this->id_counter;
+        }
+
+        /**
+         * Lightweight check for WP_Error compatibility.
+         *
+         * @param mixed $maybe_error Value to test.
+         *
+         * @return bool
+         */
+        private function is_wp_error( $maybe_error ) {
+                if ( function_exists( 'is_wp_error' ) ) {
+                        return is_wp_error( $maybe_error );
+                }
+
+                return ( $maybe_error instanceof WP_Error );
+        }
+}

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -147,6 +147,11 @@ class Softone_Woocommerce_Integration {
                 require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-order-sync.php';
 
                 /**
+                 * Helper for dynamically populating navigation menus.
+                 */
+                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-menu-populator.php';
+
+                /**
                  * Helper functions for accessing plugin settings.
                  */
                 require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/softone-woocommerce-integration-settings.php';
@@ -224,14 +229,16 @@ class Softone_Woocommerce_Integration {
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	private function define_public_hooks() {
+        private function define_public_hooks() {
 
-		$plugin_public = new Softone_Woocommerce_Integration_Public( $this->get_plugin_name(), $this->get_version() );
+                $plugin_public = new Softone_Woocommerce_Integration_Public( $this->get_plugin_name(), $this->get_version() );
+                $menu_populator = new Softone_Menu_Populator();
 
-		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
-		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+                $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
+                $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+                $this->loader->add_filter( 'wp_nav_menu_objects', $menu_populator, 'filter_menu_items', 10, 2 );
 
-	}
+        }
 
 	/**
 	 * Run the loader to execute all of the hooks with WordPress.

--- a/tests/menu-populator-regression-test.php
+++ b/tests/menu-populator-regression-test.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Regression test for the Softone_Menu_Populator helper.
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+
+class WP_Error {
+    /**
+     * @var array<string, array<int, string>>
+     */
+    public $errors = array();
+
+    /**
+     * @param string $code    Error code.
+     * @param string $message Error message.
+     */
+    public function __construct( $code = '', $message = '' ) {
+        if ( $code ) {
+            $this->errors[ $code ] = array( $message );
+        }
+    }
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+    /**
+     * Lightweight WP_Error detection.
+     *
+     * @param mixed $thing Value to test.
+     *
+     * @return bool
+     */
+    function is_wp_error( $thing ) {
+        return $thing instanceof WP_Error;
+    }
+}
+
+$GLOBALS['softone_taxonomy_exists'] = array(
+    'product_brand' => true,
+    'product_cat'   => true,
+);
+
+$GLOBALS['softone_mock_terms'] = array();
+
+if ( ! function_exists( 'taxonomy_exists' ) ) {
+    /**
+     * Mock taxonomy_exists implementation.
+     *
+     * @param string $taxonomy Taxonomy name.
+     *
+     * @return bool
+     */
+    function taxonomy_exists( $taxonomy ) {
+        return ! empty( $GLOBALS['softone_taxonomy_exists'][ $taxonomy ] );
+    }
+}
+
+if ( ! function_exists( 'get_terms' ) ) {
+    /**
+     * Mock get_terms implementation.
+     *
+     * @param array $args Arguments.
+     *
+     * @return array<int, object>
+     */
+    function get_terms( $args ) {
+        if ( empty( $args['taxonomy'] ) ) {
+            return array();
+        }
+
+        $taxonomy = (array) $args['taxonomy'];
+        $taxonomy = reset( $taxonomy );
+
+        if ( empty( $GLOBALS['softone_mock_terms'][ $taxonomy ] ) ) {
+            return array();
+        }
+
+        return $GLOBALS['softone_mock_terms'][ $taxonomy ];
+    }
+}
+
+if ( ! function_exists( 'get_term_link' ) ) {
+    /**
+     * Mock get_term_link implementation.
+     *
+     * @param object $term Term object.
+     *
+     * @return string|WP_Error
+     */
+    function get_term_link( $term ) {
+        if ( isset( $term->slug ) && false !== strpos( $term->slug, 'broken' ) ) {
+            return new WP_Error( 'broken', 'Broken link' );
+        }
+
+        return 'https://example.com/' . $term->taxonomy . '/' . $term->slug;
+    }
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+    /**
+     * Simplified sanitize_title implementation.
+     *
+     * @param string $value Raw value.
+     *
+     * @return string
+     */
+    function sanitize_title( $value ) {
+        $value = strtolower( $value );
+        $value = preg_replace( '/[^a-z0-9\-]+/', '-', $value );
+
+        return trim( $value, '-' );
+    }
+}
+
+if ( ! function_exists( '__' ) ) {
+    /**
+     * Mock translation function to satisfy class requirements.
+     *
+     * @param string $text Text to translate.
+     *
+     * @return string
+     */
+    function __( $text ) {
+        return $text;
+    }
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-softone-menu-populator.php';
+
+/**
+ * Create a mock nav menu item object.
+ *
+ * @param int    $id     ID.
+ * @param string $title  Menu title.
+ * @param int    $parent Parent ID.
+ * @param int    $order  Menu order.
+ *
+ * @return object
+ */
+function softone_create_menu_item( $id, $title, $parent = 0, $order = 0 ) {
+    $item                     = new stdClass();
+    $item->ID                 = $id;
+    $item->db_id              = $id;
+    $item->menu_item_parent   = $parent;
+    $item->post_parent        = 0;
+    $item->object             = 'custom';
+    $item->object_id          = $id;
+    $item->type               = 'custom';
+    $item->title              = $title;
+    $item->post_title         = $title;
+    $item->post_name          = sanitize_title( $title );
+    $item->url                = '#';
+    $item->classes            = array();
+    $item->menu_order         = $order;
+    $item->post_status        = 'publish';
+    $item->post_type          = 'nav_menu_item';
+
+    return $item;
+}
+
+/**
+ * Build the mock taxonomy terms used by the test.
+ */
+function softone_build_mock_terms() {
+    $brand_terms = array();
+
+    foreach ( array(
+        array( 'term_id' => 101, 'name' => 'Gamma', 'slug' => 'gamma' ),
+        array( 'term_id' => 100, 'name' => 'Alpha', 'slug' => 'alpha' ),
+        array( 'term_id' => 102, 'name' => 'Beta', 'slug' => 'beta' ),
+        array( 'term_id' => 103, 'name' => 'Broken', 'slug' => 'broken-link' ),
+    ) as $data ) {
+        $term            = (object) $data;
+        $term->taxonomy  = 'product_brand';
+        $term->parent    = 0;
+        $brand_terms[]   = $term;
+    }
+
+    $category_terms = array();
+
+    foreach ( array(
+        array( 'term_id' => 10, 'name' => 'Accessories', 'slug' => 'accessories', 'parent' => 0 ),
+        array( 'term_id' => 11, 'name' => 'Belts', 'slug' => 'belts', 'parent' => 10 ),
+        array( 'term_id' => 12, 'name' => 'Scarves', 'slug' => 'scarves', 'parent' => 10 ),
+        array( 'term_id' => 20, 'name' => 'Clothing', 'slug' => 'clothing', 'parent' => 0 ),
+        array( 'term_id' => 21, 'name' => 'Pants', 'slug' => 'pants', 'parent' => 20 ),
+        array( 'term_id' => 22, 'name' => 'Shirts', 'slug' => 'shirts', 'parent' => 20 ),
+    ) as $data ) {
+        $term            = (object) $data;
+        $term->taxonomy  = 'product_cat';
+        $category_terms[] = $term;
+    }
+
+    $GLOBALS['softone_mock_terms']['product_brand'] = $brand_terms;
+    $GLOBALS['softone_mock_terms']['product_cat']   = $category_terms;
+}
+
+softone_build_mock_terms();
+
+$main_menu_items = array(
+    softone_create_menu_item( 1, 'Home', 0, 1 ),
+    softone_create_menu_item( 2, 'Brands', 0, 2 ),
+    softone_create_menu_item( 3, 'Products', 0, 3 ),
+);
+
+$main_args = (object) array(
+    'menu' => (object) array(
+        'name' => 'Main Menu',
+    ),
+);
+
+$menu_populator = new Softone_Menu_Populator();
+
+$result = $menu_populator->filter_menu_items( $main_menu_items, $main_args );
+
+$brand_children = array();
+$top_level_categories = array();
+$category_tree = array();
+$dynamic_count = 0;
+$category_id_to_title = array();
+
+foreach ( $result as $item ) {
+    $classes = isset( $item->classes ) ? $item->classes : array();
+
+    if ( in_array( 'softone-dynamic-menu-item', $classes, true ) ) {
+        $dynamic_count++;
+    }
+
+    if ( 2 === (int) $item->menu_item_parent && in_array( 'softone-dynamic-menu-item', $classes, true ) ) {
+        $brand_children[] = $item->title;
+    }
+
+    if ( isset( $item->object ) && 'product_cat' === $item->object && in_array( 'softone-dynamic-menu-item', $classes, true ) ) {
+        $category_id_to_title[ (int) $item->db_id ] = $item->title;
+
+        if ( 3 === (int) $item->menu_item_parent ) {
+            $top_level_categories[]           = $item->title;
+            $category_tree[ $item->title ] = array();
+        } else {
+            $parent_id = (int) $item->menu_item_parent;
+
+            if ( isset( $category_id_to_title[ $parent_id ] ) ) {
+                $parent_title = $category_id_to_title[ $parent_id ];
+
+                if ( ! isset( $category_tree[ $parent_title ] ) ) {
+                    $category_tree[ $parent_title ] = array();
+                }
+
+                $category_tree[ $parent_title ][] = $item->title;
+            }
+        }
+    }
+}
+
+$expected_brand_children = array( 'Alpha', 'Beta', 'Gamma' );
+$expected_top_categories = array( 'Accessories', 'Clothing' );
+$expected_category_tree  = array(
+    'Accessories' => array( 'Belts', 'Scarves' ),
+    'Clothing'    => array( 'Pants', 'Shirts' ),
+);
+
+if ( count( $result ) !== count( $main_menu_items ) + count( $expected_brand_children ) + array_sum( array_map( 'count', $expected_category_tree ) ) + count( $expected_top_categories ) ) {
+    fwrite( STDERR, 'Unexpected number of menu items returned.' . PHP_EOL );
+    exit( 1 );
+}
+
+if ( $expected_brand_children !== $brand_children ) {
+    fwrite( STDERR, 'Brand children were not appended in alphabetical order or were missing.' . PHP_EOL );
+    exit( 1 );
+}
+
+if ( $expected_top_categories !== $top_level_categories ) {
+    fwrite( STDERR, 'Top-level categories were not appended correctly.' . PHP_EOL );
+    exit( 1 );
+}
+
+if ( $expected_category_tree !== $category_tree ) {
+    fwrite( STDERR, 'Category hierarchy was not preserved.' . PHP_EOL );
+    exit( 1 );
+}
+
+if ( $dynamic_count !== count( $expected_brand_children ) + count( $expected_top_categories ) + array_sum( array_map( 'count', $expected_category_tree ) ) ) {
+    fwrite( STDERR, 'Dynamic menu items were not tagged correctly.' . PHP_EOL );
+    exit( 1 );
+}
+
+// Verify duplicate protection by invoking the filter again.
+$second_pass = $menu_populator->filter_menu_items( $result, $main_args );
+
+if ( count( $second_pass ) !== count( $result ) ) {
+    fwrite( STDERR, 'Duplicate menu items were detected on the second pass.' . PHP_EOL );
+    exit( 1 );
+}
+
+$secondary_menu_items = array(
+    softone_create_menu_item( 1, 'Home', 0, 1 ),
+    softone_create_menu_item( 4, 'Brands', 0, 2 ),
+);
+
+$secondary_args = (object) array(
+    'menu' => (object) array(
+        'name' => 'Footer Menu',
+    ),
+);
+
+$secondary_result = $menu_populator->filter_menu_items( $secondary_menu_items, $secondary_args );
+
+if ( count( $secondary_result ) !== count( $secondary_menu_items ) ) {
+    fwrite( STDERR, 'A non-main menu was unexpectedly modified.' . PHP_EOL );
+    exit( 1 );
+}
+
+// Simulate missing taxonomy handling.
+$GLOBALS['softone_taxonomy_exists']['product_brand'] = false;
+$GLOBALS['softone_taxonomy_exists']['product_cat']   = true;
+
+$missing_taxonomy_populator = new Softone_Menu_Populator();
+$missing_result             = $missing_taxonomy_populator->filter_menu_items( $main_menu_items, $main_args );
+
+if ( count( $missing_result ) !== count( $main_menu_items ) ) {
+    fwrite( STDERR, 'Missing taxonomies did not trigger an early exit.' . PHP_EOL );
+    exit( 1 );
+}
+
+echo 'Menu population regression checks passed.' . PHP_EOL;
+exit( 0 );


### PR DESCRIPTION
## Summary
- add a Softone_Menu_Populator helper that injects product brand and category entries into the main menu while caching term lookups
- load the helper during plugin boot and register its wp_nav_menu_objects filter for the public hooks
- add a regression test verifying menu population, duplicate prevention, and missing taxonomy handling

## Testing
- php tests/menu-populator-regression-test.php
- php tests/repeated-page-detection-check.php

------
https://chatgpt.com/codex/tasks/task_e_6904eadc17588327ac1b795869e200c5