### PR TITLE
Update contributor metadata and bump to version 1.8.26

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,11 +1,11 @@
 === Softone WooCommerce Integration ===
-Contributors: georgenicolaou
+Contributors: orionaselite
 Donate link: https://www.georgenicolaou.me//
 Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.25
+Stable tag: 1.8.26
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Changelog ==
 
+= 1.8.26 =
+* Update the listed WordPress.org contributor username.
+
 = 1.8.25 =
 * Add verbose documentation around SoftOne setting accessors and bump the plugin version number.
 
@@ -109,8 +112,8 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Upgrade Notice ==
 
-= 1.8.25 =
-This release clarifies the plugin's SoftOne setting helpers with extensive inline documentation and increments the plugin version number.
+= 1.8.26 =
+Refresh the plugin metadata to reference the updated WordPress.org contributor username.
 
 == Automatic Updates ==
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.25';
+                $this->version = '1.8.26';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.25
+ * Version:           1.8.26
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.25' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.26' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- update the README to list the orionaselite WordPress.org username and document the 1.8.26 release
- bump the plugin header and runtime version references to 1.8.26

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906a13816c483278883a403757f50ad