### PR TITLE
Fix SoftOne login handshake handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.9
+Stable tag: 1.8.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
+
+= 1.8.10 =
+* Added the SoftOne handshake fields to login requests to prevent authentication failures when the API requires company information.
 
 = 1.8.9 =
 * Fixed product imports assigning every item to the default WooCommerce category by preserving the full SoftOne category hierarchy.

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -249,14 +249,18 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 'password' => $this->password,
             );
 
+            foreach ( $this->get_handshake_fields() as $key => $value ) {
+                if ( '' !== $value ) {
+                    $payload[ $key ] = $value;
+                }
+            }
+
             /**
              * Filter the login payload before dispatching the request.
              *
-             * Historically the plugin forwarded the handshake fields (company, branch,
-             * module, refid) during the login request. SoftOne rejects those extra
-             * parameters for the PT Kids environment, so the default behaviour is to
-             * omit them. Sites that rely on the old behaviour can re-introduce the
-             * fields via this filter.
+             * The login request now includes the configured handshake values by
+             * default. Sites that need to alter that behaviour (for example, to
+             * remove specific fields) can do so via this filter.
              *
              * @param array                   $payload Login payload.
              * @param Softone_API_Client|null $client  API client instance.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-        $this->version = '1.8.9';
+                        $this->version = '1.8.10';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.9
+ * Version:           1.8.10
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.9' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.10' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- include the configured SoftOne handshake fields in login payloads to avoid rejected credentials
- update documentation and version metadata for a 1.8.10 release

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905f3e01a5c83279029ce2d4ff85f75