### PR TITLE
Update Softone endpoint to HTTPS and bump version to 1.8.13

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.12
+Stable tag: 1.8.13
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/Softone_PT_Kids_Interface.md
+++ b/Softone_PT_Kids_Interface.md
@@ -29,7 +29,7 @@ The data download from Softone is done via API calls through Web Services.
 
 **Base Endpoint (from PDF):**
 ```
-http://ptkids.oncloud.gr/s1services
+https://ptkids.oncloud.gr/s1services
 ```
 
 > **Security Note:** Credentials, client IDs, and serial numbers remain redacted in this document.
@@ -425,7 +425,7 @@ Use `setData` to insert/modify records for native or custom objects. Only includ
 ## Security & Sharing
 - **Do not** embed real credentials, serials, or `clientID` values in code or docs. Use a secrets vault and environment variables.  
 - Rotate credentials if this document ever leaves your trusted environment.  
-- Restrict network access to `http://ptkids.oncloud.gr/s1services` to known IPs where possible.
+- Restrict network access to `https://ptkids.oncloud.gr/s1services` to known IPs where possible.
 
 ---
 

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -67,7 +67,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
         /**
          * Legacy SoftOne connection defaults used by the PT Kids environment.
          */
-        const LEGACY_DEFAULT_ENDPOINT = 'http://ptkids.oncloud.gr/s1services';
+        const LEGACY_DEFAULT_ENDPOINT = 'https://ptkids.oncloud.gr/s1services';
         const LEGACY_DEFAULT_APP_ID   = '1000';
         const LEGACY_DEFAULT_COMPANY  = '10';
         const LEGACY_DEFAULT_BRANCH   = '101';

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                $this->version = '1.8.12';
+                $this->version = '1.8.13';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.12
+ * Version:           1.8.13
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.12' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.13' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- update the legacy Softone endpoint to use HTTPS by default
- bump the plugin version to 1.8.13 and align accompanying documentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6906155c6b688327a9439d6ac82e9635