### PR TITLE
Ensure SoftOne client ID for each request

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.9
+Stable tag: 1.8.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -391,7 +391,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             $client_id = null;
 
             if ( $requires_client_id ) {
-                $client_id = $this->get_client_id();
+                $client_id = $this->get_client_id( true );
 
                 if ( '' === $client_id ) {
                     throw new Softone_API_Client_Exception( __( '[SO-API-011] Unable to determine SoftOne client ID.', 'softone-woocommerce-integration' ) );

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.9';
+                        $this->version = '1.8.10';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.9
+ * Version:           1.8.10
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.9' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.10' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- force the API client to request a fresh SoftOne client ID for every service call
- bump the plugin version metadata to 1.8.10 to publish the change

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690609ce561083278aac2db2314e87d1