### PR TITLE
Handle alternate SoftOne category field name

### DIFF
--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -937,6 +937,7 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
             $category_name    = $this->get_value(
                 $data,
                 array(
+                    'commecategory_name',
                     'commercategory_name',
                     'commercategory',
                     'category_name',


### PR DESCRIPTION
## Summary
- extend the category name lookup to include the commecategory_name field so SoftOne data using the alternate spelling is handled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69061fe793ac8327881f07f629a10a7a