### PR TITLE
Revert to 703eaca baseline and release 1.8.12

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.11
+Stable tag: 1.8.12
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -67,14 +67,8 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 
 == Changelog ==
 
-= 1.8.11 =
-* Prevented cached handshake data from being resent with login requests so environments that require minimal payloads can authenticate successfully again.
-
-= 1.8.10 =
-* Added the SoftOne handshake fields to login requests to prevent authentication failures when the API requires company information.
-
-= 1.8.9 =
-* Fixed product imports assigning every item to the default WooCommerce category by preserving the full SoftOne category hierarchy.
+= 1.8.12 =
+* Restore the plugin codebase from the stable 703eaca release.
 
 = 1.8.8 =
 * Added mutually exclusive stock handling options for zero-quantity imports.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -938,189 +938,35 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
          */
         protected function prepare_category_ids( array $data ) {
             $categories = array();
-            $parent_id  = 0;
-
-            $category_levels = $this->extract_category_levels( $data );
-
-            foreach ( $category_levels as $level_name ) {
-                if (
-                    '' === $level_name
-                    || $this->is_numeric_term_name( $level_name )
-                    || $this->is_uncategorized_term( $level_name )
-                ) {
-                    continue;
-                }
-
-                $term_id = $this->ensure_term( $level_name, 'product_cat', $parent_id );
-
-                if ( ! $term_id ) {
-                    continue;
-                }
-
-                $categories[] = (int) $term_id;
-                $parent_id    = (int) $term_id;
-            }
-
-            return array_values( array_unique( array_filter( $categories ) ) );
-        }
-
-        /**
-         * Extract the category hierarchy from a SoftOne row.
-         *
-         * @param array $data Normalised row data.
-         *
-         * @return array<int, string>
-         */
-        protected function extract_category_levels( array $data ) {
-            $hierarchy_keys = array(
-                'commercategory_hierarchy',
-                'commercategory_path',
-                'category_hierarchy',
-                'category_path',
-                'categories_hierarchy',
-            );
-
-            foreach ( $hierarchy_keys as $hierarchy_key ) {
-                if ( ! isset( $data[ $hierarchy_key ] ) ) {
-                    continue;
-                }
-
-                $value = $data[ $hierarchy_key ];
-
-                if ( is_array( $value ) ) {
-                    $levels = array();
-
-                    foreach ( $value as $level ) {
-                        if ( is_string( $level ) ) {
-                            $level = trim( $level );
-                            if ( '' !== $level ) {
-                                $levels[] = $level;
-                            }
-                        }
-                    }
-
-                    if ( ! empty( $levels ) ) {
-                        return $this->unique_category_levels( $levels );
-                    }
-
-                    continue;
-                }
-
-                $levels = $this->parse_category_hierarchy_string( $value );
-
-                if ( ! empty( $levels ) ) {
-                    return $this->unique_category_levels( $levels );
-                }
-            }
 
             $category_name    = $this->get_value( $data, array( 'commercategory_name', 'commercategory', 'category_name' ) );
             $subcategory_name = $this->get_value( $data, array( 'submecategory_name', 'subcategory_name', 'subcategory' ) );
 
-            $category_levels = $this->parse_category_hierarchy_string( $category_name );
+            $category_parent = 0;
 
-            if ( count( $category_levels ) > 1 ) {
-                return $this->unique_category_levels( $category_levels );
-            }
-
-            $levels = array();
-
-            if ( '' !== $category_name ) {
-                $levels[] = $category_name;
-            }
-
-            if ( '' !== $subcategory_name ) {
-                $subcategory_levels = $this->parse_category_hierarchy_string( $subcategory_name );
-
-                if ( count( $subcategory_levels ) > 1 ) {
-                    if ( ! empty( $levels ) && 0 === strcasecmp( $levels[0], $subcategory_levels[0] ) ) {
-                        $subcategory_levels = array_slice( $subcategory_levels, 1 );
-                    }
-
-                    $levels = array_merge( $levels, $subcategory_levels );
-                } elseif ( empty( $levels ) || 0 !== strcasecmp( end( $levels ), $subcategory_name ) ) {
-                    $levels[] = $subcategory_name;
+            if (
+                '' !== $category_name
+                && ! $this->is_numeric_term_name( $category_name )
+                && ! $this->is_uncategorized_term( $category_name )
+            ) {
+                $category_parent = $this->ensure_term( $category_name, 'product_cat' );
+                if ( $category_parent ) {
+                    $categories[] = $category_parent;
                 }
             }
 
-            return $this->unique_category_levels( $levels );
-        }
-
-        /**
-         * Normalise a category hierarchy string into an ordered list of levels.
-         *
-         * @param mixed $value Raw hierarchy representation.
-         *
-         * @return array<int, string>
-         */
-        protected function parse_category_hierarchy_string( $value ) {
-            if ( is_array( $value ) ) {
-                $levels = array();
-
-                foreach ( $value as $level ) {
-                    if ( is_string( $level ) ) {
-                        $level = trim( $level );
-                        if ( '' !== $level ) {
-                            $levels[] = $level;
-                        }
-                    }
+            if (
+                '' !== $subcategory_name
+                && ! $this->is_numeric_term_name( $subcategory_name )
+                && ! $this->is_uncategorized_term( $subcategory_name )
+            ) {
+                $subcategory_id = $this->ensure_term( $subcategory_name, 'product_cat', $category_parent );
+                if ( $subcategory_id ) {
+                    $categories[] = $subcategory_id;
                 }
-
-                return $levels;
             }
 
-            $value = trim( (string) $value );
-
-            if ( '' === $value ) {
-                return array();
-            }
-
-            $normalized = str_replace(
-                array( '-->', '->', '»', '›', '→', '\\', '/', '|' ),
-                '>',
-                $value
-            );
-
-            $normalized = preg_replace( '/>+/', '>', $normalized );
-
-            $parts = array_map( 'trim', explode( '>', (string) $normalized ) );
-            $parts = array_filter( $parts, 'strlen' );
-
-            if ( empty( $parts ) ) {
-                return array();
-            }
-
-            return array_values( $parts );
-        }
-
-        /**
-         * Ensure the provided category levels are unique while preserving order.
-         *
-         * @param array<int, string> $levels Category levels.
-         *
-         * @return array<int, string>
-         */
-        protected function unique_category_levels( array $levels ) {
-            $unique = array();
-            $seen   = array();
-
-            foreach ( $levels as $level ) {
-                $level = trim( (string) $level );
-
-                if ( '' === $level ) {
-                    continue;
-                }
-
-                $key = strtolower( $level );
-
-                if ( isset( $seen[ $key ] ) ) {
-                    continue;
-                }
-
-                $seen[ $key ] = true;
-                $unique[]     = $level;
-            }
-
-            return $unique;
+            return array_values( array_unique( array_filter( $categories ) ) );
         }
 
         /**

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.11';
+                        $this->version = '1.8.12';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.11
+ * Version:           1.8.12
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.11' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.12' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- restore the plugin source to match the stable 703eaca snapshot
- bump the plugin metadata and version constant to 1.8.12
- document the restored release in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905fc2ef80c8327950de87dc9b76174