### PR TITLE
Log uncategorized category reasons and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.26
+Stable tag: 1.8.27
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Changelog ==
 
+= 1.8.27 =
+* Log detailed context whenever categories map to WooCommerce's default uncategorized term to simplify debugging taxonomy imports.
+
 = 1.8.26 =
 * Update the listed WordPress.org contributor username.
 
@@ -112,8 +115,8 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Upgrade Notice ==
 
-= 1.8.26 =
-Refresh the plugin metadata to reference the updated WordPress.org contributor username.
+= 1.8.27 =
+Capture detailed uncategorized category diagnostics to investigate why SoftOne categories are not being assigned as expected.
 
 == Automatic Updates ==
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                $this->version = '1.8.26';
+                $this->version = '1.8.27';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.26
+ * Version:           1.8.27
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.26' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.27' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add diagnostic logging that explains when category and subcategory names resolve to WooCommerce's default uncategorized term
- surface the term role and match details in skip logs to aid troubleshooting and reuse the data in a dedicated uncategorized log entry
- bump the plugin version to 1.8.27 and update the accompanying metadata

## Testing
- php -l includes/class-softone-item-sync.php

------
https://chatgpt.com/codex/tasks/task_e_6906a24e76948327a9d8184d5b47f47f