### PR TITLE
Restore login compatibility by bypassing cached handshake data

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.10
+Stable tag: 1.8.11
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
+
+= 1.8.11 =
+* Prevented cached handshake data from being resent with login requests so environments that require minimal payloads can authenticate successfully again.
 
 = 1.8.10 =
 * Added the SoftOne handshake fields to login requests to prevent authentication failures when the API requires company information.

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -249,7 +249,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 'password' => $this->password,
             );
 
-            foreach ( $this->get_handshake_fields() as $key => $value ) {
+            foreach ( $this->get_handshake_fields( false ) as $key => $value ) {
                 if ( '' !== $value ) {
                     $payload[ $key ] = $value;
                 }
@@ -931,9 +931,11 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
         /**
          * Retrieve the SoftOne handshake fields configured in the settings.
          *
+         * @param bool $include_dynamic Whether to include handshake values derived from the last login response.
+         *
          * @return array
          */
-        protected function get_handshake_fields() {
+        protected function get_handshake_fields( $include_dynamic = true ) {
             $fields = array(
                 'company' => $this->company,
                 'branch'  => $this->branch,
@@ -951,7 +953,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 }
             }
 
-            if ( ! empty( $this->login_handshake ) ) {
+            if ( $include_dynamic && ! empty( $this->login_handshake ) ) {
                 foreach ( $this->login_handshake as $key => $value ) {
                     if ( ! array_key_exists( $key, $fields ) ) {
                         continue;

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.10';
+                        $this->version = '1.8.11';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.10
+ * Version:           1.8.11
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.10' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.11' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- ensure cached handshake overrides are ignored for login requests so SoftOne instances that require minimal payloads can authenticate
- document the regression fix and bump the plugin version to 1.8.11

## Testing
- php -l includes/class-softone-api-client.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l softone-woocommerce-integration.php

------
https://chatgpt.com/codex/tasks/task_e_6905f59f82d4832790fb5e8934382ace