### PR TITLE
Handle SoftOne color alias for pa_colour attribute

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.33
+Stable tag: 1.8.34
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.34 =
+* Accept the SoftOne `color` field when building WooCommerce attributes so products populate the `pa_colour` taxonomy using the same logic as `pa_brand`.
 
 = 1.8.33 =
 * Ensure WooCommerce attribute taxonomies are registered before assigning colour terms so `pa_colour` is persisted reliably and log failures when assignments cannot complete.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -1624,7 +1624,7 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 'colour' => array(
                     'label'    => __( 'Colour', 'softone-woocommerce-integration' ),
                     'value'    => $this->normalize_colour_value(
-                        trim( $this->get_value( $data, array( 'colour_name', 'color_name', 'colour' ) ) )
+                        trim( $this->get_value( $data, array( 'colour_name', 'color_name', 'colour', 'color' ) ) )
                     ),
                     'position' => 0,
                 ),

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.33';
+                        $this->version = '1.8.34';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.33
+ * Version:           1.8.34
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.33' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.34' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';

--- a/tests/force-taxonomy-refresh-regression-test.php
+++ b/tests/force-taxonomy-refresh-regression-test.php
@@ -1084,5 +1084,37 @@ if ( ! $cache_refreshed ) {
     throw new RuntimeException( 'Expected the attribute term cache to be refreshed when reusing an existing term.' );
 }
 
+$alias_product = new WC_Product_Simple();
+$alias_product->set_attributes( array() );
+
+$alias_assignments = $attribute_sync->prepare_attribute_assignments_public(
+    array(
+        'color' => ' blue ',
+    ),
+    $alias_product
+);
+
+if ( ! isset( $alias_assignments['terms'][ $colour_taxonomy ] ) ) {
+    throw new RuntimeException( 'Colour attribute terms should be prepared when using the `color` key alias.' );
+}
+
+$alias_term_ids = $alias_assignments['terms'][ $colour_taxonomy ];
+if ( $alias_term_ids !== array( $expected_term_id ) ) {
+    throw new RuntimeException( 'Expected the colour alias to reuse the existing term identifier.' );
+}
+
+if ( ! isset( $alias_assignments['attributes'][ $colour_taxonomy ] ) ) {
+    throw new RuntimeException( 'Colour attribute metadata should be prepared when using the alias key.' );
+}
+
+$alias_attribute = $alias_assignments['attributes'][ $colour_taxonomy ];
+if ( ! $alias_attribute instanceof WC_Product_Attribute ) {
+    throw new RuntimeException( 'Expected a WC_Product_Attribute instance for the colour alias assignment.' );
+}
+
+if ( $alias_attribute->get_options() !== array( $expected_term_id ) ) {
+    throw new RuntimeException( 'Colour alias attribute options should contain the reused term identifier.' );
+}
+
 echo "Taxonomy refresh regression test passed." . PHP_EOL;
 echo "Attribute term normalisation regression test passed." . PHP_EOL;


### PR DESCRIPTION
## Summary
- treat the SoftOne `color` column as a valid source for the WooCommerce `pa_colour` attribute
- extend the regression test to cover the new alias handling
- bump the plugin version to 1.8.34 and update the changelog

## Testing
- php tests/force-taxonomy-refresh-regression-test.php

------
https://chatgpt.com/codex/tasks/task_e_6907229a53ec8327be858fd763f24cdf