### PR TITLE
Allow numeric SoftOne category codes to sync

### DIFF
--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -2195,11 +2195,10 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
         protected function is_numeric_term_name( $name ) {
             $name = trim( (string) $name );
 
-            if ( '' === $name ) {
-                return false;
-            }
-
-            return (bool) preg_match( '/^\d+$/', $name );
+            // Historically the plugin skipped categories whose names were purely numeric.
+            // SoftOne categories are often numeric codes, so we no longer treat them
+            // as invalid. Always return false so numeric names are processed.
+            return false;
         }
 
         /**

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.38
+ * Version:           1.8.39
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.38' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.39' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- stop treating numeric term names as invalid so SoftOne category codes are synced
- bump the plugin version constant and header to 1.8.39

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69076e7556248327b5c88900a900199b