### PR TITLE
Add verbose documentation for settings helpers and bump to 1.8.25

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.24
+Stable tag: 1.8.25
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Changelog ==
 
+= 1.8.25 =
+* Add verbose documentation around SoftOne setting accessors and bump the plugin version number.
+
 = 1.8.24 =
 * Refresh the plugin documentation to highlight key synchronisation workflows and setup guidance.
 * Clarify troubleshooting tips and manual QA steps to support the documentation overhaul.
@@ -106,8 +109,8 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Upgrade Notice ==
 
-= 1.8.24 =
-This release overhauls the documentation, expanding setup guidance and troubleshooting steps so new stores can integrate more smoothly.
+= 1.8.25 =
+This release clarifies the plugin's SoftOne setting helpers with extensive inline documentation and increments the plugin version number.
 
 == Automatic Updates ==
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.24';
+                        $this->version = '1.8.25';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/includes/softone-woocommerce-integration-settings.php
+++ b/includes/softone-woocommerce-integration-settings.php
@@ -150,78 +150,198 @@ if ( ! function_exists( 'softone_wc_integration_get_setting' ) ) {
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_endpoint' ) ) {
+    /**
+     * Retrieve the configured SoftOne API endpoint URL.
+     *
+     * The endpoint determines the base URL used for every request the integration issues
+     * to the SoftOne backend. Centralising the lookup behind this helper keeps service
+     * classes decoupled from WordPress' Options API and makes it obvious where the value
+     * originates from when debugging requests.
+     *
+     * @return string Fully qualified endpoint URL or an empty string when not configured.
+     */
     function softone_wc_integration_get_endpoint() {
         return (string) softone_wc_integration_get_setting( 'endpoint', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_username' ) ) {
+    /**
+     * Retrieve the SoftOne username used for authentication.
+     *
+     * The username is stored alongside the rest of the connection settings and is required
+     * when performing login and authentication calls. Exposing it through a dedicated
+     * accessor ensures that authentication routines do not have to deal with low-level
+     * option fetching or fallbacks.
+     *
+     * @return string Configured SoftOne username, or an empty string if none is saved.
+     */
     function softone_wc_integration_get_username() {
         return (string) softone_wc_integration_get_setting( 'username', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_password' ) ) {
+    /**
+     * Retrieve the SoftOne password used for authentication.
+     *
+     * Although the password is stored as plain text within the options table, routing all
+     * reads through this helper makes it easy to replace the storage mechanism in the
+     * future (for example with an encrypted alternative) without touching every API call.
+     *
+     * @return string Configured SoftOne password, or an empty string if none is available.
+     */
     function softone_wc_integration_get_password() {
         return (string) softone_wc_integration_get_setting( 'password', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_app_id' ) ) {
+    /**
+     * Retrieve the SoftOne application identifier (appId).
+     *
+     * Some SoftOne environments require the application identifier to be provided with
+     * each request. By surfacing the value via a dedicated helper we keep consumers from
+     * relying on magic array keys or duplicating fallback logic.
+     *
+     * @return string Application identifier defined in the plugin settings.
+     */
     function softone_wc_integration_get_app_id() {
         return (string) softone_wc_integration_get_setting( 'app_id', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_company' ) ) {
+    /**
+     * Retrieve the SoftOne company identifier.
+     *
+     * The company (or "company id") is required for authenticate and setData calls so
+     * that SoftOne can route the request to the correct tenant. Having a well documented
+     * accessor reduces the risk of developers using the wrong option key when assembling
+     * payloads.
+     *
+     * @return string Company identifier stored in the plugin settings.
+     */
     function softone_wc_integration_get_company() {
         return (string) softone_wc_integration_get_setting( 'company', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_branch' ) ) {
+    /**
+     * Retrieve the SoftOne branch identifier used during authentication.
+     *
+     * Branch values are required by many SoftOne installations to scope inventory and
+     * sales document operations. Exposing the value via this helper keeps the behaviour
+     * consistent throughout the codebase.
+     *
+     * @return string Configured SoftOne branch identifier.
+     */
     function softone_wc_integration_get_branch() {
         return (string) softone_wc_integration_get_setting( 'branch', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_module' ) ) {
+    /**
+     * Retrieve the SoftOne module identifier.
+     *
+     * Certain SoftOne services expect a module (such as "0" for commercial management)
+     * to be present in the authenticate payload. Centralising access to the value keeps
+     * those payload builders concise and easier to audit.
+     *
+     * @return string Module identifier defined in the plugin settings.
+     */
     function softone_wc_integration_get_module() {
         return (string) softone_wc_integration_get_setting( 'module', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_refid' ) ) {
+    /**
+     * Retrieve the SoftOne reference identifier (refId).
+     *
+     * The reference identifier links API calls to a specific integration record inside
+     * SoftOne. This helper documents the intent clearly so that other components do not
+     * need to guess what the `refid` option represents.
+     *
+     * @return string Reference identifier saved in the plugin settings.
+     */
     function softone_wc_integration_get_refid() {
         return (string) softone_wc_integration_get_setting( 'refid', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_default_saldoc_series' ) ) {
+    /**
+     * Retrieve the default SoftOne SALDOC series code.
+     *
+     * When creating sales documents the integration falls back to this series whenever
+     * a more specific mapping is not available. Documenting the helper clarifies why the
+     * value matters and where it comes from.
+     *
+     * @return string Configured SALDOC series or an empty string when not set.
+     */
     function softone_wc_integration_get_default_saldoc_series() {
         return (string) softone_wc_integration_get_setting( 'default_saldoc_series', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_warehouse' ) ) {
+    /**
+     * Retrieve the default warehouse code used for stock synchronisation.
+     *
+     * SoftOne installations often expose multiple warehouses. The integration needs to
+     * know which warehouse to reference when adjusting quantities or exporting orders,
+     * so we keep the lookup in a single documented location.
+     *
+     * @return string Warehouse identifier chosen in the plugin settings.
+     */
     function softone_wc_integration_get_warehouse() {
         return (string) softone_wc_integration_get_setting( 'warehouse', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_areas' ) ) {
+    /**
+     * Retrieve the default customer area identifier.
+     *
+     * Customer synchronisation relies on the area to categorise new records in SoftOne.
+     * Centralising the accessor makes the dependency explicit and avoids "magic" strings
+     * throughout the sync logic.
+     *
+     * @return string Customer area identifier or empty string when unset.
+     */
     function softone_wc_integration_get_areas() {
         return (string) softone_wc_integration_get_setting( 'areas', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_socurrency' ) ) {
+    /**
+     * Retrieve the default SoftOne currency code for customer records.
+     *
+     * The currency influences how newly created customers are configured within SoftOne
+     * and therefore needs to be available to the customer sync routines in a predictable
+     * way.
+     *
+     * @return string Currency code as stored in the plugin settings.
+     */
     function softone_wc_integration_get_socurrency() {
         return (string) softone_wc_integration_get_setting( 'socurrency', '' );
     }
 }
 
 if ( ! function_exists( 'softone_wc_integration_get_trdcategory' ) ) {
+    /**
+     * Retrieve the default SoftOne trading category (TRDCATEGORY).
+     *
+     * Customer synchronisation assigns this category whenever a WooCommerce customer is
+     * exported without a more specific mapping. Documenting the helper highlights the
+     * relationship between the option and the resulting SoftOne records.
+     *
+     * @return string Trading category value configured for the integration.
+     */
     function softone_wc_integration_get_trdcategory() {
         return (string) softone_wc_integration_get_setting( 'trdcategory', '' );
     }

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.24
+ * Version:           1.8.25
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.24' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.25' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add detailed docblocks for SoftOne settings accessors to clarify their purpose and origin
- bump plugin version references to 1.8.25 and refresh the readme metadata and changelog

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_69069f8539c48327b298d63468a4d70a