### PR TITLE
Add diagnostic error codes and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.8
+Stable tag: 1.8.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -794,7 +794,7 @@ submit_button( __( 'Run Item Import', 'softone-woocommerce-integration' ), 'seco
                                $this->store_api_tester_result(
                                        array(
                                                'status'  => 'error',
-                                               'message' => sprintf( __( 'Invalid JSON payload: %s', 'softone-woocommerce-integration' ), json_last_error_msg() ),
+                                               'message' => sprintf( __( '[SO-ADM-001] Invalid JSON payload: %s', 'softone-woocommerce-integration' ), json_last_error_msg() ),
                                                'service' => '',
                                                'request' => array(),
                                                'response' => null,
@@ -809,7 +809,7 @@ submit_button( __( 'Run Item Import', 'softone-woocommerce-integration' ), 'seco
                                $this->store_api_tester_result(
                                        array(
                                                'status'  => 'error',
-                                               'message' => __( 'JSON payload must decode to an array or object.', 'softone-woocommerce-integration' ),
+                                               'message' => __( '[SO-ADM-002] JSON payload must decode to an array or object.', 'softone-woocommerce-integration' ),
                                                'service' => '',
                                                'request' => array(),
                                                'response' => null,
@@ -834,7 +834,7 @@ submit_button( __( 'Run Item Import', 'softone-woocommerce-integration' ), 'seco
                                        $this->store_api_tester_result(
                                                array(
                                                        'status'  => 'error',
-                                                       'message' => __( 'A setData object name is required.', 'softone-woocommerce-integration' ),
+                                                       'message' => __( '[SO-ADM-003] A setData object name is required.', 'softone-woocommerce-integration' ),
                                                        'service' => $service_name,
                                                        'request' => array(),
                                                        'response' => null,
@@ -855,7 +855,7 @@ submit_button( __( 'Run Item Import', 'softone-woocommerce-integration' ), 'seco
                                        $this->store_api_tester_result(
                                                array(
                                                        'status'  => 'error',
-                                                       'message' => __( 'A custom service name is required.', 'softone-woocommerce-integration' ),
+                                                       'message' => __( '[SO-ADM-004] A custom service name is required.', 'softone-woocommerce-integration' ),
                                                        'service' => '',
                                                        'request' => array(),
                                                        'response' => null,
@@ -875,7 +875,7 @@ submit_button( __( 'Run Item Import', 'softone-woocommerce-integration' ), 'seco
                                        $this->store_api_tester_result(
                                                array(
                                                        'status'  => 'error',
-                                                       'message' => __( 'A SqlData name is required.', 'softone-woocommerce-integration' ),
+                                                       'message' => __( '[SO-ADM-005] A SqlData name is required.', 'softone-woocommerce-integration' ),
                                                        'service' => $service_name,
                                                        'request' => array(),
                                                        'response' => null,
@@ -990,7 +990,7 @@ submit_button( __( 'Run Item Import', 'softone-woocommerce-integration' ), 'seco
                         'error',
                         sprintf(
                                 /* translators: %s: error message */
-                                __( 'Item import failed: %s', 'softone-woocommerce-integration' ),
+                                __( '[SO-ADM-006] Item import failed: %s', 'softone-woocommerce-integration' ),
                                 $exception->getMessage()
                         )
                 );
@@ -999,7 +999,7 @@ submit_button( __( 'Run Item Import', 'softone-woocommerce-integration' ), 'seco
                         'error',
                         sprintf(
                                 /* translators: %s: error message */
-                                __( 'Item import failed: %s', 'softone-woocommerce-integration' ),
+                                __( '[SO-ADM-007] Item import failed: %s', 'softone-woocommerce-integration' ),
                                 $exception->getMessage()
                         )
                 );
@@ -1050,7 +1050,7 @@ public function handle_test_connection() {
 			$type    = 'error';
 			$message = sprintf(
 				/* translators: %s: error message */
-				__( 'SoftOne connection failed: %s', 'softone-woocommerce-integration' ),
+                                __( '[SO-ADM-008] SoftOne connection failed: %s', 'softone-woocommerce-integration' ),
 				$exception->getMessage()
 			);
 
@@ -1068,7 +1068,7 @@ public function handle_test_connection() {
 			$type    = 'error';
 			$message = sprintf(
 				/* translators: %s: error message */
-				__( 'SoftOne connection failed: %s', 'softone-woocommerce-integration' ),
+                                __( '[SO-ADM-009] SoftOne connection failed: %s', 'softone-woocommerce-integration' ),
 				$exception->getMessage()
 			);
 

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -241,7 +241,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
          */
         public function login() {
             if ( '' === $this->username || '' === $this->password ) {
-                throw new Softone_API_Client_Exception( __( 'SoftOne credentials are missing. Please provide a username and password.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-001] SoftOne credentials are missing. Please provide a username and password.', 'softone-woocommerce-integration' ) );
             }
 
             $payload = array(
@@ -266,8 +266,8 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             $response = $this->call_service( 'login', $payload, false );
 
             if ( empty( $response['clientID'] ) ) {
-                $this->log_error( __( 'SoftOne login succeeded but no clientID was returned.', 'softone-woocommerce-integration' ) );
-                throw new Softone_API_Client_Exception( __( 'SoftOne login failed to provide a client ID.', 'softone-woocommerce-integration' ) );
+                $this->log_error( __( '[SO-API-002] SoftOne login succeeded but no clientID was returned.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-003] SoftOne login failed to provide a client ID.', 'softone-woocommerce-integration' ) );
             }
 
             $this->login_handshake = $this->extract_handshake_from_login_response( $response );
@@ -286,7 +286,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
          */
         public function authenticate( $client_id ) {
             if ( '' === $client_id ) {
-                throw new Softone_API_Client_Exception( __( 'Cannot authenticate without a SoftOne client ID.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-004] Cannot authenticate without a SoftOne client ID.', 'softone-woocommerce-integration' ) );
             }
 
             $payload = array(
@@ -303,8 +303,8 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             $response = $this->call_service( 'authenticate', $payload, false );
 
             if ( empty( $response['clientID'] ) ) {
-                $this->log_error( __( 'SoftOne authentication did not return a clientID.', 'softone-woocommerce-integration' ) );
-                throw new Softone_API_Client_Exception( __( 'SoftOne authentication failed to provide a client ID.', 'softone-woocommerce-integration' ) );
+                $this->log_error( __( '[SO-API-005] SoftOne authentication did not return a clientID.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-006] SoftOne authentication failed to provide a client ID.', 'softone-woocommerce-integration' ) );
             }
 
             return $response;
@@ -323,7 +323,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
          */
         public function sql_data( $sql_name, array $arguments = array(), array $extra = array() ) {
             if ( '' === $sql_name ) {
-                throw new Softone_API_Client_Exception( __( 'A SQL name is required for SqlData requests.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-007] A SQL name is required for SqlData requests.', 'softone-woocommerce-integration' ) );
             }
 
             $payload = array_merge(
@@ -353,7 +353,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
          */
         public function set_data( $object, array $data, array $extra = array() ) {
             if ( '' === $object ) {
-                throw new Softone_API_Client_Exception( __( 'A SoftOne object name is required for setData requests.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-008] A SoftOne object name is required for setData requests.', 'softone-woocommerce-integration' ) );
             }
 
             $payload = array_merge(
@@ -381,11 +381,11 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
          */
         public function call_service( $service, array $data = array(), $requires_client_id = true, $retry_on_authentication = true ) {
             if ( '' === $service ) {
-                throw new Softone_API_Client_Exception( __( 'A SoftOne service name is required.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-009] A SoftOne service name is required.', 'softone-woocommerce-integration' ) );
             }
 
             if ( '' === $this->endpoint ) {
-                throw new Softone_API_Client_Exception( __( 'SoftOne endpoint is not configured.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-010] SoftOne endpoint is not configured.', 'softone-woocommerce-integration' ) );
             }
 
             $client_id = null;
@@ -394,7 +394,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 $client_id = $this->get_client_id();
 
                 if ( '' === $client_id ) {
-                    throw new Softone_API_Client_Exception( __( 'Unable to determine SoftOne client ID.', 'softone-woocommerce-integration' ) );
+                    throw new Softone_API_Client_Exception( __( '[SO-API-011] Unable to determine SoftOne client ID.', 'softone-woocommerce-integration' ) );
                 }
             }
 
@@ -403,7 +403,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
 
             if ( isset( $response['success'] ) && false === $response['success'] ) {
                 if ( $requires_client_id && $retry_on_authentication && $this->is_authentication_error( $response ) ) {
-                    $this->log_warning( __( 'SoftOne session appears to have expired. Refreshing credentials.', 'softone-woocommerce-integration' ), array( 'service' => $service ) );
+                    $this->log_warning( __( '[SO-API-012] SoftOne session appears to have expired. Refreshing credentials.', 'softone-woocommerce-integration' ), array( 'service' => $service ) );
                     $this->clear_cached_client_id();
 
                     $client_id = $this->get_client_id( true );
@@ -477,20 +477,20 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
          * @return string
          */
         protected function bootstrap_client_session() {
-            $this->log_info( __( 'Requesting a fresh SoftOne session.', 'softone-woocommerce-integration' ) );
+            $this->log_info( __( '[SO-API-013] Requesting a fresh SoftOne session.', 'softone-woocommerce-integration' ) );
 
             $login_response = $this->login();
             $client_id      = isset( $login_response['clientID'] ) ? (string) $login_response['clientID'] : '';
 
             if ( '' === $client_id ) {
-                throw new Softone_API_Client_Exception( __( 'SoftOne login failed to return a client ID.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-014] SoftOne login failed to return a client ID.', 'softone-woocommerce-integration' ) );
             }
 
             $authenticate_response = $this->authenticate( $client_id );
             $authenticated_id      = isset( $authenticate_response['clientID'] ) ? (string) $authenticate_response['clientID'] : '';
 
             if ( '' === $authenticated_id ) {
-                throw new Softone_API_Client_Exception( __( 'SoftOne authentication did not return a client ID.', 'softone-woocommerce-integration' ) );
+                throw new Softone_API_Client_Exception( __( '[SO-API-015] SoftOne authentication did not return a client ID.', 'softone-woocommerce-integration' ) );
             }
 
             $ttl = $this->determine_client_ttl( $login_response, $authenticate_response );
@@ -586,7 +586,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             $encoded_body = wp_json_encode( $body );
 
             if ( false === $encoded_body ) {
-                $message = __( 'Unable to encode SoftOne request payload as JSON.', 'softone-woocommerce-integration' );
+                $message = __( '[SO-API-016] Unable to encode SoftOne request payload as JSON.', 'softone-woocommerce-integration' );
 
                 $context = array(
                     'service'  => $service,
@@ -615,7 +615,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             if ( is_wp_error( $response ) ) {
                 $message = sprintf(
                     /* translators: %s: error message */
-                    __( 'SoftOne request error: %s', 'softone-woocommerce-integration' ),
+                    __( '[SO-API-017] SoftOne request error: %s', 'softone-woocommerce-integration' ),
                     $response->get_error_message()
                 );
 
@@ -637,7 +637,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             if ( $status_code < 200 || $status_code >= 300 ) {
                 $message = sprintf(
                     /* translators: 1: HTTP status code, 2: response body */
-                    __( 'SoftOne responded with HTTP %1$s: %2$s', 'softone-woocommerce-integration' ),
+                    __( '[SO-API-018] SoftOne responded with HTTP %1$s: %2$s', 'softone-woocommerce-integration' ),
                     $status_code,
                     $raw_body
                 );
@@ -673,7 +673,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             if ( null === $decoded && JSON_ERROR_NONE !== json_last_error() ) {
                 $message = sprintf(
                     /* translators: %s: raw JSON response */
-                    __( 'SoftOne returned invalid JSON: %s', 'softone-woocommerce-integration' ),
+                    __( '[SO-API-019] SoftOne returned invalid JSON: %s', 'softone-woocommerce-integration' ),
                     json_last_error_msg()
                 );
 
@@ -1119,7 +1119,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             }
 
             if ( $fallback ) {
-                return __( 'SoftOne request failed.', 'softone-woocommerce-integration' );
+                return __( '[SO-API-020] SoftOne request failed.', 'softone-woocommerce-integration' );
             }
 
             return '';

--- a/includes/class-softone-customer-sync.php
+++ b/includes/class-softone-customer-sync.php
@@ -416,7 +416,7 @@ if ( ! class_exists( 'Softone_Customer_Sync' ) ) {
                         'error',
                         sprintf(
                             /* translators: %s: ISO 3166-1 alpha-2 country code. */
-                            __( 'SoftOne country mapping missing for ISO code %s.', 'softone-woocommerce-integration' ),
+                            __( '[SO-CNTRY-001] SoftOne country mapping missing for ISO code %s.', 'softone-woocommerce-integration' ),
                             $country_code
                         ),
                         $country_log_attrs

--- a/includes/class-softone-order-sync.php
+++ b/includes/class-softone-order-sync.php
@@ -104,29 +104,29 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
                     'order_id'  => $order_id,
                     'exception' => $exception,
                 ) );
-                $this->add_order_note( $order, sprintf( /* translators: %s: error message */ __( 'SoftOne customer sync failed: %s', 'softone-woocommerce-integration' ), $exception->getMessage() ) );
+                $this->add_order_note( $order, sprintf( /* translators: %s: error message */ __( '[SO-ORD-001] SoftOne customer sync failed: %s', 'softone-woocommerce-integration' ), $exception->getMessage() ) );
                 return;
             }
 
             if ( '' === $trdr ) {
-                $this->log( 'error', __( 'Unable to determine SoftOne customer (TRDR) for order.', 'softone-woocommerce-integration' ), array( 'order_id' => $order_id ) );
-                $this->add_order_note( $order, __( 'SoftOne order export skipped because a customer record could not be located.', 'softone-woocommerce-integration' ) );
+                $this->log( 'error', __( '[SO-ORD-002] Unable to determine SoftOne customer (TRDR) for order.', 'softone-woocommerce-integration' ), array( 'order_id' => $order_id ) );
+                $this->add_order_note( $order, __( '[SO-ORD-003] SoftOne order export skipped because a customer record could not be located.', 'softone-woocommerce-integration' ) );
                 return;
             }
 
             $payload = $this->build_document_payload( $order, $trdr );
 
             if ( empty( $payload['SALDOC'] ) || empty( $payload['ITELINES'] ) ) {
-                $this->log( 'error', __( 'SoftOne order payload is incomplete. Document was not created.', 'softone-woocommerce-integration' ), array( 'order_id' => $order_id ) );
-                $this->add_order_note( $order, __( 'SoftOne order export failed due to an incomplete payload.', 'softone-woocommerce-integration' ) );
+                $this->log( 'error', __( '[SO-ORD-004] SoftOne order payload is incomplete (missing SALDOC or ITELINES). Document was not created.', 'softone-woocommerce-integration' ), array( 'order_id' => $order_id ) );
+                $this->add_order_note( $order, __( '[SO-ORD-005] SoftOne order export failed due to an incomplete payload.', 'softone-woocommerce-integration' ) );
                 return;
             }
 
             $header = reset( $payload['SALDOC'] );
 
             if ( empty( $header['SERIES'] ) ) {
-                $this->log( 'error', __( 'SoftOne document series is not configured. Order export aborted.', 'softone-woocommerce-integration' ), array( 'order_id' => $order_id ) );
-                $this->add_order_note( $order, __( 'SoftOne order export failed because the document series is missing.', 'softone-woocommerce-integration' ) );
+                $this->log( 'error', __( '[SO-ORD-006] SoftOne document series is not configured. Order export aborted.', 'softone-woocommerce-integration' ), array( 'order_id' => $order_id ) );
+                $this->add_order_note( $order, __( '[SO-ORD-007] SoftOne order export failed because the document series is missing.', 'softone-woocommerce-integration' ) );
                 return;
             }
 
@@ -295,7 +295,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
                         'error',
                         sprintf(
                             /* translators: %s: ISO 3166-1 alpha-2 country code. */
-                            __( 'SoftOne country mapping missing for ISO code %s.', 'softone-woocommerce-integration' ),
+                            __( '[SO-CNTRY-001] SoftOne country mapping missing for ISO code %s.', 'softone-woocommerce-integration' ),
                             $billing_country
                         ),
                         array(
@@ -306,7 +306,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
 
                     $this->add_order_note(
                         $order,
-                        __( 'SoftOne guest customer creation skipped because the country mapping is missing.', 'softone-woocommerce-integration' )
+                        __( '[SO-ORD-011] SoftOne guest customer creation skipped because the country mapping is missing.', 'softone-woocommerce-integration' )
                     );
 
                     return '';
@@ -364,7 +364,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
             $warehouse = $this->api_client->get_warehouse();
             $order_id  = $order->get_id();
             if ( '' === $series ) {
-                $this->log( 'warning', __( 'SoftOne SALDOC series is not configured. Using fallback payload without series.', 'softone-woocommerce-integration' ), array( 'order_id' => $order->get_id() ) );
+                $this->log( 'warning', __( '[SO-ORD-009] SoftOne SALDOC series is not configured. Using fallback payload without series.', 'softone-woocommerce-integration' ), array( 'order_id' => $order->get_id() ) );
             }
 
             $header    = array(
@@ -473,7 +473,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
                 $mtrl = $this->get_product_mtrl( $product );
 
                 if ( '' === $mtrl ) {
-                    $this->log( 'warning', __( 'Order line skipped because the SoftOne item (MTRL) identifier is missing.', 'softone-woocommerce-integration' ), array(
+                    $this->log( 'warning', __( '[SO-ORD-010] Order line skipped because the SoftOne item (MTRL) identifier is missing.', 'softone-woocommerce-integration' ), array(
                         'order_id'   => $order->get_id(),
                         'item_id'    => $item->get_id(),
                         'product_id' => $product->get_id(),
@@ -558,7 +558,7 @@ if ( ! class_exists( 'Softone_Order_Sync' ) ) {
                         'attempt'   => $attempt,
                         'exception' => $exception,
                     ) );
-                    $this->add_order_note( $order, sprintf( /* translators: 1: attempt, 2: error message */ __( 'SoftOne order export attempt %1$d failed: %2$s', 'softone-woocommerce-integration' ), $attempt, $exception->getMessage() ) );
+                    $this->add_order_note( $order, sprintf( /* translators: 1: attempt, 2: error message */ __( '[SO-ORD-008] SoftOne order export attempt %1$d failed: %2$s', 'softone-woocommerce-integration' ), $attempt, $exception->getMessage() ) );
                     $last_response = array();
                 }
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.8';
+                        $this->version = '1.8.9';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.8
+ * Version:           1.8.9
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.8' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.9' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add unique diagnostic codes to SoftOne API, order export, customer sync, and admin error messages for clearer troubleshooting
- update plugin metadata to version 1.8.9 to reflect the new diagnostics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690607aae05c832794ad6d584c997ae4