### PR TITLE
Add batched AJAX menu deletion workflow

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.38
+Stable tag: 1.8.43
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/admin/css/softone-woocommerce-integration-admin.css
+++ b/admin/css/softone-woocommerce-integration-admin.css
@@ -143,6 +143,51 @@
         background: #f0f6fc;
 }
 
+.softone-delete-menu-progress {
+margin-top: 12px;
+display: none;
+flex-direction: column;
+gap: 8px;
+}
+
+.softone-delete-menu-progress[hidden] {
+display: none;
+}
+
+.softone-delete-menu-progress__bar {
+background: #dcdcde;
+border-radius: 999px;
+height: 12px;
+overflow: hidden;
+position: relative;
+}
+
+.softone-delete-menu-progress__bar-fill {
+background: #2271b1;
+height: 100%;
+width: 0;
+transition: width 0.3s ease;
+}
+
+.softone-delete-menu-progress__text {
+margin: 0;
+color: #50575e;
+}
+
+.softone-delete-menu-status {
+margin-top: 12px;
+padding: 12px 16px;
+}
+
+.softone-delete-menu-status[hidden] {
+display: none;
+}
+
+.softone-delete-menu-form .button[disabled] {
+opacity: 0.7;
+cursor: wait;
+}
+
 @media (min-width: 782px) {
         .softone-api-form-grid {
                 grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/admin/js/softone-woocommerce-integration-admin.js
+++ b/admin/js/softone-woocommerce-integration-admin.js
@@ -118,7 +118,288 @@
                         applyPreset( $( this ).val() );
                 } );
 
-                updateDescription( $presetField.val() );
-                markPresetFields( $presetField.val() );
-        } );
+updateDescription( $presetField.val() );
+markPresetFields( $presetField.val() );
+} );
+
+$( function() {
+if ( 'undefined' === typeof window.softoneMenuDeletion ) {
+return;
+}
+
+var settings = window.softoneMenuDeletion || {};
+var formSelector = settings.formSelector || '#softone-delete-main-menu-form';
+var $form = $( formSelector );
+
+if ( ! $form.length ) {
+return;
+}
+
+var ajaxUrl = settings.ajaxUrl || window.ajaxurl || '';
+
+if ( ! ajaxUrl || ! settings.action || ! settings.nonce ) {
+return;
+}
+
+var $submit = $form.find( 'input[type="submit"], button[type="submit"]' ).first();
+var $status = $( '#softone-delete-main-menu-status' );
+var $progress = $( '#softone-delete-main-menu-progress' );
+var $progressBar = $progress.find( '.softone-delete-menu-progress__bar' );
+var $progressFill = $progress.find( '.softone-delete-menu-progress__bar-fill' );
+var $progressText = $( '#softone-delete-main-menu-progress-text' );
+
+var state = {
+running: false,
+processId: '',
+total: 0,
+deleted: 0
+};
+
+var batchSize = parseInt( settings.batchSize, 10 );
+
+if ( ! batchSize || batchSize < 1 ) {
+batchSize = 20;
+}
+
+var i18n = settings.i18n || {};
+
+var ensureProgressVisible = function() {
+if ( $progress.length ) {
+$progress.prop( 'hidden', false );
+}
+};
+
+var resetProgress = function() {
+if ( $progressFill.length ) {
+$progressFill.css( 'width', '0%' );
+}
+
+if ( $progressBar.length ) {
+$progressBar.attr( 'aria-valuenow', 0 );
+}
+
+if ( $progressText.length ) {
+$progressText.text( '' );
+}
+
+if ( $progress.length ) {
+$progress.prop( 'hidden', true );
+}
+};
+
+var setProgressPercent = function( percent ) {
+if ( $progressFill.length ) {
+$progressFill.css( 'width', percent + '%' );
+}
+
+if ( $progressBar.length ) {
+$progressBar.attr( 'aria-valuenow', percent );
+}
+};
+
+var setProgressText = function( text ) {
+if ( $progressText.length ) {
+$progressText.text( text || '' );
+}
+};
+
+var showStatus = function( message, type ) {
+if ( ! $status.length ) {
+return;
+}
+
+$status.removeClass( 'notice-success notice-error notice-info' );
+
+if ( ! message ) {
+$status.prop( 'hidden', true );
+return;
+}
+
+var className = 'notice';
+
+if ( 'success' === type || 'error' === type ) {
+className += ' notice-' + type;
+} else {
+className += ' notice-info';
+}
+
+$status.addClass( className ).text( message ).prop( 'hidden', false );
+};
+
+var setButtonBusy = function( busy ) {
+if ( ! $submit.length ) {
+return;
+}
+
+$submit.prop( 'disabled', !! busy );
+
+if ( busy ) {
+$submit.attr( 'aria-busy', 'true' );
+} else {
+$submit.removeAttr( 'aria-busy' );
+}
+};
+
+var formatProgress = function( deleted, total ) {
+var template = i18n.progressTemplate || '%1$s / %2$s (%3$s%%)';
+var percent = total > 0 ? Math.min( 100, Math.round( ( deleted / total ) * 100 ) ) : 100;
+
+return template
+.replace( '%1$s', deleted )
+.replace( '%2$s', total )
+.replace( '%3$s', percent );
+};
+
+var updateProgress = function() {
+ensureProgressVisible();
+
+var total = state.total > 0 ? state.total : 0;
+var deleted = state.deleted > 0 ? state.deleted : 0;
+var percent = total > 0 ? Math.min( 100, Math.round( ( deleted / total ) * 100 ) ) : 0;
+
+setProgressPercent( percent );
+setProgressText( formatProgress( deleted, total > 0 ? total : deleted ) );
+};
+
+var handleError = function( message ) {
+setButtonBusy( false );
+state.running = false;
+showStatus( message || i18n.genericError || '', 'error' );
+};
+
+var finishSuccess = function( message ) {
+setButtonBusy( false );
+state.running = false;
+ensureProgressVisible();
+setProgressPercent( 100 );
+setProgressText( message || i18n.menuDeletedMessage || i18n.completeText || '' );
+showStatus( message || i18n.menuDeletedMessage || i18n.completeText || '', 'success' );
+};
+
+var ajaxRequest = function( step, extraData ) {
+var payload = $.extend( {}, extraData || {}, {
+action: settings.action,
+nonce: settings.nonce,
+step: step
+} );
+
+return $.ajax( {
+url: ajaxUrl,
+type: 'POST',
+dataType: 'json',
+data: payload
+} );
+};
+
+var runBatch = function() {
+ajaxRequest( 'batch', {
+process_id: state.processId,
+batch_size: batchSize
+} ).done( function( response ) {
+if ( ! response || ! response.success ) {
+var message = ( response && response.data && response.data.message ) ? response.data.message : i18n.genericError;
+handleError( message );
+return;
+}
+
+var data = response.data || {};
+
+if ( typeof data.total_items !== 'undefined' ) {
+state.total = parseInt( data.total_items, 10 ) || state.total;
+}
+
+if ( typeof data.deleted_items !== 'undefined' ) {
+state.deleted = parseInt( data.deleted_items, 10 ) || state.deleted;
+}
+
+updateProgress();
+
+if ( data.complete ) {
+finishSuccess( data.message );
+return;
+}
+
+if ( data.message ) {
+showStatus( data.message, 'info' );
+}
+
+runBatch();
+} ).fail( function( jqXHR ) {
+var message = i18n.genericError || '';
+
+if ( jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message ) {
+message = jqXHR.responseJSON.data.message;
+}
+
+handleError( message );
+} );
+};
+
+var startProcess = function() {
+if ( state.running ) {
+return;
+}
+
+state.running = true;
+state.processId = '';
+state.total = 0;
+state.deleted = 0;
+
+setButtonBusy( true );
+resetProgress();
+ensureProgressVisible();
+setProgressText( i18n.preparingText || '' );
+setProgressPercent( 0 );
+showStatus( '', '' );
+
+ajaxRequest( 'init' ).done( function( response ) {
+if ( ! response || ! response.success ) {
+var message = ( response && response.data && response.data.message ) ? response.data.message : i18n.genericError;
+handleError( message );
+return;
+}
+
+var data = response.data || {};
+
+state.processId = data.process_id || '';
+state.total = data.total_items ? parseInt( data.total_items, 10 ) : 0;
+state.deleted = data.deleted_items ? parseInt( data.deleted_items, 10 ) : 0;
+
+if ( data.message ) {
+showStatus( data.message, 'info' );
+}
+
+if ( data.complete ) {
+finishSuccess( data.message );
+return;
+}
+
+if ( ! state.processId ) {
+handleError( i18n.genericError || '' );
+return;
+}
+
+updateProgress();
+runBatch();
+} ).fail( function( jqXHR ) {
+var message = i18n.genericError || '';
+
+if ( jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message ) {
+message = jqXHR.responseJSON.data.message;
+}
+
+handleError( message );
+} );
+};
+
+$form.on( 'submit', function( event ) {
+event.preventDefault();
+
+if ( ! settings.action || ! settings.nonce ) {
+return;
+}
+
+startProcess();
+} );
+} );
 })( jQuery );

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -95,11 +95,11 @@ class Softone_Woocommerce_Integration {
          * @since    1.0.0
          */
         public function __construct() {
-                if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-                        $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-                } else {
-                        $this->version = '1.8.42';
-                }
+if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+} else {
+$this->version = '1.8.43';
+}
 		$this->plugin_name = 'softone-woocommerce-integration';
 
                 $this->load_dependencies();
@@ -238,10 +238,11 @@ class Softone_Woocommerce_Integration {
         $this->loader->add_action( 'admin_post_softone_wc_integration_test_connection', $plugin_admin, 'handle_test_connection' );
         $this->loader->add_action( 'admin_post_' . Softone_Item_Sync::ADMIN_ACTION, $plugin_admin, 'handle_item_import' );
         $this->loader->add_action( 'admin_post_softone_wc_integration_clear_sync_activity', $plugin_admin, 'handle_clear_sync_activity' );
-        $this->loader->add_action( 'admin_post_' . $plugin_admin->get_delete_main_menu_action(), $plugin_admin, 'handle_delete_main_menu' );
-        $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_sync_activity_action(), $plugin_admin, 'handle_sync_activity_ajax' );
+$this->loader->add_action( 'admin_post_' . $plugin_admin->get_delete_main_menu_action(), $plugin_admin, 'handle_delete_main_menu' );
+$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_sync_activity_action(), $plugin_admin, 'handle_sync_activity_ajax' );
+$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_delete_main_menu_ajax_action(), $plugin_admin, 'handle_delete_main_menu_ajax' );
 
-        }
+}
 
 	/**
 	 * Register all of the hooks related to the public-facing functionality

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.42
+ * Version:           1.8.43
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.42' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.43' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add AJAX-powered batch deletion for the "Main Menu" with progress UI and notices
- persist batch state server-side to delete menu items incrementally before removing the menu
- expose new localized script data and styling plus bump the plugin version and README stable tag

## Testing
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l includes/class-softone-woocommerce-integration.php

------
https://chatgpt.com/codex/tasks/task_e_6908862a7abc83278ea24c75a86bc8fc