### PR TITLE
Define missing sync last-run constant and bump to 1.8.47

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.46
+Stable tag: 1.8.47
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.47 =
+* Define the item sync last-run option constant to prevent fatal errors on the settings screen when the value is referenced.
 
 = 1.8.46 =
 * Ensure WooCommerce category terms are created and assigned even when the Softone payload hash has not changed so taxonomy sync runs for legacy imports.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -23,12 +23,13 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) :
 
 class Softone_Item_Sync {
 
-    const CRON_HOOK       = 'softone_wc_integration_sync_items';
-    const ADMIN_ACTION    = 'softone_wc_integration_run_item_import';
-    const META_MTRL       = '_softone_mtrl_id';
-    const META_LAST_SYNC  = '_softone_last_synced';
-    const META_BARCODE    = '_softone_barcode';
-    const META_BRAND      = '_softone_brand';
+    const CRON_HOOK         = 'softone_wc_integration_sync_items';
+    const ADMIN_ACTION      = 'softone_wc_integration_run_item_import';
+    const OPTION_LAST_RUN   = 'softone_last_run';
+    const META_MTRL         = '_softone_mtrl_id';
+    const META_LAST_SYNC    = '_softone_last_synced';
+    const META_BARCODE      = '_softone_barcode';
+    const META_BRAND        = '_softone_brand';
     const META_SOFTONE_CODE = '_softone_item_code';
 
     /**

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                       $this->version = '1.8.46';
+                        $this->version = '1.8.47';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.46
+ * Version:           1.8.47
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.46' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.47' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add the missing Softone_Item_Sync::OPTION_LAST_RUN constant so the settings page can read the last manual import timestamp without errors
- bump the plugin version to 1.8.47 and document the change in the readme

## Testing
- php -l includes/class-softone-item-sync.php

------
https://chatgpt.com/codex/tasks/task_e_690c96e1ad10832798073c5354799de7