### PR TITLE
Bump plugin version to 1.8.28

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.27
+Stable tag: 1.8.28
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Changelog ==
 
+= 1.8.28 =
+* Document the category and menu re-sync button so administrators can manually refresh taxonomy assignments after updating credentials.
+
 = 1.8.27 =
 * Log detailed context whenever categories map to WooCommerce's default uncategorized term to simplify debugging taxonomy imports.
 
@@ -115,8 +118,8 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Upgrade Notice ==
 
-= 1.8.27 =
-Capture detailed uncategorized category diagnostics to investigate why SoftOne categories are not being assigned as expected.
+= 1.8.28 =
+Highlight the category and menu re-sync button that allows on-demand taxonomy refreshes when catalogue changes are required immediately.
 
 == Automatic Updates ==
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                $this->version = '1.8.27';
+                        $this->version = '1.8.28';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.27
+ * Version:           1.8.28
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.27' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.28' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- bump the plugin header, version constant, and runtime fallback to 1.8.28
- update the readme stable tag, changelog, and upgrade notice to highlight the category/menu re-sync button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906a9042df48327b254356fe9f669b2