### PR TITLE
Align SoftOne authentication flow with API spec

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.11
+Stable tag: 1.8.12
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -123,13 +123,9 @@ Additional optional checks:
 
 == Login Handshake Behaviour ==
 
-The plugin now forwards the configured handshake fields (Company, Branch, Module, and Ref ID) during the SoftOne `login` request when those values are present under **Softone Integration → Settings**. Sites that must retain the legacy behaviour introduced for PT Kids can disable the additional payload parameters in code:
+SoftOne now expects the login request to contain **only** the username, password, and (optionally) the App ID. Handshake details (Company, Branch, Module, and Ref ID) are supplied by the SoftOne server in the login response and are re-used automatically for the follow-up `authenticate` request. When SoftOne does not return a value the plugin falls back to the values configured under **Softone Integration → Settings**.
 
-```
-add_filter( 'softone_wc_integration_send_login_handshake', '__return_false' );
-```
-
-Developers can also adjust the specific values sent to SoftOne via the `softone_wc_integration_login_handshake_fields` filter. Both hooks run before the `softone_wc_integration_login_payload` filter so that existing integrations can continue to refine the final request body as needed.
+The `softone_wc_integration_login_payload` filter remains available for integrations that need to adjust the final login payload before it is dispatched.
 
 == Arbitrary section ==
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                $this->version = '1.8.11';
+                $this->version = '1.8.12';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.11
+ * Version:           1.8.12
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.11' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.12' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- update the SoftOne client defaults to use the HTTP PT Kids endpoint and send only username, password, and appId during login
- reuse handshake data returned by SoftOne for authenticate requests, scope clientID/clientid fields per service, and include appId only where the spec requires it
- refresh the login handshake test, document the revised behaviour, and bump the plugin version to 1.8.12

## Testing
- php -l includes/class-softone-api-client.php
- php -l softone-woocommerce-integration.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l tests/login-handshake-test.php
- php tests/login-handshake-test.php


------
https://chatgpt.com/codex/tasks/task_e_6906135cdccc8327b5e9cd27c4b3a116