### PR TITLE
Release 1.8.24

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.23
+Stable tag: 1.8.24
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Changelog ==
 
+= 1.8.24 =
+* Refresh the plugin documentation to highlight key synchronisation workflows and setup guidance.
+* Clarify troubleshooting tips and manual QA steps to support the documentation overhaul.
+
 = 1.8.23 =
 * Refresh plugin documentation to reflect the latest synchronisation features, tools, and troubleshooting workflows.
 
@@ -102,8 +106,8 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Upgrade Notice ==
 
-= 1.8.23 =
-This update revises the plugin documentation to outline current setup, synchronisation flows, and troubleshooting tips. Review the README before onboarding new stores.
+= 1.8.24 =
+This release overhauls the documentation, expanding setup guidance and troubleshooting steps so new stores can integrate more smoothly.
 
 == Automatic Updates ==
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.23';
+                        $this->version = '1.8.24';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.23
+ * Version:           1.8.24
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.23' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.24' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- bump the plugin version constant and header to 1.8.24
- align the core class fallback version with the new release number
- update README metadata, changelog, and upgrade notice for the 1.8.24 documentation refresh

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69069da8f4e083279a071111c2c452d0