### PR TITLE
Improve term recovery on creation errors

### DIFF
--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.39
+ * Version:           1.8.40
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.39' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.40' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- retry term lookups after wp_insert_term failures to recover valid identifiers before aborting
- log successful recoveries and continue returning identifiers when terms already exist
- bump plugin version to 1.8.40

## Testing
- php -l includes/class-softone-item-sync.php

------
https://chatgpt.com/codex/tasks/task_e_690771ab27a08327adf9443e41806bc8