### PR TITLE
Normalize colour suffix handling and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.30
+Stable tag: 1.8.31
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.31 =
+* Strip colour suffixes appended to imported product names and use the extracted value to populate the Colour attribute with normalised casing.
 
 = 1.8.30 =
 * Automatically assign featured and gallery images from the media library when filenames share the product SKU and numeric suffixes.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -91,7 +91,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.30';
+                        $this->version = '1.8.31';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.30
+ * Version:           1.8.31
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.30' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.31' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';

--- a/tests/force-taxonomy-refresh-regression-test.php
+++ b/tests/force-taxonomy-refresh-regression-test.php
@@ -476,7 +476,7 @@ class Softone_Item_Sync_Test_Double extends Softone_Item_Sync {
      * @param WC_Product  $product Product instance.
      * @return array<string,array>
      */
-    protected function prepare_attribute_assignments( array $data, $product ) {
+    protected function prepare_attribute_assignments( array $data, $product, array $fallback_attributes = array() ) {
         return array(
             'attributes' => array(),
             'terms'      => array(),


### PR DESCRIPTION
## Summary
- strip colour suffixes from imported product names and normalise the extracted value
- feed the derived colour back into WooCommerce attributes when native data is missing
- bump the plugin version to 1.8.31 and document the change in the changelog

## Testing
- php -l includes/class-softone-item-sync.php

------
https://chatgpt.com/codex/tasks/task_e_690717a61df483278bc7b51d8578b4cc