### PR TITLE
Fix manual item import handler and expose sync summary

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.49
+Stable tag: 1.8.50
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.50 =
+* Ensure the manual "Run Item Import" action delegates to the admin handler so notices are displayed after completion.
+* Provide a public `sync()` method on the item sync service that returns a summary for the settings screen and logs the outcome.
 
 = 1.8.49 =
 * Prevent fatal errors that stopped product synchronisation by allowing the item sync service to register hooks via the plugin loader.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.49';
+                        $this->version = '1.8.50';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.49
+ * Version:           1.8.50
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.49' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.50' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- prevent the item sync service from short-circuiting the manual import action when the loader is present and add a shared sync execution routine
- expose a public `sync()` API that returns summary data for the settings screen, logs the outcome, and is reused by the fallback admin handler
- bump the plugin to version 1.8.50 and document the change in the readme

## Testing
- php -l includes/class-softone-item-sync.php
- php -l softone-woocommerce-integration.php
- php -l includes/class-softone-woocommerce-integration.php

------
https://chatgpt.com/codex/tasks/task_e_690c9bc17a9c8327bbcb88746e42d8dd