### PR TITLE
Preserve whitespace in Softone API passwords

### DIFF
--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -1501,15 +1501,15 @@ public function handle_test_connection() {
 			return '';
 		}
 
-		$value = wp_unslash( $value );
+                $value = wp_unslash( $value );
 
-		if ( is_object( $value ) && ! method_exists( $value, '__toString' ) ) {
-			return '';
-		}
+                if ( is_object( $value ) && ! method_exists( $value, '__toString' ) ) {
+                        return '';
+                }
 
-		return trim( (string) $value );
+                return (string) $value;
 
-	}
+        }
 
         /**
          * Sanitize a generic text value.

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -211,7 +211,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
 
             $this->endpoint = isset( $this->settings['endpoint'] ) ? trim( (string) $this->settings['endpoint'] ) : '';
             $this->username = isset( $this->settings['username'] ) ? trim( (string) $this->settings['username'] ) : '';
-            $this->password = isset( $this->settings['password'] ) ? trim( (string) $this->settings['password'] ) : '';
+            $this->password = isset( $this->settings['password'] ) ? (string) $this->settings['password'] : '';
             $this->app_id   = isset( $this->settings['app_id'] ) ? trim( (string) $this->settings['app_id'] ) : '';
             $this->company  = isset( $this->settings['company'] ) ? trim( (string) $this->settings['company'] ) : '';
             $this->branch   = isset( $this->settings['branch'] ) ? trim( (string) $this->settings['branch'] ) : '';

--- a/tests/password-sanitization-login-test.php
+++ b/tests/password-sanitization-login-test.php
@@ -198,6 +198,35 @@ if ( ! isset( $client->captured_payload['appId'] ) ) {
     exit( 1 );
 }
 
+$password_with_spaces = "  spaced password  ";
+
+$sanitized_with_spaces = $admin->sanitize_settings(
+    array(
+        'endpoint' => 'https://example.test/api',
+        'username' => 'example-user',
+        'password' => $password_with_spaces,
+        'app_id'   => '0',
+    )
+);
+
+if ( ! isset( $sanitized_with_spaces['password'] ) || $sanitized_with_spaces['password'] !== $password_with_spaces ) {
+    fwrite( STDERR, "Password sanitization trimmed leading or trailing spaces.\n" );
+    exit( 1 );
+}
+
+$client_with_spaces = new Softone_API_Client_Login_Test( $sanitized_with_spaces );
+$response_with_spaces = $client_with_spaces->login();
+
+if ( empty( $response_with_spaces['clientID'] ) ) {
+    fwrite( STDERR, "Login response for spaced password did not contain a client ID.\n" );
+    exit( 1 );
+}
+
+if ( empty( $client_with_spaces->captured_payload ) || $client_with_spaces->captured_payload['password'] !== $password_with_spaces ) {
+    fwrite( STDERR, "Login payload did not preserve leading/trailing spaces in the password.\n" );
+    exit( 1 );
+}
+
 if ( '0' !== $client->captured_payload['appId'] ) {
     fwrite( STDERR, "Login payload did not preserve an appId configured as '0'.\n" );
     exit( 1 );


### PR DESCRIPTION
## Summary
- stop trimming Softone password values during admin sanitization and client construction so leading/trailing spaces are preserved
- extend the password sanitization test coverage with a spaced-password scenario to verify login payloads

## Testing
- php tests/password-sanitization-login-test.php
- php tests/menu-populator-regression-test.php
- php tests/repeated-page-detection-check.php

------
https://chatgpt.com/codex/tasks/task_e_69060bf1906083278680ef49f1281678