### PR TITLE
Ensure product category assignments persist during sync

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.georgenicolaou.me//
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.8.20
+Stable tag: 1.8.21
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
+
+= 1.8.21 =
+* Ensure product category assignments persist after saving WooCommerce products so synced items inherit the expected hierarchy.
 
 = 1.8.20 =
 * Improve the category synchronisation log viewer to detect entries across all WooCommerce log files.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -717,6 +717,27 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 throw new Exception( __( 'Unable to save the WooCommerce product.', 'softone-woocommerce-integration' ) );
             }
 
+            if (
+                ! empty( $category_ids )
+                && function_exists( 'taxonomy_exists' )
+                && taxonomy_exists( 'product_cat' )
+                && function_exists( 'wp_set_object_terms' )
+            ) {
+                $category_assignment = wp_set_object_terms( $product_id, $category_ids, 'product_cat' );
+
+                if ( is_wp_error( $category_assignment ) ) {
+                    $this->log(
+                        'error',
+                        'SOFTONE_CAT_SYNC_009 Failed to assign product categories.',
+                        array(
+                            'product_id'    => $product_id,
+                            'category_ids'  => $category_ids,
+                            'error_message' => $category_assignment->get_error_message(),
+                        )
+                    );
+                }
+            }
+
             if ( $mtrl ) {
                 update_post_meta( $product_id, self::META_MTRL, $mtrl );
             }

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.20';
+                        $this->version = '1.8.21';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.20
+ * Version:           1.8.21
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.20' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.21' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- assign product categories after saving synced products so WooCommerce receives the expected hierarchy
- log failures when taxonomy assignment does not succeed
- bump the plugin version to 1.8.21 and update the readme stable tag

## Testing
- php -l includes/class-softone-item-sync.php
- php -l softone-woocommerce-integration.php
- php -l includes/class-softone-woocommerce-integration.php

------
https://chatgpt.com/codex/tasks/task_e_690651883d148327b56fc1de1cecb93b