### PR TITLE
Keep stale products published by default

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.17
+Stable tag: 1.8.18
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
+
+= 1.8.18 =
+* Keep stale products published by default while marking them out of stock.
 
 = 1.8.17 =
 * Improve logging to capture additional diagnostic details when API requests fail.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -765,9 +765,9 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 return 0;
             }
 
-            $action = apply_filters( 'softone_wc_integration_stale_item_action', 'draft' );
+            $action = apply_filters( 'softone_wc_integration_stale_item_action', 'stock_out' );
             if ( ! in_array( $action, array( 'draft', 'stock_out' ), true ) ) {
-                $action = 'draft';
+                $action = 'stock_out';
             }
 
             $batch_size = (int) apply_filters( 'softone_wc_integration_stale_item_batch_size', 50 );
@@ -836,6 +836,10 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                             $product->set_status( 'draft' );
                         }
                     } else {
+                        if ( 'publish' !== $product->get_status() ) {
+                            $product->set_status( 'publish' );
+                        }
+
                         $product->set_stock_status( 'outofstock' );
                     }
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.17';
+                        $this->version = '1.8.18';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.17
+ * Version:           1.8.18
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.17' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.18' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- default stale product handling to mark items out of stock instead of drafting them
- republish previously drafted items when the stale action runs
- bump plugin version references and changelog to 1.8.18

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690641aa8e1483279d791746488e339a