### PR TITLE
Ensure SoftOne login forwards appId values verbatim

### DIFF
--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -911,7 +911,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 $body['clientid'] = $client_id;
             }
 
-            if ( $this->app_id && ! isset( $body['appId'] ) ) {
+            if ( null !== $this->app_id && '' !== $this->app_id && ! isset( $body['appId'] ) ) {
                 $body['appId'] = $this->normalize_app_id( $this->app_id );
             }
 
@@ -981,14 +981,14 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
          *
          * @param string $app_id Raw app identifier from settings.
          *
-         * @return int|string
+         * @return string
          */
         protected function normalize_app_id( $app_id ) {
-            if ( is_numeric( $app_id ) ) {
-                return (int) $app_id;
+            if ( is_string( $app_id ) ) {
+                return trim( $app_id );
             }
 
-            return (string) $app_id;
+            return trim( (string) $app_id );
         }
 
         /**


### PR DESCRIPTION
## Summary
- ensure the SoftOne login payload always appends the configured appId value, even when it is a falsy string such as "0"
- normalise the appId as a trimmed string so leading zeros are preserved
- extend the login regression script to capture the prepared payload and verify both "0" and padded app IDs are forwarded unchanged

## Testing
- php tests/password-sanitization-login-test.php

------
https://chatgpt.com/codex/tasks/task_e_690603c3e40c832797c35fcf5aa092e9