### PR TITLE
Update README with current integration details

### DIFF
--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.22';
+                        $this->version = '1.8.23';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.22
+ * Version:           1.8.23
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.22' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.23' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- replace the boilerplate readme with current product description, installation guidance, troubleshooting tips, and updated metadata
- expand supplemental sections covering configuration, manual QA, and login handshake behaviour for the SoftOne workflow
- bump the plugin version constant and stable tag to 1.8.23 to align with the refreshed documentation

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_69069c8fb22883279e6b432a71a203a9