### PR TITLE
Revert to commit 2ae9c8e and release 1.8.47

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.51
+Stable tag: 1.8.47
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,23 +78,8 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Changelog ==
 
-= 1.8.51 =
-* Restore legacy Softone item import helpers used by regression tests and guard admin menu batching against missing WordPress constants.
-
-= 1.8.50 =
-* Ensure the manual "Run Item Import" action delegates to the admin handler so notices are displayed after completion.
-* Provide a public `sync()` method on the item sync service that returns a summary for the settings screen and logs the outcome.
-
-= 1.8.49 =
-* Prevent fatal errors that stopped product synchronisation by allowing the item sync service to register hooks via the plugin loader.
-* Add activity logging when the loader fallback is triggered and when cron events are scheduled or cleared for the item sync.
-
-= 1.8.48 =
-* Fix fatal errors triggered when the item sync service logs activity by updating calls to the shared activity logger to use the
-  expanded signature.
-
 = 1.8.47 =
-* Define the item sync last-run option constant to prevent fatal errors on the settings screen when the value is referenced.
+* Revert the plugin codebase to the logic deployed in commit 2ae9c8e to restore stable item synchronisation behaviour.
 
 = 1.8.46 =
 * Ensure WooCommerce category terms are created and assigned even when the Softone payload hash has not changed so taxonomy sync runs for legacy imports.

--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -139,7 +139,7 @@ private $menu_delete_default_batch_size = 20;
  *
  * @var int
  */
-    private $menu_delete_state_lifetime = 3600;
+private $menu_delete_state_lifetime = HOUR_IN_SECONDS;
 
         /**
          * Base transient key for connection test notices.
@@ -217,10 +217,6 @@ private $menu_delete_default_batch_size = 20;
                 $this->version     = $version;
                 $this->item_sync   = $item_sync;
                 $this->activity_logger = $activity_logger ?: new Softone_Sync_Activity_Logger();
-
-                if ( defined( 'HOUR_IN_SECONDS' ) ) {
-                        $this->menu_delete_state_lifetime = (int) HOUR_IN_SECONDS;
-                }
 
         }
 

--- a/includes/class-softone-customer-sync.php
+++ b/includes/class-softone-customer-sync.php
@@ -1,11 +1,8 @@
 <?php
 /**
- * SoftOne customer synchronisation – ONLY when WooCommerce orders become "completed".
+ * SoftOne customer synchronisation service.
  *
- * Calls SoftOne:
- *   service: setData
- *   object : CUSTOMER
- *   data   : { CUSTOMER: [ { ... } ], CUSEXTRA: [ { BOOL01: "1" } ] }
+ * @package    Softone_Woocommerce_Integration
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,135 +10,595 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! class_exists( 'Softone_Customer_Sync' ) ) {
-
+    /**
+     * Handles synchronising WooCommerce customers with SoftOne.
+     */
     class Softone_Customer_Sync {
 
-        const META_DONE         = '_softone_customer_synced';
-        const META_SOFTONE_ID   = '_softone_customer_id';
+        const META_TRDR     = '_softone_trdr';
+        const LOGGER_SOURCE = 'softone-customer-sync';
+        const CODE_PREFIX   = 'WEB';
 
+        /**
+         * API client instance.
+         *
+         * @var Softone_API_Client
+         */
         protected $api_client;
+
+        /**
+         * Logger instance.
+         *
+         * @var WC_Logger|Psr\Log\LoggerInterface|null
+         */
         protected $logger;
 
-        public function __construct( $api_client = null, $logger = null ) {
-            $this->api_client = ( $api_client instanceof Softone_API_Client )
-                ? $api_client
-                : ( class_exists( 'Softone_API_Client' ) ? new Softone_API_Client() : null );
-
-            $this->logger = ( $logger && method_exists( $logger, 'log' ) )
-                ? $logger
-                : ( function_exists( 'wc_get_logger' ) ? wc_get_logger() : null );
+        /**
+         * Constructor.
+         *
+         * @param Softone_API_Client|null                $api_client Optional API client.
+         * @param WC_Logger|Psr\Log\LoggerInterface|null $logger     Optional logger instance.
+         */
+        public function __construct( ?Softone_API_Client $api_client = null, $logger = null ) {
+            $this->api_client = $api_client ?: new Softone_API_Client();
+            $this->logger     = $logger ?: $this->get_default_logger();
         }
 
-        public function register_hooks( $loader ) {
-            $loader->add_action( 'woocommerce_order_status_completed', $this, 'on_order_completed', 10, 1 );
+        /**
+         * Register WordPress hooks via the loader.
+         *
+         * @param Softone_Woocommerce_Integration_Loader $loader Loader instance.
+         *
+         * @return void
+         */
+        public function register_hooks( Softone_Woocommerce_Integration_Loader $loader ) {
+            $loader->add_action( 'woocommerce_created_customer', $this, 'handle_customer_created', 10, 1 );
+            $loader->add_action( 'woocommerce_checkout_customer_created', $this, 'handle_checkout_customer_created', 10, 2 );
+            $loader->add_action( 'woocommerce_checkout_update_customer', $this, 'handle_checkout_update_customer', 10, 2 );
+            $loader->add_action( 'woocommerce_save_account_details', $this, 'handle_account_details_saved', 10, 1 );
+            $loader->add_action( 'profile_update', $this, 'handle_profile_update', 10, 1 );
+            $loader->add_action( 'woocommerce_customer_save_address', $this, 'handle_customer_save_address', 10, 1 );
         }
 
-        public function on_order_completed( $order_id ) {
-            $order_id = (int) $order_id;
-            if ( $order_id <= 0 ) {
-                return;
+        /**
+         * Ensure a WooCommerce customer has an associated SoftOne TRDR identifier.
+         *
+         * @param int $customer_id Customer identifier.
+         *
+         * @return string
+         */
+        public function ensure_customer_trdr( $customer_id ) {
+            $customer_id = absint( $customer_id );
+
+            if ( $customer_id <= 0 ) {
+                return '';
             }
 
-            $order = wc_get_order( $order_id );
-            if ( ! $order ) {
-                return;
+            $existing = get_user_meta( $customer_id, self::META_TRDR, true );
+            $existing = is_scalar( $existing ) ? (string) $existing : '';
+
+            if ( '' !== $existing ) {
+                return $existing;
             }
 
-            if ( 'yes' === get_post_meta( $order_id, self::META_DONE, true ) ) {
-                $this->log( 'debug', 'Already synced', array( 'order_id' => $order_id ) );
-                return;
+            if ( ! class_exists( 'WC_Customer' ) ) {
+                return '';
             }
-
-            $envelope = $this->build_envelope( $order );
 
             try {
-                if ( ! $this->api_client || ! method_exists( $this->api_client, 'sql_data' ) ) {
-                    throw new \RuntimeException( 'SoftOne API client unavailable' );
-                }
-
-                $result = $this->api_client->sql_data(
-                    'setData',
-                    array(
-                        'object' => 'CUSTOMER',
-                        'data'   => $envelope['data'],
-                    ),
-                    array()
-                );
-
-                if ( is_array( $result ) && isset( $result['id'] ) ) {
-                    update_post_meta( $order_id, self::META_SOFTONE_ID, (string) $result['id'] );
-                }
-
-                $this->log( 'info', 'SoftOne customer sync complete', array( 'order_id' => $order_id, 'result' => $result ) );
-
-            } catch ( \Throwable $e ) {
-                $this->log( 'error', 'SoftOne customer sync failed', array(
-                    'order_id' => $order_id,
-                    'error'    => $e->getMessage(),
-                ) );
+                $customer = new WC_Customer( $customer_id );
+            } catch ( Exception $exception ) {
+                $this->log( 'error', $exception->getMessage(), array( 'user_id' => $customer_id, 'exception' => $exception ) );
+                return '';
             }
 
-            update_post_meta( $order_id, self::META_DONE, 'yes' );
+            if ( ! $customer || ! $customer->get_id() ) {
+                return '';
+            }
+
+            try {
+                $this->sync_customer( $customer );
+            } catch ( Softone_API_Client_Exception $exception ) {
+                $this->log( 'error', $exception->getMessage(), array( 'user_id' => $customer_id, 'exception' => $exception ) );
+                return '';
+            }
+
+            $updated = get_user_meta( $customer_id, self::META_TRDR, true );
+
+            return is_scalar( $updated ) ? (string) $updated : '';
         }
 
-        protected function build_envelope( $order ) {
-            $email    = (string) $order->get_billing_email();
-            $phone    = (string) $order->get_billing_phone();
-            $fname    = (string) $order->get_billing_first_name();
-            $lname    = (string) $order->get_billing_last_name();
-            $company  = (string) $order->get_billing_company();
-            $addr1    = (string) $order->get_billing_address_1();
-            $addr2    = (string) $order->get_billing_address_2();
-            $city     = (string) $order->get_billing_city();
-            $state    = (string) $order->get_billing_state();
-            $postcode = (string) $order->get_billing_postcode();
-            $country  = (string) $order->get_billing_country();
+        /**
+         * Handle the WooCommerce customer creation action.
+         *
+         * @param int $customer_id Customer identifier.
+         *
+         * @return void
+         */
+        public function handle_customer_created( $customer_id ) {
+            $this->maybe_sync_customer( $customer_id );
+        }
 
-            $code = 'WEB' . $order->get_id();
+        /**
+         * Handle the checkout customer creation action.
+         *
+         * @param int   $customer_id Customer identifier.
+         * @param array $data        Raw checkout data (unused).
+         *
+         * @return void
+         */
+        public function handle_checkout_customer_created( $customer_id, $data = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+            $this->maybe_sync_customer( $customer_id );
+        }
 
-            $country_id  = apply_filters( 'softone_wc_country_to_id', 57, $country, $order ); // default Cyprus
-            $area_id     = apply_filters( 'softone_wc_area_to_id', 22, $country, $state, $order );
-            $currency_id = apply_filters( 'softone_wc_currency_to_id', 47, get_woocommerce_currency(), $order );
-            $trdcategory = apply_filters( 'softone_wc_trdcategory', 1, $order );
+        /**
+         * Handle checkout updates for logged-in customers.
+         *
+         * @param WC_Customer|int $customer Customer instance or identifier.
+         * @param array           $data     Checkout data (unused).
+         *
+         * @return void
+         */
+        public function handle_checkout_update_customer( $customer, $data = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+            if ( is_object( $customer ) && method_exists( $customer, 'get_id' ) ) {
+                $customer_id = $customer->get_id();
+            } else {
+                $customer_id = $customer;
+            }
 
-            $name = $company ?: trim( "$fname $lname" );
-            $address = trim( $addr1 . ' ' . $addr2 );
+            $this->maybe_sync_customer( $customer_id );
+        }
 
-            $customer_row = array(
-                'CODE'        => $code,
-                'NAME'        => $name ?: 'Web Customer',
-                'COUNTRY'     => (int) $country_id,
-                'AREAS'       => (int) $area_id,
-                'PHONE01'     => $phone,
-                'PHONE02'     => $phone,
-                'SOCURRENCY'  => (int) $currency_id,
-                'EMAIL'       => $email,
-                'ADDRESS'     => $address ?: 'No address',
-                'CITY'        => $city ?: 'City',
-                'ZIP'         => $postcode ?: '0000',
-                'TRDCATEGORY' => (int) $trdcategory,
+        /**
+         * Handle the account details update action.
+         *
+         * @param int $customer_id Customer identifier.
+         *
+         * @return void
+         */
+        public function handle_account_details_saved( $customer_id ) {
+            $this->maybe_sync_customer( $customer_id );
+        }
+
+        /**
+         * Handle generic profile updates.
+         *
+         * @param int $customer_id Customer identifier.
+         *
+         * @return void
+         */
+        public function handle_profile_update( $customer_id ) {
+            $this->maybe_sync_customer( $customer_id );
+        }
+
+        /**
+         * Handle address updates from the My Account area.
+         *
+         * @param int $customer_id Customer identifier.
+         *
+         * @return void
+         */
+        public function handle_customer_save_address( $customer_id ) {
+            $this->maybe_sync_customer( $customer_id );
+        }
+
+        /**
+         * Attempt to synchronise a customer with SoftOne.
+         *
+         * @param int $customer_id Customer identifier.
+         *
+         * @return void
+         */
+        protected function maybe_sync_customer( $customer_id ) {
+            $customer_id = absint( $customer_id );
+
+            if ( $customer_id <= 0 ) {
+                return;
+            }
+
+            if ( ! class_exists( 'WC_Customer' ) ) {
+                return;
+            }
+
+            try {
+                $customer = new WC_Customer( $customer_id );
+            } catch ( Exception $exception ) {
+                $this->log( 'error', $exception->getMessage(), array( 'user_id' => $customer_id, 'exception' => $exception ) );
+                return;
+            }
+
+            if ( ! $customer || ! $customer->get_id() ) {
+                return;
+            }
+
+            try {
+                $this->sync_customer( $customer );
+            } catch ( Softone_API_Client_Exception $exception ) {
+                $this->log( 'error', $exception->getMessage(), array( 'user_id' => $customer_id, 'exception' => $exception ) );
+            }
+        }
+
+        /**
+         * Synchronise a WooCommerce customer with SoftOne.
+         *
+         * @param WC_Customer $customer WooCommerce customer instance.
+         *
+         * @throws Softone_API_Client_Exception When API requests fail.
+         *
+         * @return void
+         */
+        protected function sync_customer( WC_Customer $customer ) {
+            $customer_id = $customer->get_id();
+            $existing    = get_user_meta( $customer_id, self::META_TRDR, true );
+            $existing    = is_scalar( $existing ) ? (string) $existing : '';
+
+            if ( '' !== $existing ) {
+                $this->update_customer( $customer, $existing );
+                return;
+            }
+
+            $match = $this->locate_existing_customer( $customer );
+
+            if ( ! empty( $match['TRDR'] ) ) {
+                $trdr = (string) $match['TRDR'];
+                update_user_meta( $customer_id, self::META_TRDR, $trdr );
+                $this->update_customer( $customer, $trdr );
+                return;
+            }
+
+            $this->create_customer( $customer );
+        }
+
+        /**
+         * Query SoftOne for an existing customer record matching the WooCommerce customer.
+         *
+         * @param WC_Customer $customer WooCommerce customer instance.
+         *
+         * @throws Softone_API_Client_Exception When API requests fail.
+         *
+         * @return array<string,mixed>
+         */
+        protected function locate_existing_customer( WC_Customer $customer ) {
+            $code  = $this->generate_customer_code( $customer );
+            $email = $customer->get_email();
+
+            $arguments = array();
+
+            if ( '' !== $code ) {
+                $arguments['CODE'] = $code;
+            }
+
+            if ( '' !== $email ) {
+                $arguments['EMAIL'] = $email;
+            }
+
+            $response = $this->api_client->sql_data( 'getCustomers', $arguments );
+            $rows     = isset( $response['rows'] ) && is_array( $response['rows'] ) ? $response['rows'] : array();
+
+            foreach ( $rows as $row ) {
+                $row_code  = isset( $row['CODE'] ) ? (string) $row['CODE'] : '';
+                $row_email = isset( $row['EMAIL'] ) ? (string) $row['EMAIL'] : '';
+
+                if ( '' !== $code && strcasecmp( $row_code, $code ) === 0 ) {
+                    return $row;
+                }
+
+                if ( '' !== $email && strcasecmp( $row_email, $email ) === 0 ) {
+                    return $row;
+                }
+            }
+
+            return array();
+        }
+
+        /**
+         * Create a new SoftOne customer record.
+         *
+         * @param WC_Customer $customer WooCommerce customer instance.
+         *
+         * @throws Softone_API_Client_Exception When API requests fail.
+         *
+         * @return void
+         */
+        protected function create_customer( WC_Customer $customer ) {
+            $payload = $this->build_customer_payload( $customer );
+
+            if ( empty( $payload['CUSTOMER'] ) ) {
+                return;
+            }
+
+            $response = $this->api_client->set_data( 'CUSTOMER', $payload );
+
+            if ( empty( $response['id'] ) ) {
+                return;
+            }
+
+            $trdr = (string) $response['id'];
+            update_user_meta( $customer->get_id(), self::META_TRDR, $trdr );
+        }
+
+        /**
+         * Update an existing SoftOne customer record.
+         *
+         * @param WC_Customer $customer WooCommerce customer instance.
+         * @param string      $trdr     SoftOne customer identifier.
+         *
+         * @throws Softone_API_Client_Exception When API requests fail.
+         *
+         * @return void
+         */
+        protected function update_customer( WC_Customer $customer, $trdr ) {
+            $payload = $this->build_customer_payload( $customer, $trdr );
+
+            if ( empty( $payload['CUSTOMER'] ) ) {
+                return;
+            }
+
+            $this->api_client->set_data( 'CUSTOMER', $payload );
+        }
+
+        /**
+         * Build the payload for SoftOne setData requests.
+         *
+         * @param WC_Customer   $customer WooCommerce customer instance.
+         * @param string|null   $trdr     Existing SoftOne identifier, if available.
+         *
+         * @return array<string,array<int,array<string,string>>>
+         */
+        protected function build_customer_payload( WC_Customer $customer, $trdr = null ) {
+            $billing_first_name = $customer->get_billing_first_name();
+            $billing_last_name  = $customer->get_billing_last_name();
+            $shipping_first     = method_exists( $customer, 'get_shipping_first_name' ) ? $customer->get_shipping_first_name() : '';
+            $shipping_last      = method_exists( $customer, 'get_shipping_last_name' ) ? $customer->get_shipping_last_name() : '';
+
+            $name = trim( implode( ' ', array_filter( array(
+                $customer->get_first_name(),
+                $customer->get_last_name(),
+            ), array( $this, 'filter_empty_value' ) ) ) );
+
+            if ( '' === $name ) {
+                $name = trim( implode( ' ', array_filter( array( $billing_first_name, $billing_last_name ), array( $this, 'filter_empty_value' ) ) ) );
+            }
+
+            if ( '' === $name ) {
+                $name = trim( implode( ' ', array_filter( array( $shipping_first, $shipping_last ), array( $this, 'filter_empty_value' ) ) ) );
+            }
+
+            if ( '' === $name ) {
+                $name = $customer->get_email();
+            }
+
+            $billing_phone  = $customer->get_billing_phone();
+            $shipping_phone = method_exists( $customer, 'get_shipping_phone' ) ? $customer->get_shipping_phone() : '';
+            $primary_phone  = '' !== $billing_phone ? $billing_phone : $shipping_phone;
+            $secondary      = ( '' !== $billing_phone && '' !== $shipping_phone && $billing_phone !== $shipping_phone ) ? $shipping_phone : '';
+
+            $address_1 = $customer->get_billing_address_1();
+            $address_2 = $customer->get_billing_address_2();
+
+            if ( '' === $address_1 && method_exists( $customer, 'get_shipping_address_1' ) ) {
+                $address_1 = $customer->get_shipping_address_1();
+                $address_2 = method_exists( $customer, 'get_shipping_address_2' ) ? $customer->get_shipping_address_2() : '';
+            }
+
+            $city     = $customer->get_billing_city();
+            $postcode = $customer->get_billing_postcode();
+            $country  = $customer->get_billing_country();
+
+            if ( '' === $city && method_exists( $customer, 'get_shipping_city' ) ) {
+                $city = $customer->get_shipping_city();
+            }
+
+            if ( '' === $postcode && method_exists( $customer, 'get_shipping_postcode' ) ) {
+                $postcode = $customer->get_shipping_postcode();
+            }
+
+            if ( '' === $country && method_exists( $customer, 'get_shipping_country' ) ) {
+                $country = $customer->get_shipping_country();
+            }
+
+            $country_code      = strtoupper( trim( (string) $country ) );
+            $softone_country   = '';
+            $country_log_attrs = array(
+                'customer_id' => $customer->get_id(),
             );
 
-            $customer_row = apply_filters( 'softone_wc_customer_payload', $customer_row, $order );
+            if ( null !== $trdr ) {
+                $country_log_attrs['trdr'] = (string) $trdr;
+            }
 
-            $cusextra_row = array( 'BOOL01' => '1' );
-            $cusextra_row = apply_filters( 'softone_wc_customer_extra_payload', $cusextra_row, $order );
+            if ( '' !== $country_code ) {
+                $country_log_attrs['country'] = $country_code;
+                $softone_country              = $this->map_country_to_softone_id( $country_code );
+
+                if ( '' === $softone_country ) {
+                    $this->log(
+                        'error',
+                        sprintf(
+                            /* translators: %s: ISO 3166-1 alpha-2 country code. */
+                            __( '[SO-CNTRY-001] SoftOne country mapping missing for ISO code %s.', 'softone-woocommerce-integration' ),
+                            $country_code
+                        ),
+                        $country_log_attrs
+                    );
+
+                    return array();
+                }
+            }
+
+            $record = array(
+                'CODE'        => $this->generate_customer_code( $customer ),
+                'NAME'        => $name,
+                'EMAIL'       => $customer->get_email(),
+                'PHONE01'     => $primary_phone,
+                'PHONE02'     => $secondary,
+                'ADDRESS'     => $address_1,
+                'ADDRESS2'    => $address_2,
+                'CITY'        => $city,
+                'ZIP'         => $postcode,
+                'COUNTRY'     => $softone_country,
+                'AREAS'       => $this->api_client->get_areas(),
+                'SOCURRENCY'  => $this->api_client->get_socurrency(),
+                'TRDCATEGORY' => $this->api_client->get_trdcategory(),
+            );
+
+            if ( null !== $trdr ) {
+                $record['TRDR'] = (string) $trdr;
+            }
+
+            $record = array_filter( $record, array( $this, 'filter_empty_value' ) );
+
+            if ( empty( $record['CODE'] ) ) {
+                $record['CODE'] = $this->generate_customer_code( $customer );
+            }
+
+            if ( empty( $record['NAME'] ) ) {
+                return array();
+            }
 
             return array(
-                'data' => array(
-                    'CUSTOMER' => array( $customer_row ),
-                    'CUSEXTRA' => array( $cusextra_row ),
-                ),
+                'CUSTOMER' => array( $record ),
             );
         }
 
-        protected function log( $level, $message, array $context = array() ) {
-            if ( $this->logger && method_exists( $this->logger, 'log' ) ) {
-                $context['source'] = 'softone-customer-sync';
-                $this->logger->log( $level, $message, $context );
-            } elseif ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                error_log( '[softone-customer-sync][' . strtoupper( $level ) . '] ' . $message . ' ' . wp_json_encode( $context ) );
+        /**
+         * Determine whether a value should be considered empty for payload purposes.
+         *
+         * @param mixed $value Value to inspect.
+         *
+         * @return bool
+         */
+        protected function filter_empty_value( $value ) {
+            if ( null === $value ) {
+                return false;
             }
+
+            if ( is_string( $value ) ) {
+                return '' !== trim( $value );
+            }
+
+            return ! empty( $value );
+        }
+
+        /**
+         * Map an ISO 3166-1 alpha-2 country code to the SoftOne numeric identifier.
+         *
+         * @param string $country_code ISO country code from WooCommerce data.
+         *
+         * @return string
+         */
+        public function map_country_to_softone_id( $country_code ) {
+            $country_code = strtoupper( trim( (string) $country_code ) );
+
+            if ( '' === $country_code ) {
+                return '';
+            }
+
+            $mappings = array();
+
+            if ( function_exists( 'softone_wc_integration_get_setting' ) ) {
+                $mappings = softone_wc_integration_get_setting( 'country_mappings', array() );
+            }
+
+            if ( ! is_array( $mappings ) ) {
+                $mappings = array();
+            }
+
+            $normalized = array();
+
+            foreach ( $mappings as $code => $identifier ) {
+                if ( ! is_scalar( $code ) ) {
+                    continue;
+                }
+
+                $normalized_code = strtoupper( trim( (string) $code ) );
+
+                if ( '' === $normalized_code ) {
+                    continue;
+                }
+
+                $normalized_identifier = is_scalar( $identifier ) ? trim( (string) $identifier ) : '';
+
+                if ( '' === $normalized_identifier ) {
+                    continue;
+                }
+
+                $normalized[ $normalized_code ] = $normalized_identifier;
+            }
+
+            /**
+             * Filter the configured country mappings before they are used.
+             *
+             * @param array<string,string>   $normalized   Associative array of ISO => SoftOne ID pairs.
+             * @param string                 $country_code Requested ISO country code.
+             * @param Softone_Customer_Sync  $customer_sync Customer synchronisation service instance.
+             */
+            $normalized = apply_filters( 'softone_wc_integration_country_mappings', $normalized, $country_code, $this );
+
+            $softone_id = isset( $normalized[ $country_code ] ) ? (string) $normalized[ $country_code ] : '';
+
+            /**
+             * Filter the resolved SoftOne country identifier.
+             *
+             * @param string                $softone_id   The mapped identifier (empty string when missing).
+             * @param string                $country_code Requested ISO country code.
+             * @param array<string,string>  $normalized   Associative array of ISO => SoftOne ID pairs.
+             * @param Softone_Customer_Sync $customer_sync Customer synchronisation service instance.
+             */
+            $softone_id = apply_filters( 'softone_wc_integration_country_id', $softone_id, $country_code, $normalized, $this );
+
+            return is_scalar( $softone_id ) ? trim( (string) $softone_id ) : '';
+        }
+
+        /**
+         * Generate a deterministic customer code for SoftOne.
+         *
+         * @param WC_Customer $customer WooCommerce customer instance.
+         *
+         * @return string
+         */
+        protected function generate_customer_code( WC_Customer $customer ) {
+            $id = absint( $customer->get_id() );
+
+            if ( $id <= 0 ) {
+                return '';
+            }
+
+            return sprintf( '%s%06d', self::CODE_PREFIX, $id );
+        }
+
+        /**
+         * Retrieve the default WooCommerce logger when available.
+         *
+         * @return WC_Logger|Psr\Log\LoggerInterface|null
+         */
+        protected function get_default_logger() {
+            if ( function_exists( 'wc_get_logger' ) ) {
+                return wc_get_logger();
+            }
+
+            return null;
+        }
+
+        /**
+         * Log a message using the configured logger.
+         *
+         * @param string $level   Log level (debug, info, warning, error).
+         * @param string $message Log message.
+         * @param array  $context Additional context.
+         *
+         * @return void
+         */
+        protected function log( $level, $message, array $context = array() ) {
+            if ( ! $this->logger || ! method_exists( $this->logger, 'log' ) ) {
+                return;
+            }
+
+            if ( class_exists( 'WC_Logger' ) && $this->logger instanceof WC_Logger ) {
+                $context['source'] = self::LOGGER_SOURCE;
+            }
+
+            $this->logger->log( $level, $message, $context );
         }
     }
 }

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -1,11 +1,8 @@
 <?php
 /**
- * SoftOne item synchronisation service (variable products by colour).
+ * SoftOne item synchronisation service.
  *
- * Creates variable parents grouped by cleaned title (DESC without "| colour"), brand and CODE;
- * then creates variations by colour. Safely handles SoftOne's odd field names.
- *
- * @package Softone_Woocommerce_Integration
+ * @package    Softone_Woocommerce_Integration
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,434 +12,349 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Softone_Category_Sync_Logger' ) ) {
     require_once __DIR__ . '/class-softone-category-sync-logger.php';
 }
+
 if ( ! class_exists( 'Softone_Sync_Activity_Logger' ) ) {
     require_once __DIR__ . '/class-softone-sync-activity-logger.php';
 }
 
-if ( ! class_exists( 'Softone_Item_Sync' ) ) :
-
-class Softone_Item_Sync {
-
-    const CRON_HOOK         = 'softone_wc_integration_sync_items';
-    const ADMIN_ACTION      = 'softone_wc_integration_run_item_import';
-    const OPTION_LAST_RUN   = 'softone_last_run';
-    const META_MTRL         = '_softone_mtrl_id';
-    const META_LAST_SYNC    = '_softone_last_synced';
-    const META_BARCODE      = '_softone_barcode';
-    const META_BRAND        = '_softone_brand';
-    const META_SOFTONE_CODE = '_softone_item_code';
-    const META_PAYLOAD_HASH = '_softone_payload_hash';
-
+if ( ! class_exists( 'Softone_Item_Sync' ) ) {
     /**
-     * Track whether taxonomy refresh is forced during a manual import.
-     *
-     * @var bool
+     * Handles importing SoftOne catalogue items into WooCommerce.
      */
-    protected $force_taxonomy_refresh = false;
+    class Softone_Item_Sync {
 
-    /**
-     * Optional Softone API client used by legacy import helpers.
-     *
-     * @var Softone_API_Client|null
-     */
-    protected $api_client;
+        const CRON_HOOK          = 'softone_wc_integration_sync_items';
+        const ADMIN_ACTION       = 'softone_wc_integration_run_item_import';
+        const META_MTRL          = '_softone_mtrl_id';
+        const META_LAST_SYNC     = '_softone_last_synced';
+        const META_PAYLOAD_HASH  = '_softone_payload_hash';
+        const OPTION_LAST_RUN    = 'softone_wc_integration_last_item_sync';
+        const LOGGER_SOURCE      = 'softone-item-sync';
+        const DEFAULT_CRON_EVENT = 'hourly';
 
-    /**
-     * Optional logger provided by older integrations.
-     *
-     * @var object|null
-     */
-    protected $legacy_logger;
+        /** @var Softone_API_Client */
+        protected $api_client;
 
-    /**
-     * Constructor kept for backwards compatibility with older bootstraps.
-     */
-    public function __construct( $api_client = null, $logger = null ) {
-        if ( null !== $api_client ) {
-            $this->api_client = $api_client;
+        /** @var WC_Logger|Psr\Log\LoggerInterface|null */
+        protected $logger;
+
+        /** @var Softone_Category_Sync_Logger|object|null */
+        protected $category_logger;
+
+        /** @var Softone_Sync_Activity_Logger|null */
+        protected $activity_logger;
+
+        /** @var array<string,int> */
+        protected $term_cache = array();
+
+        /** @var array<string,int> */
+        protected $attribute_term_cache = array();
+
+        /** @var array<string,int> */
+        protected $attribute_taxonomy_cache = array();
+
+        /** @var array<string,int> */
+        protected $cache_stats = array();
+
+        /** @var bool */
+        protected $force_taxonomy_refresh = false;
+
+        public function __construct( ?Softone_API_Client $api_client = null, $logger = null, $category_logger = null, ?Softone_Sync_Activity_Logger $activity_logger = null ) {
+            $this->api_client = $api_client ?: new Softone_API_Client();
+            $this->logger     = $logger ?: $this->get_default_logger();
+
+            if ( null !== $category_logger && method_exists( $category_logger, 'log_assignment' ) ) {
+                $this->category_logger = $category_logger;
+            } else {
+                $this->category_logger = new Softone_Category_Sync_Logger( $this->logger );
+            }
+
+            $this->activity_logger = $activity_logger;
+
+            $this->reset_caches();
         }
 
-        if ( null !== $logger ) {
-            $this->legacy_logger = $logger;
-        }
-    }
-
-    /**
-     * Back-compat for older loader code that expects register_hooks().
-     * (Your loader is calling ->register_hooks(); keep it working.)
-     *
-     * @param mixed $loader Optional loader helper used by the plugin bootstrap.
-     *
-     * @return void
-     */
-    public function register_hooks( $loader = null ) {
-        if ( $this->register_hooks_with_loader( $loader ) ) {
-            return;
+        /** @return void */
+        public function register_hooks( Softone_Woocommerce_Integration_Loader $loader ) {
+            $loader->add_action( 'init', $this, 'maybe_schedule_cron' );
+            $loader->add_action( self::CRON_HOOK, $this, 'handle_scheduled_sync', 10, 0 );
         }
 
-        $this->init();
-
-        if ( null !== $loader ) {
-            $this->log_loader_fallback( $loader );
-        }
-    }
-
-    /**
-     * Preferred hook wiring (new name used internally).
-     */
-    public function init() {
-        add_action( self::CRON_HOOK, [ $this, 'run' ] );
-        add_action( 'admin_post_' . self::ADMIN_ACTION, [ $this, 'run_from_admin' ] );
-        // Ensure attribute taxonomy exists early (after WC init).
-        add_action( 'init', [ $this, 'ensure_colour_taxonomy' ], 11 );
-    }
-
-    /**
-     * Attempt to register hooks via the plugin loader helper when available.
-     *
-     * @param mixed $loader Potential loader instance.
-     *
-     * @return bool True when hooks were registered using the loader, false otherwise.
-     */
-    protected function register_hooks_with_loader( $loader ) : bool {
-        if ( ! is_object( $loader ) || ! method_exists( $loader, 'add_action' ) ) {
-            return false;
+        /** @return void */
+        public function maybe_schedule_cron() {
+            self::schedule_event();
         }
 
-        $loader->add_action( self::CRON_HOOK, $this, 'run' );
-        $loader->add_action( 'init', $this, 'ensure_colour_taxonomy', 11 );
+        /** @return void */
+        public static function schedule_event() {
+            if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+                return;
+            }
 
-        return true;
-    }
+            $interval = apply_filters( 'softone_wc_integration_item_sync_interval', self::DEFAULT_CRON_EVENT );
+            if ( ! is_string( $interval ) || '' === $interval ) {
+                $interval = self::DEFAULT_CRON_EVENT;
+            }
 
-    /**
-     * Log when the loader fallback path is triggered.
-     *
-     * @param mixed $loader Loader value that could not be used.
-     *
-     * @return void
-     */
-    protected function log_loader_fallback( $loader ) {
-        if ( ! class_exists( 'Softone_Sync_Activity_Logger' ) ) {
-            return;
+            wp_schedule_event( time() + MINUTE_IN_SECONDS, $interval, self::CRON_HOOK );
         }
 
-        $context = array(
-            'loader_type' => is_object( $loader ) ? get_class( $loader ) : gettype( $loader ),
-        );
+        /** @return void */
+        public static function clear_scheduled_event() {
+            if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+                wp_clear_scheduled_hook( self::CRON_HOOK );
+                return;
+            }
 
-        $logger = new Softone_Sync_Activity_Logger();
-        $logger->log(
-            'item_sync',
-            'loader_fallback',
-            'SoftOne item sync registered hooks directly because the loader helper was unavailable.',
-            $context
-        );
-    }
+            $timestamp = wp_next_scheduled( self::CRON_HOOK );
 
-    /**
-     * Manual trigger from wp-admin action.
-     */
-    public function run_from_admin() {
-        try {
-            $this->sync();
-        } catch ( \Throwable $e ) {
-            // The sync activity logger already captured the failure; keep fallback handler silent.
+            while ( false !== $timestamp ) {
+                wp_unschedule_event( $timestamp, self::CRON_HOOK );
+                $timestamp = wp_next_scheduled( self::CRON_HOOK );
+            }
         }
 
-        if ( ! headers_sent() ) {
-            wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url() );
+        /** @return void */
+        public function handle_scheduled_sync() {
+            try {
+                $result = $this->sync();
+                if ( isset( $result['processed'] ) ) {
+                    $timestamp = isset( $result['started_at'] ) ? (int) $result['started_at'] : time();
+                    update_option( self::OPTION_LAST_RUN, $timestamp );
+                }
+            } catch ( Exception $exception ) {
+                $this->log( 'error', $exception->getMessage(), array( 'exception' => $exception ) );
+            }
         }
 
-        exit;
-    }
+        /**
+         * @throws Softone_API_Client_Exception
+         * @throws Exception
+         */
+        public function sync( $force_full_import = null, $force_taxonomy_refresh = false ) {
+            if ( ! class_exists( 'WC_Product' ) ) {
+                throw new Exception( __( 'WooCommerce is required to sync items.', 'softone-woocommerce-integration' ) );
+            }
 
-    /**
-     * Schedule the recurring cron event that runs the item synchronisation.
-     *
-     * @return bool True when the event was scheduled, false otherwise.
-     */
-    public static function schedule_event() {
-        if ( ! function_exists( 'wp_next_scheduled' ) || ! function_exists( 'wp_schedule_event' ) ) {
-            self::log_cron_event(
-                'cron_schedule_unsupported',
-                'Failed to schedule the SoftOne item sync because WordPress cron helpers are unavailable.'
-            );
+            $started_at = time();
+            $last_run   = (int) get_option( self::OPTION_LAST_RUN );
 
-            return false;
-        }
+            $this->reset_caches();
+            $this->maybe_adjust_memory_limits();
 
-        $next_run = wp_next_scheduled( self::CRON_HOOK );
-        if ( $next_run ) {
-            self::log_cron_event(
-                'cron_schedule_skipped',
-                'Skipped scheduling the SoftOne item sync because an event already exists.',
-                array( 'scheduled_for' => (int) $next_run )
-            );
+            $cache_addition_previous_state = null;
+            $term_counting_previous_state  = null;
+            $comment_count_previous_state  = null;
 
-            return false;
-        }
+            if ( function_exists( 'wp_suspend_cache_addition' ) ) {
+                $cache_addition_previous_state = wp_suspend_cache_addition( true );
+            }
 
-        $scheduled = wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+            if ( function_exists( 'wp_defer_term_counting' ) ) {
+                $term_counting_previous_state = wp_defer_term_counting( true );
+            }
 
-        if ( false === $scheduled ) {
-            self::log_cron_event(
-                'cron_schedule_failed',
-                'WordPress failed to schedule the SoftOne item sync event.'
-            );
+            if ( function_exists( 'wp_defer_comment_counting' ) ) {
+                $comment_count_previous_state = wp_defer_comment_counting( true );
+            }
 
-            return false;
-        }
-
-        self::log_cron_event(
-            'cron_scheduled',
-            'Scheduled the SoftOne item sync hourly cron event.'
-        );
-
-        return true;
-    }
-
-    /**
-     * Remove the scheduled cron event used by the item synchronisation.
-     *
-     * @return bool True when an event was removed, false otherwise.
-     */
-    public static function clear_scheduled_event() {
-        if ( ! function_exists( 'wp_next_scheduled' ) || ! function_exists( 'wp_unschedule_event' ) ) {
-            self::log_cron_event(
-                'cron_clear_unsupported',
-                'Failed to clear the SoftOne item sync because WordPress cron helpers are unavailable.'
-            );
-
-            return false;
-        }
-
-        $timestamp = wp_next_scheduled( self::CRON_HOOK );
-
-        if ( ! $timestamp ) {
-            self::log_cron_event(
-                'cron_clear_skipped',
-                'Skipped clearing the SoftOne item sync because no event was scheduled.'
-            );
-
-            return false;
-        }
-
-        $cleared = wp_unschedule_event( $timestamp, self::CRON_HOOK );
-
-        if ( false === $cleared ) {
-            self::log_cron_event(
-                'cron_clear_failed',
-                'WordPress failed to clear the SoftOne item sync cron event.',
-                array( 'scheduled_for' => (int) $timestamp )
-            );
-
-            return false;
-        }
-
-        self::log_cron_event(
-            'cron_cleared',
-            'Cleared the scheduled SoftOne item sync cron event.',
-            array( 'scheduled_for' => (int) $timestamp )
-        );
-
-        return true;
-    }
-
-    /**
-     * Main sync entrypoint – fetch your SoftOne rows and import.
-     * Replace fetch_softone_items() with your real API call.
-     */
-    public function run() {
-        $logger = new Softone_Sync_Activity_Logger();
-
-        try {
-            $result = $this->execute_sync();
-            $this->log_sync_result( $result, $logger );
-        } catch ( \Throwable $e ) {
-            $this->log_sync_exception( $e, $logger );
-        }
-    }
-
-    /**
-     * Execute the item import and return a summary.
-     *
-     * @param bool|null $force_full_import      Whether a full import was requested.
-     * @param bool      $force_taxonomy_refresh Whether taxonomy data should be refreshed.
-     *
-     * @return array<string,mixed>
-     */
-    protected function execute_sync( $force_full_import = null, $force_taxonomy_refresh = false ) {
-        $payload = $this->fetch_softone_items( $force_full_import, $force_taxonomy_refresh );
-
-        if ( ! is_array( $payload ) ) {
-            throw new \UnexpectedValueException( 'SoftOne: Unexpected response payload.' );
-        }
-
-        $rows = isset( $payload['rows'] ) && is_array( $payload['rows'] ) ? $payload['rows'] : array();
-
-        $result = array(
-            'started_at'      => time(),
-            'processed'       => 0,
-            'created'         => 0,
-            'updated'         => 0,
-            'skipped'         => 0,
-            'rows_count'      => count( $rows ),
-            'payload_success' => isset( $payload['success'] ) ? (bool) $payload['success'] : null,
-        );
-
-        if ( empty( $rows ) ) {
-            return $result;
-        }
-
-        $result['processed'] = (int) $this->process_items( $rows );
-
-        if ( $result['rows_count'] > $result['processed'] ) {
-            $result['skipped'] = $result['rows_count'] - $result['processed'];
-        }
-
-        return $result;
-    }
-
-    /**
-     * Public sync API used by the admin handler.
-     *
-     * @param bool|null $force_full_import      Whether a full import was requested.
-     * @param bool      $force_taxonomy_refresh Whether taxonomy data should be refreshed.
-     *
-     * @return array<string,mixed>
-     */
-    public function sync( $force_full_import = null, $force_taxonomy_refresh = false ) {
-        $logger = new Softone_Sync_Activity_Logger();
-
-        try {
-            $previous_refresh_state         = $this->force_taxonomy_refresh;
-            $this->force_taxonomy_refresh   = (bool) $force_taxonomy_refresh;
-            $result = $this->execute_sync( $force_full_import, $force_taxonomy_refresh );
-            $this->log_sync_result( $result, $logger );
-
-            $this->force_taxonomy_refresh = $previous_refresh_state;
-
-            return $result;
-        } catch ( \Throwable $e ) {
-            $this->log_sync_exception( $e, $logger );
-
-            $this->force_taxonomy_refresh = $previous_refresh_state;
-
-            throw $e;
-        }
-    }
-
-    /**
-     * Persist a successful sync result to the activity log.
-     *
-     * @param array<string,mixed>               $result Summary values.
-     * @param Softone_Sync_Activity_Logger|null $logger Logger instance.
-     *
-     * @return void
-     */
-    protected function log_sync_result( array $result, $logger ) {
-        if ( ! $logger instanceof Softone_Sync_Activity_Logger ) {
-            return;
-        }
-
-        if ( empty( $result['rows_count'] ) ) {
-            $logger->log(
-                'item_sync',
-                'empty_payload',
-                'SoftOne: No items to sync or API error.',
+            $this->log(
+                'info',
+                'Starting Softone item sync run.',
                 array(
-                    'payload_success' => isset( $result['payload_success'] ) ? $result['payload_success'] : null,
-                    'row_count'       => 0,
+                    'started_at' => $started_at,
+                    'last_run'   => $last_run,
                 )
             );
 
-            return;
+            if ( null === $force_full_import ) {
+                $force_full_import = false;
+            }
+
+            $force_full_import = (bool) apply_filters( 'softone_wc_integration_item_sync_force_full', $force_full_import, $last_run );
+
+            $extra = array();
+
+            if ( $last_run > 0 && ! $force_full_import ) {
+                $elapsed_seconds = max( 0, $started_at - $last_run );
+                $minutes         = max( 1, (int) ceil( $elapsed_seconds / MINUTE_IN_SECONDS ) );
+                $extra['pMins']  = $minutes;
+
+                $this->log(
+                    'info',
+                    sprintf( 'Running Softone item sync in delta mode for the last %d minute(s).', $minutes ),
+                    array(
+                        'minutes'    => $minutes,
+                        'started_at' => $started_at,
+                        'last_run'   => $last_run,
+                    )
+                );
+            }
+
+            $stats = array(
+                'processed'  => 0,
+                'created'    => 0,
+                'updated'    => 0,
+                'skipped'    => 0,
+                'started_at' => $started_at,
+            );
+
+            $previous_force_taxonomy_refresh = $this->force_taxonomy_refresh;
+            $this->force_taxonomy_refresh    = (bool) $force_taxonomy_refresh;
+
+            try {
+                foreach ( $this->yield_item_rows( $extra ) as $row ) {
+                    $stats['processed']++;
+
+                    try {
+                        $normalized = $this->normalize_row( $row );
+                        $result     = $this->import_row( $normalized, $started_at );
+
+                        if ( 'created' === $result ) {
+                            $stats['created']++;
+                        } elseif ( 'updated' === $result ) {
+                            $stats['updated']++;
+                        } else {
+                            $stats['skipped']++;
+                        }
+                    } catch ( Exception $exception ) {
+                        $stats['skipped']++;
+                        $this->log( 'error', $exception->getMessage(), array( 'row' => $row ) );
+                    }
+                }
+
+                $stale_processed = $this->handle_stale_products( $started_at );
+
+                if ( $stale_processed > 0 ) {
+                    $stats['stale_processed'] = $stale_processed;
+                }
+
+                $this->log( 'debug', 'Softone item sync cache usage summary.', array( 'cache_stats' => $this->cache_stats ) );
+
+                return $stats;
+            } finally {
+                if ( function_exists( 'wp_suspend_cache_addition' ) && null !== $cache_addition_previous_state ) {
+                    wp_suspend_cache_addition( $cache_addition_previous_state );
+                }
+                if ( function_exists( 'wp_defer_term_counting' ) && null !== $term_counting_previous_state ) {
+                    wp_defer_term_counting( $term_counting_previous_state );
+                }
+                if ( function_exists( 'wp_defer_comment_counting' ) && null !== $comment_count_previous_state ) {
+                    wp_defer_comment_counting( $comment_count_previous_state );
+                }
+                $this->force_taxonomy_refresh = $previous_force_taxonomy_refresh;
+            }
         }
 
-        $processed = isset( $result['processed'] ) ? (int) $result['processed'] : 0;
+        /** @return void */
+        protected function maybe_adjust_memory_limits() {
+            if ( function_exists( 'wp_raise_memory_limit' ) ) {
+                wp_raise_memory_limit( 'admin' );
+            }
 
-        $logger->log(
-            'item_sync',
-            'processed',
-            sprintf( 'SoftOne: processed %d rows into variable products.', $processed ),
-            array( 'processed_rows' => $processed )
-        );
-    }
+            $target_limit = apply_filters( 'softone_wc_integration_item_sync_memory_limit', '1024M' );
+            if ( ! is_string( $target_limit ) || '' === trim( $target_limit ) ) {
+                return;
+            }
 
-    /**
-     * Persist sync exceptions to the activity log.
-     *
-     * @param \Throwable                        $exception Caught exception instance.
-     * @param Softone_Sync_Activity_Logger|null $logger    Logger instance.
-     *
-     * @return void
-     */
-    protected function log_sync_exception( \Throwable $exception, $logger ) {
-        if ( ! $logger instanceof Softone_Sync_Activity_Logger ) {
-            return;
+            $target_bytes  = $this->normalize_memory_limit( $target_limit );
+            $current_limit = function_exists( 'ini_get' ) ? ini_get( 'memory_limit' ) : false;
+
+            if ( $target_bytes <= 0 && -1 !== $target_bytes ) {
+                return;
+            }
+
+            if ( false === $current_limit || '' === $current_limit ) {
+                if ( function_exists( 'ini_set' ) ) {
+                    @ini_set( 'memory_limit', $target_limit );
+                }
+                return;
+            }
+
+            $current_bytes = $this->normalize_memory_limit( $current_limit );
+
+            if ( -1 === $current_bytes || ( $current_bytes >= $target_bytes && $target_bytes > 0 ) ) {
+                return;
+            }
+
+            if ( function_exists( 'ini_set' ) ) {
+                @ini_set( 'memory_limit', $target_limit );
+            }
         }
 
-        $logger->log(
-            'item_sync',
-            'exception',
-            'SoftOne error: ' . $exception->getMessage(),
-            array(
-                'exception_class' => get_class( $exception ),
-                'code'            => (int) $exception->getCode(),
-            )
-        );
-    }
+        /** @return int */
+        protected function normalize_memory_limit( $value ) {
+            if ( function_exists( 'wp_convert_hr_to_bytes' ) ) {
+                return (int) wp_convert_hr_to_bytes( $value );
+            }
 
-    /**
-     * STUB – replace with your actual SoftOne API request.
-     */
-    protected function fetch_softone_items( $force_full_import = null, $force_taxonomy_refresh = false ) {
-        return [
-            'success' => true,
-            'rows'    => [],
-        ];
-    }
+            if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
+                return 0;
+            }
 
-    /**
-     * Legacy Softone pagination helper used by historical import flows.
-     */
-    protected function yield_item_rows( array $extra ) {
-        if ( ! $this->api_client || ! is_object( $this->api_client ) || ! method_exists( $this->api_client, 'sql_data' ) ) {
-            return ( function () { yield from []; } )();
+            $value = trim( (string) $value );
+
+            if ( '' === $value ) {
+                return 0;
+            }
+
+            if ( '-1' === $value ) {
+                return -1;
+            }
+
+            $unit   = strtolower( substr( $value, -1 ) );
+            $number = (float) $value;
+
+            if ( in_array( $unit, array( 'g', 'm', 'k' ), true ) ) {
+                $number = (float) substr( $value, 0, -1 );
+            }
+
+            switch ( $unit ) {
+                case 'g':
+                    $number *= 1024;
+                case 'm':
+                    $number *= 1024;
+                case 'k':
+                    $number *= 1024;
+                    break;
+            }
+
+            return (int) round( $number );
         }
 
-        $default_page_size = 250;
-        $page_size         = (int) apply_filters( 'softone_wc_integration_item_sync_page_size', $default_page_size );
-        if ( $page_size <= 0 ) {
-            $page_size = $default_page_size;
-        }
+        /**
+         * @param array $extra
+         * @return Generator<int, array<string, mixed>>
+         */
+        protected function yield_item_rows( array $extra ) {
+            $default_page_size  = 250;
+            $filtered_page_size = (int) apply_filters( 'softone_wc_integration_item_sync_page_size', $default_page_size );
+            $page_size          = $filtered_page_size > 0 ? $filtered_page_size : $default_page_size;
 
-        $max_pages     = (int) apply_filters( 'softone_wc_integration_item_sync_max_pages', 0 );
-        $page          = 1;
-        $previous_hash = [];
+            $max_pages     = (int) apply_filters( 'softone_wc_integration_item_sync_max_pages', 0 );
+            $page          = 1;
+            $previous_hash = array();
 
-        $generator = function () use ( $extra, $page_size, $max_pages, &$page, &$previous_hash ) {
             while ( true ) {
-                $request_extra          = $extra;
-                $request_extra['pPage'] = $page;
-                $request_extra['pSize'] = $page_size;
+                $page_extra          = $extra;
+                $page_extra['pPage'] = $page;
+                $page_extra['pSize'] = $page_size;
 
-                $response = $this->api_client->sql_data( 'getItems', [], $request_extra );
-                $rows     = isset( $response['rows'] ) && is_array( $response['rows'] ) ? $response['rows'] : [];
+                $response = $this->api_client->sql_data( 'getItems', array(), $page_extra );
+                $rows     = isset( $response['rows'] ) && is_array( $response['rows'] ) ? $response['rows'] : array();
 
                 $this->log_activity(
                     'api_requests',
                     'payload_received',
                     'Received payload from Softone API for getItems request.',
-                    [
+                    array(
                         'endpoint'  => 'getItems',
                         'page'      => $page,
                         'page_size' => $page_size,
                         'row_count' => count( $rows ),
-                        'request'   => $request_extra,
+                        'request'   => $page_extra,
                         'payload'   => $this->prepare_api_payload_for_logging( $response ),
-                    ]
+                    )
                 );
 
                 if ( empty( $rows ) ) {
@@ -454,7 +366,7 @@ class Softone_Item_Sync {
                     $this->log(
                         'warning',
                         'Detected repeated page payload when fetching Softone item rows. Aborting further pagination to prevent an infinite loop.',
-                        [ 'page' => $page, 'page_size' => $page_size ]
+                        array( 'page' => $page, 'page_size' => $page_size )
                     );
                     break;
                 }
@@ -465,7 +377,14 @@ class Softone_Item_Sync {
                     yield $row;
                 }
 
-                if ( count( $rows ) < $page_size ) {
+                $row_count = count( $rows );
+                unset( $rows );
+
+                if ( function_exists( 'gc_collect_cycles' ) ) {
+                    gc_collect_cycles();
+                }
+
+                if ( $row_count < $page_size ) {
                     break;
                 }
 
@@ -475,1113 +394,1658 @@ class Softone_Item_Sync {
                     break;
                 }
             }
-        };
+        }
 
-        return $generator();
-    }
+        /** @return string */
+        protected function hash_item_rows( array $rows ) {
+            $context = hash_init( 'md5' );
+            $this->hash_append_value( $context, $rows );
+            return hash_final( $context );
+        }
 
-    /**
-     * Hash the API payload to detect repeated pages.
-     */
-    protected function hash_item_rows( array $rows ) {
-        $context = hash_init( 'md5' );
-        $this->hash_append_value( $context, $rows );
+        /** @return void */
+        protected function hash_append_value( $context, $value ) {
+            if ( is_array( $value ) ) {
+                $keys       = array_keys( $value );
+                $item_count = count( $value );
+                $is_list    = 0 === $item_count || $keys === range( 0, $item_count - 1 );
 
-        return hash_final( $context );
-    }
+                if ( $is_list ) {
+                    hash_update( $context, '[' );
+                    $is_first = true;
+                    foreach ( $value as $item ) {
+                        if ( $is_first ) { $is_first = false; } else { hash_update( $context, ',' ); }
+                        $this->hash_append_value( $context, $item );
+                    }
+                    hash_update( $context, ']' );
+                    return;
+                }
 
-    /**
-     * Append values to a hashing context.
-     */
-    protected function hash_append_value( $context, $value ) {
-        if ( is_array( $value ) ) {
-            $keys       = array_keys( $value );
-            $item_count = count( $value );
-            $is_list    = 0 === $item_count || $keys === range( 0, $item_count - 1 );
-
-            if ( $is_list ) {
-                hash_update( $context, '[' );
-                $first = true;
-                foreach ( $value as $item ) {
-                    if ( $first ) { $first = false; } else { hash_update( $context, ',' ); }
+                hash_update( $context, '{' );
+                $is_first = true;
+                foreach ( $value as $key => $item ) {
+                    if ( $is_first ) { $is_first = false; } else { hash_update( $context, ',' ); }
+                    $encoded_key = $this->encode_json_fragment( (string) $key );
+                    hash_update( $context, $encoded_key );
+                    hash_update( $context, ':' );
                     $this->hash_append_value( $context, $item );
                 }
-                hash_update( $context, ']' );
-
+                hash_update( $context, '}' );
                 return;
             }
 
-            hash_update( $context, '{' );
-            $first = true;
-            foreach ( $value as $key => $item ) {
-                if ( $first ) { $first = false; } else { hash_update( $context, ',' ); }
-                hash_update( $context, $this->encode_json_fragment( (string) $key ) );
-                hash_update( $context, ':' );
-                $this->hash_append_value( $context, $item );
+            $encoded = $this->encode_json_fragment( $value );
+            hash_update( $context, $encoded );
+        }
+
+        /** @return string */
+        protected function encode_json_fragment( $value ) {
+            $encoded = wp_json_encode( $value );
+            if ( false === $encoded ) { $encoded = json_encode( $value ); }
+            if ( false === $encoded ) { $encoded = ''; }
+            return (string) $encoded;
+        }
+
+        /** @return array */
+        protected function normalize_row( array $row ) {
+            $normalized = array();
+            foreach ( $row as $key => $value ) {
+                $normalized_key = strtolower( preg_replace( '/[^a-zA-Z0-9]+/', '_', (string) $key ) );
+                $normalized_key = trim( $normalized_key, '_' );
+                if ( '' === $normalized_key ) { continue; }
+                $normalized[ $normalized_key ] = $value;
             }
-            hash_update( $context, '}' );
-
-            return;
+            return $normalized;
         }
 
-        hash_update( $context, $this->encode_json_fragment( $value ) );
+/**
+ * @throws Exception
+ * @return string created|updated|skipped
+ */
+protected function import_row( array $data, $run_timestamp ) {
+    $mtrl         = isset( $data['mtrl'] ) ? (string) $data['mtrl'] : '';
+    $sku_requested = $this->determine_sku( $data );
+
+    if ( '' === $mtrl && '' === $sku_requested ) {
+        throw new Exception( __( 'Unable to determine a product identifier for the imported row.', 'softone-woocommerce-integration' ) );
     }
 
-    /**
-     * Encode a value using JSON semantics for hashing purposes.
-     */
-    protected function encode_json_fragment( $value ) {
-        $encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $value ) : json_encode( $value );
-        if ( false === $encoded ) {
-            $encoded = '';
-        }
-
-        return (string) $encoded;
+    // DE-DUPE: if the SKU already exists on ANY product, we will update THAT product (no duplicate products)
+    $existing_by_sku_id = 0;
+    if ( '' !== $sku_requested && function_exists( 'wc_get_product_id_by_sku' ) ) {
+        $existing_by_sku_id = (int) wc_get_product_id_by_sku( $sku_requested );
     }
 
-    /**
-     * Lightweight legacy activity logger shim.
-     */
-    protected function log_activity( $channel, $action, $message, array $context = [] ) {
-        if ( is_object( $this->legacy_logger ) && method_exists( $this->legacy_logger, 'log' ) ) {
-            $this->legacy_logger->log( $action, $message, $context );
-            return;
-        }
+    // Existing by our usual lookup (prefers SKU first now, then MTRL)
+    $product_id = $this->find_existing_product( $sku_requested, $mtrl );
 
-        $this->log( $action, $message, $context );
+    // If find_existing_product() didn’t find it but a SKU owner exists, use the SKU owner
+    if ( 0 === $product_id && $existing_by_sku_id > 0 ) {
+        $product_id = $existing_by_sku_id;
     }
 
-    /**
-     * Prepare API payloads for logging output.
-     */
-    protected function prepare_api_payload_for_logging( $payload ) {
-        return $payload;
+    $is_new = ( 0 === $product_id );
+
+    $hash_source  = $data;
+    ksort( $hash_source );
+    $payload_hash = md5( wp_json_encode( $hash_source ) );
+
+    if ( $is_new ) {
+        $product = new WC_Product_Simple();
+        $product->set_status( 'publish' );
+    } else {
+        $product = wc_get_product( $product_id );
     }
 
-    /**
-     * Transform rows => variable parents + colour variations.
-     */
-    public function process_items( array $rows ) : int {
-        $logger = new Softone_Sync_Activity_Logger();
+    if ( ! $product ) {
+        throw new Exception( __( 'Failed to load the matching WooCommerce product.', 'softone-woocommerce-integration' ) );
+    }
 
-        $groups = [];
+    $category_ids = $this->prepare_category_ids( $data );
 
-        foreach ( $rows as $r ) {
-            $desc_raw  = $this->g( $r, 'DESC' );
-            $brand     = $this->g( $r, 'BRAND NAME' ) ?: $this->g( $r, 'BRAND' ) ?: '';
-            $code      = $this->g( $r, 'CODE' ); // parent CODE (stable id)
-            $sku       = $this->g( $r, 'SKU' );  // variation SKU
-            $barcode   = $this->g( $r, 'BARCODE' );
-            $mtrl      = $this->g( $r, 'MTRL' );
-            $price     = $this->g( $r, 'RETAILPRICE' );
-            $qty       = $this->g( $r, 'Stock QTY' );
+    if ( ! $is_new ) {
+        $existing_hash    = (string) get_post_meta( $product_id, self::META_PAYLOAD_HASH, true );
+        $categories_match = $this->product_categories_match( $product_id, $category_ids );
 
-            // Colour: prefer explicit, else parse from " | colour" suffix in DESC.
-            $colour    = $this->g( $r, 'COLOUR NAME' ) ?: $this->parse_colour_from_desc( $desc_raw );
-            $base_desc = $this->strip_colour_from_desc( $desc_raw );
-            $title_for_parent = $base_desc ?: $desc_raw ?: ( $sku ?: $code );
-
-            $groups_key = $this->parent_key( $brand, $title_for_parent, $code );
-
-            $groups[ $groups_key ]['brand']            = $brand;
-            $groups[ $groups_key ]['title']            = $title_for_parent;
-            $groups[ $groups_key ]['code']             = $code;
-            $groups[ $groups_key ]['category_name']    = $this->g( $r, 'COMMECATEGORY NAME' ) ?: $this->g( $r, 'COMMERCATEGORY NAME' ) ?: '';
-            $groups[ $groups_key ]['subcategory_name'] = $this->g( $r, 'SUBMECATEGORY NAME' ) ?: $this->g( $r, 'SUBCATEGORY NAME' ) ?: '';
-
-            $groups[ $groups_key ]['items'][] = [
-                'sku'     => $sku,
-                'barcode' => $barcode,
-                'mtrl'    => $mtrl,
-                'price'   => is_numeric( $price ) ? (float) $price : null,
-                'qty'     => ( $qty === '' || $qty === null ) ? null : (float) $qty,
-                'colour'  => $colour ?: 'N/A',
-                'raw'     => $r,
-            ];
-        }
-
-        $processed = 0;
-
-        foreach ( $groups as $key => $group ) {
-            $parent_id = $this->upsert_variable_parent( $group );
-            if ( ! $parent_id ) {
-                $logger->log(
-                    'item_sync',
-                    'parent_upsert_failed',
-                    'Failed to upsert parent for key: ' . $key,
+        if ( ! $this->force_taxonomy_refresh && '' !== $existing_hash && $existing_hash === $payload_hash ) {
+            if ( $categories_match ) {
+                $this->log(
+                    'debug',
+                    'Skipping product import because the payload hash matches the existing product.',
                     array(
-                        'brand' => isset( $group['brand'] ) ? $group['brand'] : '',
-                        'code'  => isset( $group['code'] ) ? $group['code'] : '',
+                        'product_id'             => $product_id,
+                        'sku'                    => $sku_requested,
+                        'mtrl'                   => $mtrl,
+                        'payload_hash'           => $payload_hash,
+                        'existing_hash'          => $existing_hash,
+                        'category_ids'           => $category_ids,
+                        'categories_match'       => true,
+                        'force_taxonomy_refresh' => (bool) $this->force_taxonomy_refresh,
                     )
                 );
-                continue;
-            }
-
-            // Ensure pa_colour set on parent
-            $this->attach_parent_colour_attribute( $parent_id, wp_list_pluck( $group['items'], 'colour' ) );
-
-            // Upsert variations
-            foreach ( $group['items'] as $item ) {
-                $this->upsert_colour_variation( $parent_id, $item );
-            }
-
-            // Categories & brand meta
-            $this->apply_categories_and_brand( $parent_id, $group );
-
-            $processed += count( $group['items'] );
-
-            // Force parent type to "variable"
-            $product = wc_get_product( $parent_id );
-            if ( $product && $product->get_type() !== 'variable' ) {
-                wp_set_object_terms( $parent_id, 'variable', 'product_type', false );
-            }
-        }
-
-        return $processed;
-    }
-
-    /**
-     * Backwards compatible single row import handler.
-     *
-     * Older integrations invoke import_row() directly when synchronising
-     * catalogue data. The refactored variable product workflow no longer uses
-     * this path internally, however the regression suite (and legacy installs)
-     * still rely on it. Re-introduce a lightweight implementation that keeps
-     * the public surface stable while delegating to modern helpers wherever
-     * possible.
-     *
-     * @param array $data          Normalised SoftOne item data.
-     * @param int   $run_timestamp Sync timestamp.
-     *
-     * @throws \RuntimeException When WooCommerce product APIs are unavailable.
-     *
-     * @return string created|updated|skipped
-     */
-    protected function import_row( array $data, $run_timestamp ) {
-        if ( ! class_exists( 'WC_Product' ) ) {
-            throw new \RuntimeException( __( 'WooCommerce is required to sync items.', 'softone-woocommerce-integration' ) );
-        }
-
-        $normalized = $this->normalize_legacy_row( $data );
-
-        $mtrl         = isset( $normalized['mtrl'] ) ? (string) $normalized['mtrl'] : '';
-        $sku_requested = $this->determine_sku( $normalized );
-
-        if ( '' === $mtrl && '' === $sku_requested ) {
-            throw new \RuntimeException( __( 'Unable to determine a product identifier for the imported row.', 'softone-woocommerce-integration' ) );
-        }
-
-        $product_id = $this->find_existing_product( $sku_requested, $mtrl );
-        $is_new     = ( $product_id <= 0 );
-
-        $product = $is_new ? new WC_Product_Simple() : wc_get_product( $product_id );
-
-        if ( ! $product ) {
-            throw new \RuntimeException( __( 'Failed to load the matching WooCommerce product.', 'softone-woocommerce-integration' ) );
-        }
-
-        if ( $is_new && method_exists( $product, 'set_status' ) ) {
-            $product->set_status( 'publish' );
-        }
-
-        $payload_hash = $this->build_payload_hash( $normalized );
-        $category_ids = $this->prepare_category_ids( $normalized );
-
-        if ( ! $is_new ) {
-            $existing_hash    = (string) get_post_meta( $product_id, self::META_PAYLOAD_HASH, true );
-            $categories_match = $this->product_categories_match( $product_id, $category_ids );
-
-            if ( ! $this->force_taxonomy_refresh && '' !== $existing_hash && $existing_hash === $payload_hash && $categories_match ) {
                 return 'skipped';
             }
+
+            $this->log(
+                'debug',
+                'Continuing product import to refresh mismatched category assignments despite a matching payload hash.',
+                array(
+                    'product_id'             => $product_id,
+                    'sku'                    => $sku_requested,
+                    'mtrl'                   => $mtrl,
+                    'payload_hash'           => $payload_hash,
+                    'existing_hash'          => $existing_hash,
+                    'category_ids'           => $category_ids,
+                    'categories_match'       => false,
+                    'force_taxonomy_refresh' => (bool) $this->force_taxonomy_refresh,
+                )
+            );
+        }
+    }
+
+    // ---------- PRODUCT NAME ----------
+    $name              = $this->get_value( $data, array( 'varchar02','desc', 'description', 'code' ) );
+    $derived_colour    = '';
+    $normalized_name   = '';
+    $fallback_metadata = array();
+
+    if ( '' !== $name ) {
+        list( $normalized_name, $derived_colour ) = $this->split_product_name_and_colour( $name );
+        if ( '' === $normalized_name ) {
+            $normalized_name = $name;
+        }
+        if ( '' !== $normalized_name ) {
+            $product->set_name( $normalized_name );
+        }
+    }
+
+    if ( '' !== $derived_colour ) {
+        $fallback_metadata['colour'] = $derived_colour;
+    }
+
+    // ---------- DESCRIPTIONS ----------
+    $description = $this->get_value(
+        $data,
+        array( 'long_description', 'longdescription', 'cccsocylodes', 'remarks', 'remark', 'notes' )
+    );
+    if ( '' !== $description ) {
+        $product->set_description( $description );
+    }
+
+    $short_description = $this->get_value( $data, array( 'short_description', 'cccsocyshdes' ) );
+    if ( '' !== $short_description ) {
+        $product->set_short_description( $short_description );
+    }
+
+    // ---------- PRICE ----------
+    $price = $this->get_value( $data, array( 'retailprice' ) );
+    if ( '' !== $price ) {
+        $product->set_regular_price( wc_format_decimal( $price ) );
+    }
+
+    // ---------- SKU (ensure unique, but if someone else owns it, we UPDATE THAT product) ----------
+    $extra_suffixes = array();
+    if ( '' !== $derived_colour && function_exists( 'sanitize_title' ) ) {
+        $extra_suffixes[] = sanitize_title( $derived_colour );
+    }
+
+    // If we’re updating a different product but the SKU belongs to another product, switch to that product to avoid duplicates
+    if ( '' !== $sku_requested && $is_new && $existing_by_sku_id > 0 ) {
+        $product     = wc_get_product( $existing_by_sku_id );
+        $product_id  = $existing_by_sku_id;
+        $is_new      = false;
+        $this->log( 'info', 'Reusing existing product by SKU to prevent duplication.', array( 'product_id' => $product_id, 'sku' => $sku_requested ) );
+    }
+
+    // Now set or adjust SKU on this product
+    $effective_sku = $this->ensure_unique_sku(
+        $sku_requested,
+        $is_new ? 0 : (int) $product_id,
+        $extra_suffixes
+    );
+
+    if ( '' !== $effective_sku ) {
+        $product->set_sku( $effective_sku );
+    } else {
+        $this->log(
+            'warning',
+            'SKU left empty after failing to find a unique variant.',
+            array(
+                'requested_sku' => $sku_requested,
+                'product_id'    => $is_new ? 0 : (int) $product_id,
+                'suffixes'      => $extra_suffixes,
+            )
+        );
+    }
+
+    // ---------- STOCK ----------
+    $stock_quantity = $this->get_value( $data, array( 'stock_qty', 'qty1' ) );
+    if ( '' !== $stock_quantity ) {
+        $stock_amount = wc_stock_amount( $stock_quantity );
+        if ( 0 === $stock_amount && softone_wc_integration_should_force_minimum_stock() ) {
+            $stock_amount = 1;
         }
 
-        $name = $this->first_non_empty( $normalized, [ 'varchar02', 'desc', 'description', 'code', 'name' ] );
-        if ( null !== $name && method_exists( $product, 'set_name' ) ) {
-            $product->set_name( $name );
-        }
+        $product->set_manage_stock( true );
+        $product->set_stock_quantity( $stock_amount );
 
-        $description = $this->first_non_empty( $normalized, [ 'long_description', 'longdescription', 'remarks', 'remark', 'notes' ] );
-        if ( null !== $description && method_exists( $product, 'set_description' ) ) {
-            $product->set_description( $description );
-        }
+        $should_backorder = softone_wc_integration_should_backorder_out_of_stock();
 
-        $short_description = $this->first_non_empty( $normalized, [ 'short_description', 'short_desc' ] );
-        if ( null !== $short_description && method_exists( $product, 'set_short_description' ) ) {
-            $product->set_short_description( $short_description );
-        }
-
-        $price = $this->first_non_empty( $normalized, [ 'retailprice', 'price' ] );
-        if ( null !== $price && method_exists( $product, 'set_regular_price' ) ) {
-            $product->set_regular_price( wc_format_decimal( $price ) );
-        }
-
-        $stock_quantity = $this->first_non_empty( $normalized, [ 'stock_qty', 'qty1', 'qty' ] );
-        if ( null !== $stock_quantity && method_exists( $product, 'set_manage_stock' ) ) {
-            $amount = wc_stock_amount( $stock_quantity );
-            $product->set_manage_stock( true );
-            if ( method_exists( $product, 'set_stock_quantity' ) ) {
-                $product->set_stock_quantity( $amount );
+        if ( $should_backorder && $stock_amount <= 0 && method_exists( $product, 'set_backorders' ) ) {
+            $product->set_backorders( 'notify' );
+            $product->set_stock_status( 'onbackorder' );
+        } else {
+            if ( method_exists( $product, 'set_backorders' ) ) {
+                $product->set_backorders( 'no' );
             }
-            if ( method_exists( $product, 'set_stock_status' ) ) {
-                $product->set_stock_status( $amount > 0 ? 'instock' : 'outofstock' );
+            $product->set_stock_status( $stock_amount > 0 ? 'instock' : 'outofstock' );
+        }
+    }
+
+    // ---------- CATEGORIES ----------
+    if ( ! empty( $category_ids ) ) {
+        $product->set_category_ids( $category_ids );
+    }
+
+    // ---------- ATTRIBUTES ----------
+    $brand_value           = trim( $this->get_value( $data, array( 'brand_name', 'brand' ) ) );
+    $attribute_assignments = $this->prepare_attribute_assignments( $data, $product, $fallback_metadata );
+
+    if ( ! empty( $attribute_assignments['attributes'] ) ) {
+        $product->set_attributes( $attribute_assignments['attributes'] );
+    } elseif ( empty( $attribute_assignments['attributes'] ) && $is_new ) {
+        $product->set_attributes( array() );
+    }
+
+    // ---------- SAVE FIRST ----------
+    $product_id = $product->save();
+    if ( ! $product_id ) {
+        throw new Exception( __( 'Unable to save the WooCommerce product.', 'softone-woocommerce-integration' ) );
+    }
+
+    // If we learned MTRL during import, ensure it’s set on reused products too
+    if ( $mtrl ) {
+        update_post_meta( $product_id, self::META_MTRL, $mtrl );
+    }
+
+    // ---------- IMAGES (after save) ----------
+    $sku_for_images = ( '' !== $effective_sku ? $effective_sku : $sku_requested );
+    if ( ! empty( $sku_for_images ) && class_exists( 'Softone_Sku_Image_Attacher' ) ) {
+        \Softone_Sku_Image_Attacher::attach_gallery_from_sku( (int) $product_id, (string) $sku_for_images );
+    }
+
+    // ---------- CATEGORY TERMS ----------
+    if ( ! empty( $category_ids ) && function_exists( 'taxonomy_exists' ) && taxonomy_exists( 'product_cat' ) && function_exists( 'wp_set_object_terms' ) ) {
+        $category_assignment = wp_set_object_terms( $product_id, $category_ids, 'product_cat' );
+
+        if ( is_wp_error( $category_assignment ) ) {
+            $this->log(
+                'error',
+                'SOFTONE_CAT_SYNC_009 Failed to assign product categories.',
+                array(
+                    'product_id'    => $product_id,
+                    'category_ids'  => $category_ids,
+                    'error_message' => $category_assignment->get_error_message(),
+                )
+            );
+        }
+    }
+
+    // ---------- META ----------
+    update_post_meta( $product_id, self::META_PAYLOAD_HASH, $payload_hash );
+    if ( is_numeric( $run_timestamp ) ) {
+        update_post_meta( $product_id, self::META_LAST_SYNC, (int) $run_timestamp );
+    }
+
+    // ---------- ATTRIBUTE TERMS (taxonomies) ----------
+    foreach ( $attribute_assignments['terms'] as $taxonomy => $term_ids ) {
+        $normalized_term_ids = array();
+        foreach ( (array) $term_ids as $term_id ) {
+            $term_id = (int) $term_id;
+            if ( $term_id > 0 ) {
+                $normalized_term_ids[] = $term_id;
             }
         }
-
-        if ( method_exists( $product, 'set_category_ids' ) ) {
-            $product->set_category_ids( $category_ids );
+        if ( empty( $normalized_term_ids ) ) {
+            continue;
         }
 
-        $effective_sku = $this->ensure_unique_sku( $sku_requested, $is_new ? 0 : (int) $product_id );
-        if ( '' !== $effective_sku && method_exists( $product, 'set_sku' ) ) {
-            $product->set_sku( $effective_sku );
+        if ( function_exists( 'taxonomy_exists' ) && ! taxonomy_exists( $taxonomy ) ) {
+            $this->log(
+                'error',
+                'SOFTONE_ATTR_SYNC_000 Missing attribute taxonomy before assignment.',
+                array(
+                    'product_id'      => $product_id,
+                    'taxonomy'        => $taxonomy,
+                    'term_ids'        => $normalized_term_ids,
+                    'attribute_value' => isset( $attribute_assignments['values'][ $taxonomy ] ) ? $attribute_assignments['values'][ $taxonomy ] : '',
+                )
+            );
+            continue;
         }
 
-        $attribute_assignments = $this->prepare_attribute_assignments( $normalized, $product, array() );
-        if ( method_exists( $product, 'set_attributes' ) ) {
-            if ( ! empty( $attribute_assignments['attributes'] ) ) {
-                $product->set_attributes( $attribute_assignments['attributes'] );
-            } elseif ( $is_new ) {
-                $product->set_attributes( array() );
+        wp_set_object_terms( $product_id, $normalized_term_ids, $taxonomy );
+    }
+
+    // ---------- CLEAR TAXONOMIES ----------
+    foreach ( $attribute_assignments['clear'] as $taxonomy ) {
+        if ( '' === $taxonomy ) { continue; }
+        wp_set_object_terms( $product_id, array(), $taxonomy );
+    }
+
+    // ---------- BRAND (attribute + WooCommerce Brands taxonomy) ----------
+    $this->assign_brand_term( $product_id, $brand_value );               // attribute pa_brand
+    $this->assign_product_brand_term( $product_id, $brand_value );       // taxonomy product_brand
+
+    $action = $is_new ? 'created' : 'updated';
+    $this->log(
+        'info',
+        sprintf( 'Product %s via Softone sync.', $action ),
+        array(
+            'product_id' => $product_id,
+            'sku'        => $sku_for_images,
+            'mtrl'       => $mtrl,
+            'timestamp'  => $run_timestamp,
+        )
+    );
+
+    return $action;
+}
+
+
+
+        /** @return int */
+        protected function handle_stale_products( $run_timestamp ) {
+            if ( ! is_numeric( $run_timestamp ) || $run_timestamp <= 0 ) {
+                return 0;
             }
-        }
 
-        if ( method_exists( $product, 'save' ) ) {
-            $product_id = (int) $product->save();
-        }
+            $action = apply_filters( 'softone_wc_integration_stale_item_action', 'stock_out' );
+            if ( ! in_array( $action, array( 'draft', 'stock_out' ), true ) ) {
+                $action = 'stock_out';
+            }
 
-        if ( $product_id <= 0 ) {
-            throw new \RuntimeException( __( 'Unable to save the WooCommerce product.', 'softone-woocommerce-integration' ) );
-        }
+            $batch_size = (int) apply_filters( 'softone_wc_integration_stale_item_batch_size', 50 );
+            if ( $batch_size <= 0 ) {
+                $batch_size = 50;
+            }
 
-        if ( '' !== $mtrl ) {
-            update_post_meta( $product_id, self::META_MTRL, $mtrl );
-        }
+            $processed = 0;
 
-        update_post_meta( $product_id, self::META_PAYLOAD_HASH, $payload_hash );
-        if ( is_numeric( $run_timestamp ) ) {
-            update_post_meta( $product_id, self::META_LAST_SYNC, (int) $run_timestamp );
-        }
-
-        if ( ! empty( $category_ids ) && function_exists( 'wp_set_object_terms' ) ) {
-            $assignment = wp_set_object_terms( $product_id, $category_ids, 'product_cat' );
-            if ( is_wp_error( $assignment ) ) {
-                $this->log(
-                    'error',
-                    'Failed to assign product categories during Softone legacy import.',
+            do {
+                $query = new WP_Query(
                     array(
-                        'product_id'    => $product_id,
-                        'category_ids'  => $category_ids,
-                        'error_message' => $assignment->get_error_message(),
+                        'post_type'      => 'product',
+                        'post_status'    => 'any',
+                        'fields'         => 'ids',
+                        'posts_per_page' => $batch_size,
+                        'orderby'        => 'ID',
+                        'order'          => 'ASC',
+                        'meta_query'     => array(
+                            'relation' => 'AND',
+                            array(
+                                'key'     => self::META_MTRL,
+                                'compare' => 'EXISTS',
+                            ),
+                            array(
+                                'relation' => 'OR',
+                                array(
+                                    'key'     => self::META_LAST_SYNC,
+                                    'compare' => 'NOT EXISTS',
+                                ),
+                                array(
+                                    'key'     => self::META_LAST_SYNC,
+                                    'value'   => (int) $run_timestamp,
+                                    'type'    => 'NUMERIC',
+                                    'compare' => '<',
+                                ),
+                            ),
+                        ),
+                    )
+                );
+
+                if ( ! $query->have_posts() ) {
+                    wp_reset_postdata();
+                    break;
+                }
+
+                foreach ( $query->posts as $product_id ) {
+                    $processed++;
+
+                    $product = wc_get_product( $product_id );
+                    if ( ! $product ) {
+                        $this->log( 'warning', 'Unable to load product while marking as stale.', array( 'product_id' => $product_id ) );
+                        update_post_meta( $product_id, self::META_LAST_SYNC, (int) $run_timestamp );
+                        continue;
+                    }
+
+                    if ( 'draft' === $action ) {
+                        if ( 'draft' !== $product->get_status() ) {
+                            $product->set_status( 'draft' );
+                        }
+                    } else {
+                        if ( 'publish' !== $product->get_status() ) {
+                            $product->set_status( 'publish' );
+                        }
+                        $product->set_stock_status( 'outofstock' );
+                    }
+
+                    $product->save();
+                    // --- Attach images based on SKU ---
+                    if ( ! empty( $sku ) ) {
+                    Softone_Sku_Image_Attacher::attach_gallery_from_sku( (int) $product_id, (string) $sku );
+                    }
+                    update_post_meta( $product_id, self::META_LAST_SYNC, (int) $run_timestamp );
+
+                    $this->log( 'info', 'Marked product as stale following Softone sync run.', array( 'product_id' => $product_id, 'action' => $action ) );
+                }
+
+                wp_reset_postdata();
+            } while ( true );
+
+            if ( $processed > 0 ) {
+                $this->log(
+                    'notice',
+                    sprintf( 'Handled %d stale Softone products.', $processed ),
+                    array(
+                        'action'     => $action,
+                        'timestamp'  => $run_timestamp,
+                        'batch_size' => $batch_size,
                     )
                 );
             }
+
+            return $processed;
         }
 
-        if ( ! empty( $attribute_assignments['terms'] ) && function_exists( 'wp_set_object_terms' ) ) {
-            foreach ( $attribute_assignments['terms'] as $taxonomy => $term_ids ) {
-                if ( empty( $term_ids ) ) {
-                    continue;
+        /** @return string */
+        protected function determine_sku( array $data ) {
+            $candidates = array( 'sku', 'barcode', 'code' );
+            foreach ( $candidates as $key ) {
+                if ( isset( $data[ $key ] ) && '' !== trim( (string) $data[ $key ] ) ) {
+                    return (string) $data[ $key ];
                 }
-
-                wp_set_object_terms( $product_id, array_map( 'intval', (array) $term_ids ), $taxonomy );
             }
+            return '';
         }
 
-        if ( ! empty( $attribute_assignments['clear'] ) && function_exists( 'wp_set_object_terms' ) ) {
-            foreach ( $attribute_assignments['clear'] as $taxonomy ) {
-                if ( '' === $taxonomy ) {
-                    continue;
+        /**
+         * Ensure a unique SKU across the catalog.
+         *
+         * Strategy:
+         *  - If $base_sku is unused or used by $current_product_id, keep it.
+         *  - Else try `$base_sku-<suffixParts>` if provided (e.g. colour), then increment `-2`, `-3`, ...
+         *  - After max attempts, return '' (leave SKU empty, valid in WC).
+         *
+         * @param string $base_sku
+         * @param int    $current_product_id
+         * @param array  $extra_suffix_parts e.g. ['red']
+         * @return string
+         */
+        protected function ensure_unique_sku( $base_sku, $current_product_id = 0, array $extra_suffix_parts = array() ) {
+            $base_sku = trim( (string) $base_sku );
+            if ( '' === $base_sku ) {
+                return '';
+            }
+
+            // Base free or belongs to the same product?
+            if ( ! $this->sku_taken_by_other( $base_sku, (int) $current_product_id ) ) {
+                return $base_sku;
+            }
+
+            // Try with suffix parts (e.g., colour)
+            $suffix = '';
+            $parts  = array();
+            foreach ( $extra_suffix_parts as $p ) {
+                $p = trim( (string) $p );
+                if ( '' !== $p ) { $parts[] = $p; }
+            }
+            if ( ! empty( $parts ) ) {
+                $suffix = '-' . implode( '-', $parts );
+            }
+
+            $candidate  = $base_sku . $suffix;
+            $max_checks = (int) apply_filters( 'softone_wc_integration_sku_unique_attempts', 100 );
+
+            if ( $this->sku_taken_by_other( $candidate, (int) $current_product_id ) ) {
+                $idx = 2;
+                while ( $this->sku_taken_by_other( $candidate, (int) $current_product_id ) && $idx <= $max_checks ) {
+                    $candidate = $base_sku . $suffix . '-' . $idx;
+                    $idx++;
                 }
-
-                wp_set_object_terms( $product_id, array(), $taxonomy );
             }
+
+            if ( $this->sku_taken_by_other( $candidate, (int) $current_product_id ) ) {
+                // Still taken; leave empty.
+                return '';
+            }
+
+            return $candidate;
         }
 
-        $brand_value = $this->first_non_empty( $normalized, [ 'brand_name', 'brand' ] );
-        if ( null !== $brand_value ) {
-            $this->assign_brand_term( $product_id, $brand_value );
-            $this->assign_product_brand_term( $product_id, $brand_value );
+        /**
+         * Check if SKU belongs to someone else (not the current product).
+         *
+         * @param string $sku
+         * @param int    $current_product_id
+         * @return bool
+         */
+        protected function sku_taken_by_other( $sku, $current_product_id = 0 ) {
+            $sku = trim( (string) $sku );
+            if ( '' === $sku ) {
+                return false;
+            }
+
+            $owner_id = function_exists( 'wc_get_product_id_by_sku' ) ? (int) wc_get_product_id_by_sku( $sku ) : 0;
+            if ( ! $owner_id ) {
+                return false;
+            }
+
+            $current_product_id = (int) $current_product_id;
+            return $current_product_id <= 0 || $owner_id !== $current_product_id;
         }
+/** @return int */
+protected function find_existing_product( $sku, $mtrl ) {
+    global $wpdb;
 
-        $action = $is_new ? 'created' : 'updated';
+    // 1) Prefer SKU match first to avoid duplicate products when MTRL is missing/empty
+    $sku = trim( (string) $sku );
+    if ( '' !== $sku && function_exists( 'wc_get_product_id_by_sku' ) ) {
+        $by_sku = (int) wc_get_product_id_by_sku( $sku );
+        if ( $by_sku > 0 ) {
+            return $by_sku;
+        }
+    }
 
-        $this->log(
-            'info',
-            sprintf( 'Product %s via Softone legacy import.', $action ),
-            array(
-                'product_id' => $product_id,
-                'sku'        => $effective_sku ?: $sku_requested,
-                'mtrl'       => $mtrl,
-                'timestamp'  => $run_timestamp,
-            )
+    // 2) Fallback to Softone MTRL meta match
+    $mtrl = trim( (string) $mtrl );
+    if ( '' !== $mtrl ) {
+        $query = $wpdb->prepare(
+            "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s LIMIT 1",
+            self::META_MTRL,
+            $mtrl
         );
-
-        return $action;
-    }
-
-    protected function upsert_variable_parent( array $group ) : int {
-        $title = $group['title'];
-        $code  = $group['code'];
-
-        $existing = $this->find_product_by_meta( self::META_SOFTONE_CODE, $code );
-        $post_id  = $existing ?: wc_get_product_id_by_sku( $code );
-
-        if ( ! $post_id ) {
-            $post_id = wp_insert_post( [
-                'post_title'   => wp_strip_all_tags( $title ),
-                'post_status'  => 'publish',
-                'post_type'    => 'product',
-                'post_content' => '',
-            ] );
-        }
-
-        if ( ! $post_id || is_wp_error( $post_id ) ) {
-            return 0;
-        }
-
-        wp_set_object_terms( $post_id, 'variable', 'product_type', false );
-
-        update_post_meta( $post_id, self::META_SOFTONE_CODE, $code );
-        update_post_meta( $post_id, self::META_LAST_SYNC, current_time( 'mysql' ) );
-
-        $product = wc_get_product( $post_id );
-        if ( $product ) {
-            if ( ! $product->get_sku() ) {
-                $product->set_sku( $code ); // parent SKU = CODE
-            }
-            $product->save();
-        }
-
-        return (int) $post_id;
-    }
-
-    protected function attach_parent_colour_attribute( int $parent_id, array $colours ) {
-        $colours = array_filter( array_map( 'trim', $colours ) );
-        $colours = array_unique( $colours );
-
-        $taxonomy = 'pa_colour';
-        $this->ensure_colour_taxonomy();
-
-        $term_slugs = [];
-        foreach ( $colours as $c ) {
-            $term = $this->get_or_create_term( $taxonomy, $c );
-            if ( $term && ! is_wp_error( $term ) ) {
-                $term_slugs[] = $term['slug'];
-            }
-        }
-
-        $product = wc_get_product( $parent_id );
-        if ( ! $product ) return;
-
-        $attributes = $product->get_attributes();
-        $tax_obj    = wc_get_attribute_taxonomy_by_name( $taxonomy );
-
-        $attr = new WC_Product_Attribute();
-        $attr->set_id( (int) ( $tax_obj ? $tax_obj->attribute_id : 0 ) );
-        $attr->set_name( $taxonomy );
-        $attr->set_options( $term_slugs );
-        $attr->set_visible( true );
-        $attr->set_variation( true );
-
-        $attributes[ $taxonomy ] = $attr;
-        $product->set_attributes( $attributes );
-        $product->save();
-
-        if ( ! empty( $term_slugs ) ) {
-            wp_set_object_terms( $parent_id, $term_slugs, $taxonomy, false );
+        $found = $wpdb->get_var( $query );
+        if ( $found ) {
+            return (int) $found;
         }
     }
 
-    protected function upsert_colour_variation( int $parent_id, array $item ) {
-        $taxonomy   = 'pa_colour';
-        $colour_raw = $item['colour'] ?: 'N/A';
-        $colour     = $this->normalize_colour_name( $colour_raw );
-        $term       = $this->get_or_create_term( $taxonomy, $colour );
-        if ( ! $term || is_wp_error( $term ) ) return;
+    return 0;
+}
 
-        $variation_id = $this->find_existing_variation( $parent_id, $taxonomy, $term['slug'] );
-        if ( ! $variation_id ) {
-            $variation_id = wp_insert_post( [
-                'post_title'  => get_the_title( $parent_id ) . ' – ' . $colour,
-                'post_name'   => sanitize_title( get_the_title( $parent_id ) . ' ' . $colour ),
-                'post_status' => 'publish',
-                'post_parent' => $parent_id,
-                'post_type'   => 'product_variation',
-                'menu_order'  => 0,
-            ] );
-        }
-        if ( ! $variation_id || is_wp_error( $variation_id ) ) return;
 
-        update_post_meta( $variation_id, 'attribute_' . $taxonomy, $term['slug'] );
-
-        $v = new WC_Product_Variation( $variation_id );
-
-        if ( ! empty( $item['sku'] ) && $v->get_sku() !== $item['sku'] ) {
-            $v->set_sku( $item['sku'] );
-        }
-
-        if ( isset( $item['price'] ) && $item['price'] !== null ) {
-            $v->set_regular_price( (string) $item['price'] );
-        }
-
-        if ( $item['qty'] === null ) {
-            $v->set_manage_stock( false );
-            $v->set_stock_status( 'instock' );
-        } else {
-            $v->set_manage_stock( true );
-            $v->set_stock_quantity( max( 0, (int) round( $item['qty'] ) ) );
-            $v->set_stock_status( ( (float) $item['qty'] ) > 0 ? 'instock' : 'outofstock' );
-        }
-
-        $v->save();
-
-        if ( ! empty( $item['barcode'] ) ) {
-            update_post_meta( $variation_id, self::META_BARCODE, $item['barcode'] );
-        }
-        if ( ! empty( $item['mtrl'] ) ) {
-            update_post_meta( $variation_id, self::META_MTRL, $item['mtrl'] );
-        }
-        update_post_meta( $variation_id, self::META_LAST_SYNC, current_time( 'mysql' ) );
-    }
-
-    protected function apply_categories_and_brand( int $parent_id, array $group ) {
-        $cat  = trim( (string) $group['category_name'] );
-        $sub  = trim( (string) $group['subcategory_name'] );
-        $cats = array_filter( [ $cat, $sub ] );
-
-        if ( ! empty( $cats ) ) {
-            $term_ids = [];
-            foreach ( $cats as $label ) {
-                $term = term_exists( $label, 'product_cat' );
-                if ( ! $term ) {
-                    $term = wp_insert_term( $label, 'product_cat' );
-                }
-                if ( $term && ! is_wp_error( $term ) ) {
-                    $term_ids[] = (int) ( is_array( $term ) ? $term['term_id'] : $term );
+        /** @return bool */
+        protected function product_categories_match( $product_id, array $category_ids ) {
+            $normalized_target_ids = array();
+            foreach ( (array) $category_ids as $category_id ) {
+                $category_id = (int) $category_id;
+                if ( $category_id > 0 ) {
+                    $normalized_target_ids[] = $category_id;
                 }
             }
-            if ( ! empty( $term_ids ) ) {
-                wp_set_object_terms( $parent_id, $term_ids, 'product_cat', false );
+            sort( $normalized_target_ids );
+            $normalized_target_ids = array_values( array_unique( $normalized_target_ids ) );
+
+            if ( $product_id <= 0 ) { return false; }
+            if ( ! function_exists( 'taxonomy_exists' ) || ! taxonomy_exists( 'product_cat' ) ) { return false; }
+            if ( ! function_exists( 'wp_get_object_terms' ) ) { return false; }
+
+            $existing_terms = wp_get_object_terms( $product_id, 'product_cat', array( 'fields' => 'ids' ) );
+            if ( is_wp_error( $existing_terms ) ) { return false; }
+
+            $normalized_existing_ids = array();
+            foreach ( (array) $existing_terms as $existing_term_id ) {
+                $existing_term_id = (int) $existing_term_id;
+                if ( $existing_term_id > 0 ) {
+                    $normalized_existing_ids[] = $existing_term_id;
+                }
             }
+            sort( $normalized_existing_ids );
+            $normalized_existing_ids = array_values( array_unique( $normalized_existing_ids ) );
+
+            return $normalized_existing_ids === $normalized_target_ids;
         }
 
-        if ( ! empty( $group['brand'] ) ) {
-            update_post_meta( $parent_id, self::META_BRAND, $group['brand'] );
-        }
-    }
+        /**
+         * Prepare a list of category IDs from the SoftOne data.
+         *
+         * @param array $data Normalised data.
+         * @return array<int>
+         */
+        protected function prepare_category_ids( array $data ) {
+            $categories = array();
 
-    /**
-     * Ensure pa_colour exists.
-     */
-    public function ensure_colour_taxonomy() {
-        $taxonomy = 'pa_colour';
-        if ( taxonomy_exists( $taxonomy ) ) {
-            return;
-        }
-        if ( function_exists( 'wc_create_attribute' ) ) {
-            $attr_id = wc_create_attribute( [
-                'name'         => 'Colour',
-                'slug'         => 'pa_colour',
-                'type'         => 'select',
-                'order_by'     => 'menu_order',
-                'has_archives' => false,
-            ] );
-            if ( ! is_wp_error( $attr_id ) ) {
-                register_taxonomy(
-                    $taxonomy,
-                    apply_filters( 'woocommerce_taxonomy_objects_' . $taxonomy, [ 'product' ] ),
-                    apply_filters( 'woocommerce_taxonomy_args_' . $taxonomy, [
-                        'labels'       => [ 'name' => __( 'Colours', 'woocommerce' ) ],
-                        'hierarchical' => false,
-                        'show_ui'      => false,
-                        'query_var'    => true,
-                        'rewrite'      => false,
-                    ] )
+            $category_name = $this->get_value(
+                $data,
+                array( 'commecategory_name', 'commercategory_name', 'commercategory', 'category_name', 'Category Name', 'Category' )
+            );
+            $subcategory_name = $this->get_value(
+                $data,
+                array( 'submecategory_name', 'subcategory_name', 'subcategory', 'Subcategory Name', 'Subcategory' )
+            );
+            $subsubcategory_name = $this->get_value(
+                $data,
+                array( 'subsubcategoy_name', 'subsubcategory_name', 'subsubcategory', 'sub_subcategory_name', 'sub_subcategory' )
+            );
+
+            $category_parent = 0;
+
+            $category_slug       = function_exists( 'sanitize_title' ) ? sanitize_title( $category_name ) : '';
+            $subcategory_slug    = function_exists( 'sanitize_title' ) ? sanitize_title( $subcategory_name ) : '';
+            $subsubcategory_slug = function_exists( 'sanitize_title' ) ? sanitize_title( $subsubcategory_name ) : '';
+
+            $category_uncategorized       = $this->evaluate_uncategorized_term( $category_name );
+            $subcategory_uncategorized    = $this->evaluate_uncategorized_term( $subcategory_name );
+            $subsubcategory_uncategorized = $this->evaluate_uncategorized_term( $subsubcategory_name );
+
+            $item_log_context = array();
+            $sku  = isset( $data['sku'] ) ? (string) $data['sku'] : '';
+            $mtrl = isset( $data['mtrl'] ) ? (string) $data['mtrl'] : '';
+            if ( '' !== $sku )  { $item_log_context['sku']  = $sku; }
+            if ( '' !== $mtrl ) { $item_log_context['mtrl'] = $mtrl; }
+
+            // Top-level
+            $category_context = array(
+                'raw_name'       => $category_name,
+                'sanitized_slug' => $category_slug,
+                'term_id'        => 0,
+                'parent_id'      => 0,
+            );
+            $category_log_context = $this->extend_log_context_with_item( $category_context, $item_log_context );
+
+            if ( '' !== $category_name && ! $this->is_numeric_term_name( $category_name ) ) {
+                $this->log( 'debug', 'SOFTONE_CAT_SYNC_002 Ensuring top-level category.', $category_log_context );
+                $category_parent = $this->ensure_term( $category_name, 'product_cat' );
+                $this->log(
+                    'debug',
+                    'SOFTONE_CAT_SYNC_002 Result for top-level category ensure.',
+                    $this->extend_log_context_with_item(
+                        array_merge( $category_context, array( 'term_id' => $category_parent ) ),
+                        $item_log_context
+                    )
                 );
-            }
-        }
-    }
-
-    protected function find_existing_variation( int $parent_id, string $taxonomy, string $term_slug ) : int {
-        $ids = get_children( [
-            'post_parent' => $parent_id,
-            'post_type'   => 'product_variation',
-            'numberposts' => -1,
-            'post_status' => [ 'publish', 'private' ],
-            'fields'      => 'ids',
-        ] );
-        if ( empty( $ids ) ) return 0;
-        foreach ( $ids as $vid ) {
-            $val = get_post_meta( $vid, 'attribute_' . $taxonomy, true );
-            if ( $val === $term_slug ) return (int) $vid;
-        }
-        return 0;
-    }
-
-    protected function get_or_create_term( string $taxonomy, string $label ) {
-        $label = $this->normalize_colour_name( $label );
-        $exists = term_exists( $label, $taxonomy );
-        if ( $exists ) {
-            $term = is_array( $exists ) ? get_term( $exists['term_id'], $taxonomy ) : get_term( (int) $exists, $taxonomy );
-        } else {
-            $term = wp_insert_term( $label, $taxonomy, [ 'slug' => sanitize_title( $label ) ] );
-            if ( ! is_wp_error( $term ) ) {
-                $term = get_term( $term['term_id'], $taxonomy );
-            }
-        }
-        if ( is_wp_error( $term ) || ! $term ) return null;
-        return [ 'term_id' => $term->term_id, 'slug' => $term->slug, 'name' => $term->name ];
-    }
-
-    protected function parse_colour_from_desc( ?string $desc ) : ?string {
-        if ( ! $desc ) return null;
-        if ( preg_match( '/\s*\|\s*([^|]+)\s*$/u', $desc, $m ) ) {
-            $colour = trim( $m[1] );
-            if ( $colour !== '' && $colour !== '-' ) {
-                return $this->normalize_colour_name( $colour );
-            }
-        }
-        return null;
-    }
-
-    protected function strip_colour_from_desc( ?string $desc ) : ?string {
-        if ( ! $desc ) return $desc;
-        return preg_replace( '/\s*\|\s*[^|]+\s*$/u', '', $desc );
-    }
-
-    protected function normalize_colour_name( string $c ) : string {
-        $c = trim( $c );
-        $map = [
-            'blk' => 'Black',
-            'black' => 'Black',
-            'denim blue' => 'Denim Blue',
-            'olive green' => 'Olive Green',
-            'sepia black' => 'Sepia Black',
-            '-' => '',
-        ];
-        $lc = function_exists('mb_strtolower') ? mb_strtolower( $c, 'UTF-8' ) : strtolower( $c );
-        if ( isset( $map[ $lc ] ) ) return $map[ $lc ];
-        if ( function_exists('mb_convert_case') ) {
-            return mb_convert_case( $c, MB_CASE_TITLE, 'UTF-8' );
-        }
-        return ucwords( strtolower( $c ) );
-    }
-
-    protected function g( array $row, string $key ) {
-        if ( isset( $row[ $key ] ) ) return $row[ $key ];
-        $alts = [
-            $key,
-            str_replace( ' ', '_', $key ),
-            str_replace( '_', ' ', $key ),
-        ];
-        foreach ( $alts as $k ) {
-            if ( isset( $row[ $k ] ) ) return $row[ $k ];
-        }
-        foreach ( $row as $k => $v ) {
-            if ( strtolower( $k ) === strtolower( $key ) ) {
-                return $v;
-            }
-        }
-        return null;
-    }
-
-    protected function parent_key( string $brand, string $title, string $code ) : string {
-        return md5( implode( '|', [ trim( $brand ), trim( $title ), trim( (string) $code ) ] ) );
-    }
-
-    protected function find_product_by_meta( string $meta_key, $meta_val ) : int {
-        if ( ! $meta_val ) return 0;
-        $q = new WP_Query( [
-            'post_type'      => 'product',
-            'posts_per_page' => 1,
-            'meta_key'       => $meta_key,
-            'meta_value'     => $meta_val,
-            'fields'         => 'ids',
-            'post_status'    => [ 'publish', 'draft', 'pending', 'private' ],
-            'no_found_rows'  => true,
-        ] );
-        if ( $q->have_posts() ) {
-            return (int) $q->posts[0];
-        }
-        return 0;
-    }
-
-    /**
-     * Locate an existing product by SKU or SoftOne MTRL metadata.
-     */
-    protected function find_existing_product( $sku, $mtrl ) {
-        $sku = trim( (string) $sku );
-        if ( '' !== $sku && function_exists( 'wc_get_product_id_by_sku' ) ) {
-            $existing = (int) wc_get_product_id_by_sku( $sku );
-            if ( $existing > 0 ) {
-                return $existing;
-            }
-        }
-
-        $mtrl = trim( (string) $mtrl );
-        if ( '' !== $mtrl ) {
-            $existing = $this->find_product_by_meta( self::META_MTRL, $mtrl );
-            if ( $existing > 0 ) {
-                return $existing;
-            }
-        }
-
-        return 0;
-    }
-
-    /**
-     * Build a payload hash used to detect identical imports.
-     */
-    protected function build_payload_hash( array $data ) : string {
-        $hash_source = $data;
-        ksort( $hash_source );
-
-        $encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $hash_source ) : json_encode( $hash_source );
-        if ( false === $encoded ) {
-            $encoded = '';
-        }
-
-        return md5( (string) $encoded );
-    }
-
-    /**
-     * Determine the preferred SKU candidate.
-     */
-    protected function determine_sku( array $data ) : string {
-        foreach ( [ 'sku', 'barcode', 'code' ] as $key ) {
-            if ( isset( $data[ $key ] ) && '' !== trim( (string) $data[ $key ] ) ) {
-                return (string) $data[ $key ];
-            }
-        }
-
-        return '';
-    }
-
-    /**
-     * Normalise category identifiers embedded in the row payload.
-     *
-     * @param array $data Normalised row payload.
-     *
-     * @return array<int>
-     */
-    protected function prepare_category_ids( array $data ) {
-        $ids = [];
-
-        if ( isset( $data['category_ids'] ) ) {
-            $ids = (array) $data['category_ids'];
-        }
-
-        $normalized = [];
-        foreach ( $ids as $id ) {
-            $id = (int) $id;
-            if ( $id > 0 ) {
-                $normalized[] = $id;
-            }
-        }
-
-        $normalized = array_values( array_unique( $normalized ) );
-
-        return $normalized;
-    }
-
-    /**
-     * Compare existing product category assignments with the target payload.
-     */
-    protected function product_categories_match( $product_id, array $category_ids ) : bool {
-        $product_id = (int) $product_id;
-        if ( $product_id <= 0 ) {
-            return false;
-        }
-
-        $target = array_values( array_unique( array_map( 'intval', array_filter( $category_ids ) ) ) );
-        sort( $target );
-
-        if ( function_exists( 'wp_get_object_terms' ) ) {
-            $existing_terms = wp_get_object_terms( $product_id, 'product_cat', [ 'fields' => 'ids' ] );
-            if ( is_wp_error( $existing_terms ) ) {
-                return false;
+                if ( $category_parent ) { $categories[] = $category_parent; }
+            } else {
+                $reason = ( '' === $category_name ) ? 'empty_name' : ( $this->is_numeric_term_name( $category_name ) ? 'numeric_name' : 'uncategorized' );
+                $skip_context = array_merge( $this->build_uncategorized_log_fields( $category_uncategorized ), array( 'reason' => $reason ) );
+                $this->log( 'debug', 'SOFTONE_CAT_SYNC_012 Skipping top-level category ensure.', $this->extend_log_context_with_item( $skip_context, $item_log_context ) );
             }
 
-            $existing = array_map( 'intval', (array) $existing_terms );
-        } elseif ( isset( $GLOBALS['softone_object_terms']['product_cat'][ $product_id ] ) ) {
-            $existing = array_map( 'intval', (array) $GLOBALS['softone_object_terms']['product_cat'][ $product_id ] );
-        } else {
-            $product = wc_get_product( $product_id );
-            if ( ! $product || ! method_exists( $product, 'get_category_ids' ) ) {
-                return false;
+            // Subcategory
+            $subcategory_parent = $category_parent;
+            $subcategory_context = array(
+                'raw_name'       => $subcategory_name,
+                'sanitized_slug' => $subcategory_slug,
+                'term_id'        => 0,
+                'parent_id'      => $subcategory_parent,
+            );
+            $subcategory_log_context = $this->extend_log_context_with_item( $subcategory_context, $item_log_context );
+
+            if ( '' !== $subcategory_name && ! $this->is_numeric_term_name( $subcategory_name ) ) {
+                $this->log( 'debug', 'SOFTONE_CAT_SYNC_002 Ensuring subcategory.', $subcategory_log_context );
+                $subcategory_parent = $this->ensure_term( $subcategory_name, 'product_cat', $subcategory_parent );
+                $this->log(
+                    'debug',
+                    'SOFTONE_CAT_SYNC_002 Result for subcategory ensure.',
+                    $this->extend_log_context_with_item(
+                        array_merge( $subcategory_context, array( 'term_id' => $subcategory_parent ) ),
+                        $item_log_context
+                    )
+                );
+                if ( $subcategory_parent ) { $categories[] = $subcategory_parent; }
+            } else {
+                $reason = ( '' === $subcategory_name ) ? 'empty_name' : ( $this->is_numeric_term_name( $subcategory_name ) ? 'numeric_name' : 'uncategorized' );
+                $skip_context = array_merge( $this->build_uncategorized_log_fields( $subcategory_uncategorized ), array( 'reason' => $reason ) );
+                $this->log( 'debug', 'SOFTONE_CAT_SYNC_012 Skipping subcategory ensure.', $this->extend_log_context_with_item( $skip_context, $item_log_context ) );
             }
 
-            $existing = array_map( 'intval', (array) $product->get_category_ids() );
+            // Sub-subcategory
+            $subsubcategory_parent = $subcategory_parent ?: $category_parent;
+            $subsubcategory_context = array(
+                'raw_name'       => $subsubcategory_name,
+                'sanitized_slug' => $subsubcategory_slug,
+                'term_id'        => 0,
+                'parent_id'      => $subsubcategory_parent,
+            );
+            $subsubcategory_log_context = $this->extend_log_context_with_item( $subsubcategory_context, $item_log_context );
+
+            if ( '' !== $subsubcategory_name && ! $this->is_numeric_term_name( $subsubcategory_name ) ) {
+                $this->log( 'debug', 'SOFTONE_CAT_SYNC_002 Ensuring sub-subcategory.', $subsubcategory_log_context );
+                $subsubcategory_parent = $this->ensure_term( $subsubcategory_name, 'product_cat', $subsubcategory_parent );
+                $this->log(
+                    'debug',
+                    'SOFTONE_CAT_SYNC_002 Result for sub-subcategory ensure.',
+                    $this->extend_log_context_with_item(
+                        array_merge( $subsubcategory_context, array( 'term_id' => $subsubcategory_parent ) ),
+                        $item_log_context
+                    )
+                );
+                if ( $subsubcategory_parent ) { $categories[] = $subsubcategory_parent; }
+            } else {
+                $reason = ( '' === $subsubcategory_name ) ? 'empty_name' : ( $this->is_numeric_term_name( $subsubcategory_name ) ? 'numeric_name' : 'uncategorized' );
+                $skip_context = array_merge( $this->build_uncategorized_log_fields( $subsubcategory_uncategorized ), array( 'reason' => $reason ) );
+                $this->log( 'debug', 'SOFTONE_CAT_SYNC_012 Skipping sub-subcategory ensure.', $this->extend_log_context_with_item( $skip_context, $item_log_context ) );
+            }
+
+            $categories = array_values( array_unique( array_map( 'intval', array_filter( $categories ) ) ) );
+            return $categories;
         }
+/**
+ * Build attribute assignments for the product.
+ *
+ * - Adds hidden custom attributes:
+ *     - softone_mtrl
+ *     - related_item_mtrl
+ * - Ensures taxonomy attributes for Colour, Size, Brand (visible on frontend).
+ *
+ * @param array       $data
+ * @param WC_Product  $product
+ * @param array       $fallback_attributes e.g. ['colour' => 'Red'].
+ *
+ * @return array{attributes: array<int,WC_Product_Attribute>, terms: array, values: array, clear: array}
+ */
+protected function prepare_attribute_assignments( array $data, $product, array $fallback_attributes = array() ) {
+    $assignments = array(
+        'attributes' => array(),
+        'terms'      => array(),
+        'values'     => array(),
+        'clear'      => array(),
+    );
 
-        $existing = array_values( array_unique( $existing ) );
-        sort( $existing );
-
-        return $existing === $target;
-    }
-
-    /**
-     * Retrieve the first non-empty value from a list of candidate keys.
-     */
-    protected function first_non_empty( array $data, array $keys ) {
-        foreach ( $keys as $key ) {
-            if ( isset( $data[ $key ] ) ) {
-                $value = $data[ $key ];
-                if ( '' !== $value && null !== $value ) {
-                    return $value;
+    // ---------------- Hidden custom attribute: softone_mtrl ----------------
+    $mtrl_value = (string) $this->get_value( $data, array( 'mtrl', 'MTRL', 'mtrl_code', 'MTRL_CODE' ) );
+    $mtrl_value = trim( $mtrl_value );
+    if ( $mtrl_value !== '' && class_exists( 'WC_Product_Attribute' ) ) {
+        try {
+            $attr = new WC_Product_Attribute();
+            $attr->set_id( 0 );
+            $attr->set_name( 'softone_mtrl' );
+            $attr->set_options( array( $mtrl_value ) );
+            $attr->set_visible( false );
+            $attr->set_variation( false );
+            $assignments['attributes'][] = $attr;
+        } catch ( \Throwable $e ) {
+            if ( method_exists( $product, 'get_id' ) ) {
+                $pid = (int) $product->get_id();
+                if ( $pid > 0 ) {
+                    update_post_meta( $pid, self::META_MTRL, $mtrl_value );
                 }
             }
         }
-
-        return null;
     }
 
-    /**
-     * Ensure SKUs remain unique by appending numeric suffixes when necessary.
-     */
-    protected function ensure_unique_sku( $base_sku, $current_product_id = 0 ) : string {
-        $base_sku = trim( (string) $base_sku );
-        if ( '' === $base_sku ) {
-            return '';
-        }
-
-        if ( ! $this->sku_taken_by_other( $base_sku, $current_product_id ) ) {
-            return $base_sku;
-        }
-
-        $attempts = (int) apply_filters( 'softone_wc_integration_sku_unique_attempts', 50 );
-        $suffix   = 2;
-        $candidate = $base_sku . '-' . $suffix;
-
-        while ( $this->sku_taken_by_other( $candidate, $current_product_id ) && $suffix <= $attempts ) {
-            $suffix++;
-            $candidate = $base_sku . '-' . $suffix;
-        }
-
-        if ( $this->sku_taken_by_other( $candidate, $current_product_id ) ) {
-            return '';
-        }
-
-        return $candidate;
-    }
-
-    /**
-     * Detect when a SKU is already owned by another product.
-     */
-    protected function sku_taken_by_other( $sku, $current_product_id = 0 ) : bool {
-        $sku = trim( (string) $sku );
-        if ( '' === $sku ) {
-            return false;
-        }
-
-        if ( ! function_exists( 'wc_get_product_id_by_sku' ) ) {
-            return false;
-        }
-
-        $owner_id = (int) wc_get_product_id_by_sku( $sku );
-        if ( $owner_id <= 0 ) {
-            return false;
-        }
-
-        $current_product_id = (int) $current_product_id;
-
-        return $current_product_id <= 0 || $owner_id !== $current_product_id;
-    }
-
-    /**
-     * Normalise a colour attribute value for taxonomy usage.
-     */
-    protected function normalize_colour_value( $colour ) {
-        $colour = is_string( $colour ) ? trim( $colour ) : '';
-        if ( '' === $colour ) {
-            return '';
-        }
-
-        return $this->normalize_colour_name( $colour );
-    }
-
-    /**
-     * Resolve the colour attribute slug, preferring existing taxonomies.
-     */
-    protected function resolve_colour_attribute_slug() {
-        if ( function_exists( 'wc_attribute_taxonomy_id_by_name' ) ) {
-            if ( wc_attribute_taxonomy_id_by_name( 'colour' ) ) {
-                return 'colour';
-            }
-
-            if ( wc_attribute_taxonomy_id_by_name( 'color' ) ) {
-                return 'color';
+    // ---------------- Hidden custom attribute: related_item_mtrl ----------------
+    $related_mtrl = (string) $this->get_value( $data, array( 'related_item_mtrl', 'related_mtrl', 'rel_mtrl' ) );
+    $related_mtrl = trim( $related_mtrl );
+    if ( $related_mtrl !== '' && class_exists( 'WC_Product_Attribute' ) ) {
+        try {
+            $attr = new WC_Product_Attribute();
+            $attr->set_id( 0 );
+            $attr->set_name( 'related_item_mtrl' );
+            $attr->set_options( array( $related_mtrl ) );
+            $attr->set_visible( false );
+            $attr->set_variation( false );
+            $assignments['attributes'][] = $attr;
+        } catch ( \Throwable $e ) {
+            if ( method_exists( $product, 'get_id' ) ) {
+                $pid = (int) $product->get_id();
+                if ( $pid > 0 ) {
+                    update_post_meta( $pid, '_softone_related_item_mtrl', $related_mtrl );
+                }
             }
         }
+    }
 
+    // ---------------- Visible taxonomy attributes: Colour, Size, Brand ----------------
+    $colour_value = $this->normalize_colour_value(
+        trim( $this->get_value( $data, array( 'colour_name', 'color_name', 'colour', 'color' ) ) )
+    );
+    if ( $colour_value === '' && isset( $fallback_attributes['colour'] ) ) {
+        $colour_value = $this->normalize_colour_value( (string) $fallback_attributes['colour'] );
+    }
+
+    $size_value  = trim( $this->get_value( $data, array( 'size_name', 'size' ) ) );
+    $brand_value = trim( $this->get_value( $data, array( 'brand_name', 'brand' ) ) );
+
+    // (slug => [Label, Value, Position])
+    // For colour we resolve to pa_colour or pa_color safely
+    $colour_slug = $this->resolve_colour_attribute_slug(); // 'colour' or 'color'
+    $attribute_map = array(
+        $colour_slug => array( __( 'Colour', 'softone-woocommerce-integration' ), $colour_value, 0 ),
+        'size'       => array( __( 'Size',   'softone-woocommerce-integration' ), $size_value,   1 ),
+        'brand'      => array( __( 'Brand',  'softone-woocommerce-integration' ), $brand_value,  2 ),
+    );
+
+    foreach ( $attribute_map as $slug => $tuple ) {
+        list( $label, $value, $position ) = $tuple;
+
+        $taxonomy = function_exists( 'wc_attribute_taxonomy_name' )
+            ? wc_attribute_taxonomy_name( $slug )
+            : '';
+
+        if ( '' === $value ) {
+            if ( $taxonomy !== '' ) {
+                $assignments['clear'][] = $taxonomy;
+            }
+            continue;
+        }
+
+        $attribute_id = $this->ensure_attribute_taxonomy( $slug, $label );
+        if ( ! $attribute_id ) {
+            continue;
+        }
+
+        $term_id = $this->ensure_attribute_term( $taxonomy, $value );
+        if ( ! $term_id ) {
+            continue;
+        }
+
+        if ( class_exists( 'WC_Product_Attribute' ) ) {
+            $attr = new WC_Product_Attribute();
+            $attr->set_id( (int) $attribute_id );
+            $attr->set_name( $taxonomy );
+            $attr->set_options( array( (int) $term_id ) );
+            $attr->set_position( (int) $position );
+            $attr->set_visible( true );
+            $attr->set_variation( false );
+
+            $assignments['attributes'][]      = $attr;
+            $assignments['terms'][ $taxonomy ] = array( (int) $term_id );
+            $assignments['values'][ $taxonomy ] = $value;
+        }
+    }
+
+    return $assignments;
+}
+
+/** @return string 'colour' or 'color' */
+protected function resolve_colour_attribute_slug() {
+    // If pa_colour already exists, use 'colour'
+    if ( function_exists( 'wc_attribute_taxonomy_id_by_name' ) && wc_attribute_taxonomy_id_by_name( 'colour' ) ) {
         return 'colour';
     }
+    // If pa_color exists (some stores use US spelling), use 'color'
+    if ( function_exists( 'wc_attribute_taxonomy_id_by_name' ) && wc_attribute_taxonomy_id_by_name( 'color' ) ) {
+        return 'color';
+    }
+    // Default to creating 'colour'
+    return 'colour';
+}
 
-    /**
-     * Ensure the requested attribute taxonomy exists and return its identifier.
-     */
-    protected function ensure_attribute_taxonomy( $slug, $label ) {
-        if ( ! function_exists( 'wc_attribute_taxonomy_id_by_name' ) ) {
-            return 0;
+
+        
+        /** @return array{0:string,1:string} */
+        protected function split_product_name_and_colour( $name ) {
+            $name   = (string) $name;
+            $colour = '';
+
+            if ( '' === $name || false === strpos( $name, '|' ) ) {
+                return array( $name, $colour );
+            }
+
+            $parts = explode( '|', $name, 2 );
+
+            $clean_name = isset( $parts[0] ) ? trim( $parts[0] ) : '';
+            $suffix     = isset( $parts[1] ) ? trim( $parts[1] ) : '';
+
+            if ( '' !== $suffix ) {
+                $colour = $this->normalize_colour_value( $suffix );
+            }
+
+            return array( $clean_name, $colour );
         }
 
-        $attribute_id = (int) wc_attribute_taxonomy_id_by_name( $slug );
+        /** @return string */
+        protected function normalize_colour_value( $colour ) {
+            $colour = trim( (string) $colour );
+            if ( '' === $colour ) { return ''; }
+            if ( function_exists( 'mb_convert_case' ) ) {
+                return mb_convert_case( $colour, MB_CASE_TITLE, 'UTF-8' );
+            }
+            return ucwords( strtolower( $colour ) );
+        }
 
-        if ( $attribute_id <= 0 && function_exists( 'wc_create_attribute' ) ) {
+        /** @return int */
+        protected function ensure_attribute_taxonomy( $slug, $label ) {
+            if ( ! function_exists( 'wc_attribute_taxonomy_id_by_name' ) ) {
+                return 0;
+            }
+
+            $key = strtolower( (string) $slug );
+
+            if ( array_key_exists( $key, $this->attribute_taxonomy_cache ) ) {
+                $this->cache_stats['attribute_taxonomy_cache_hits']++;
+                $attribute_id = (int) $this->attribute_taxonomy_cache[ $key ];
+
+                if ( $attribute_id > 0 && ! $this->ensure_attribute_taxonomy_is_registered( $slug, $label ) ) {
+                    unset( $this->attribute_taxonomy_cache[ $key ] );
+                    return 0;
+                }
+                return $attribute_id;
+            }
+
+            $this->cache_stats['attribute_taxonomy_cache_misses']++;
+
+            $attribute_id = wc_attribute_taxonomy_id_by_name( $slug );
+            if ( $attribute_id ) {
+                $attribute_id = (int) $attribute_id;
+                $this->attribute_taxonomy_cache[ $key ] = $attribute_id;
+
+                if ( ! $this->ensure_attribute_taxonomy_is_registered( $slug, $label ) ) {
+                    unset( $this->attribute_taxonomy_cache[ $key ] );
+                    return 0;
+                }
+                return $attribute_id;
+            }
+
+            if ( ! function_exists( 'wc_create_attribute' ) ) {
+                return 0;
+            }
+
             $result = wc_create_attribute(
-                [
+                array(
                     'slug'         => $slug,
                     'name'         => $label,
                     'type'         => 'select',
                     'order_by'     => 'menu_order',
                     'has_archives' => false,
-                ]
+                )
             );
 
             if ( is_wp_error( $result ) ) {
-                $this->log( 'error', 'Failed to create attribute taxonomy.', [ 'slug' => $slug, 'error' => $result->get_error_message() ] );
+                $this->log( 'error', $result->get_error_message() );
                 return 0;
             }
 
             $attribute_id = (int) $result;
+            $this->cache_stats['attribute_taxonomy_created']++;
+
+            delete_transient( 'wc_attribute_taxonomies' );
+            if ( function_exists( 'wc_get_attribute_taxonomies' ) ) {
+                wc_get_attribute_taxonomies();
+            }
+
+            $this->attribute_taxonomy_cache[ $key ] = $attribute_id;
+
+            if ( ! $this->ensure_attribute_taxonomy_is_registered( $slug, $label ) ) {
+                unset( $this->attribute_taxonomy_cache[ $key ] );
+                return 0;
+            }
+
+            return $attribute_id;
         }
 
-        if ( $attribute_id > 0 && function_exists( 'wc_attribute_taxonomy_name' ) ) {
+        /** @return bool */
+        protected function ensure_attribute_taxonomy_is_registered( $slug, $label ) {
+            if ( ! function_exists( 'wc_attribute_taxonomy_name' ) ) {
+                return false;
+            }
+
             $taxonomy = wc_attribute_taxonomy_name( $slug );
-            if ( '' !== $taxonomy && function_exists( 'taxonomy_exists' ) && ! taxonomy_exists( $taxonomy ) && function_exists( 'register_taxonomy' ) ) {
-                register_taxonomy( $taxonomy, [ 'product' ], [ 'hierarchical' => false ] );
-            }
-        }
-
-        return $attribute_id;
-    }
-
-    /**
-     * Ensure an attribute term exists for the provided taxonomy.
-     */
-    protected function ensure_attribute_term( $taxonomy, $value ) {
-        if ( '' === $taxonomy ) {
-            return 0;
-        }
-
-        $normalized_value = $this->normalize_colour_value( $value );
-
-        if ( '' === $normalized_value ) {
-            return 0;
-        }
-
-        $term = false;
-        if ( function_exists( 'get_term_by' ) ) {
-            $term = get_term_by( 'name', $normalized_value, $taxonomy );
-            if ( ! $term && function_exists( 'sanitize_title' ) ) {
-                $term = get_term_by( 'slug', sanitize_title( $normalized_value ), $taxonomy );
-            }
-        }
-
-        if ( $term && ! is_wp_error( $term ) ) {
-            $term_id = (int) $term->term_id;
-
-            if ( property_exists( $term, 'name' ) && $term->name !== $normalized_value && function_exists( 'wp_update_term' ) ) {
-                wp_update_term( $term_id, $taxonomy, [ 'name' => $normalized_value ] );
+            if ( '' === $taxonomy ) {
+                return false;
             }
 
-            if ( function_exists( 'clean_term_cache' ) ) {
-                clean_term_cache( [ $term_id ], $taxonomy );
+            if ( function_exists( 'taxonomy_exists' ) && taxonomy_exists( $taxonomy ) ) {
+                return true;
             }
+
+            if ( ! function_exists( 'register_taxonomy' ) ) {
+                $this->log(
+                    'error',
+                    'Unable to register attribute taxonomy because register_taxonomy() is unavailable.',
+                    array( 'slug' => $slug, 'taxonomy' => $taxonomy )
+                );
+                return false;
+            }
+
+            register_taxonomy(
+                $taxonomy,
+                apply_filters( 'woocommerce_taxonomy_objects_' . $taxonomy, array( 'product' ) ),
+                apply_filters(
+                    'woocommerce_taxonomy_args_' . $taxonomy,
+                    array(
+                        'labels'       => array( 'name' => $label ),
+                        'hierarchical' => false,
+                        'show_ui'      => false,
+                        'query_var'    => true,
+                        'rewrite'      => false,
+                    )
+                )
+            );
+
+            if ( function_exists( 'taxonomy_exists' ) && taxonomy_exists( $taxonomy ) ) {
+                return true;
+            }
+
+            $this->log( 'error', 'Failed to register attribute taxonomy for assignment.', array( 'slug' => $slug, 'taxonomy' => $taxonomy ) );
+            return false;
+        }
+
+        /** @return int */
+        protected function ensure_attribute_term( $taxonomy, $value ) {
+            $value = trim( (string) $value );
+            if ( '' === $value ) {
+                return 0;
+            }
+
+            $key = $this->build_attribute_term_cache_key( $taxonomy, $value );
+            if ( array_key_exists( $key, $this->attribute_term_cache ) ) {
+                $this->cache_stats['attribute_term_cache_hits']++;
+                return (int) $this->attribute_term_cache[ $key ];
+            }
+
+            $this->cache_stats['attribute_term_cache_misses']++;
+
+            $term = get_term_by( 'name', $value, $taxonomy );
+            if ( $term && ! is_wp_error( $term ) ) {
+                $term_id = (int) $term->term_id;
+                $this->attribute_term_cache[ $key ] = $term_id;
+                return $term_id;
+            }
+
+            $result = wp_insert_term( $value, $taxonomy );
+            if ( is_wp_error( $result ) ) {
+                if ( 'term_exists' === $result->get_error_code() ) {
+                    $existing_term_id = $result->get_error_data();
+                    if ( is_array( $existing_term_id ) && isset( $existing_term_id['term_id'] ) ) {
+                        $existing_term_id = $existing_term_id['term_id'];
+                    }
+                    $existing_term_id = (int) $existing_term_id;
+
+                    if ( $existing_term_id > 0 ) {
+                        if ( function_exists( 'clean_term_cache' ) ) {
+                            clean_term_cache( array( $existing_term_id ), $taxonomy );
+                        }
+                        $term_object = function_exists( 'get_term' ) ? get_term( $existing_term_id, $taxonomy ) : null;
+                        $term_name   = '';
+                        if ( $term_object && ! is_wp_error( $term_object ) && isset( $term_object->name ) ) {
+                            $term_name = (string) $term_object->name;
+                        }
+                        if ( $term_name !== $value && function_exists( 'wp_update_term' ) ) {
+                            $update_result = wp_update_term( $existing_term_id, $taxonomy, array( 'name' => $value ) );
+                            if ( is_wp_error( $update_result ) ) {
+                                $this->log( 'error', $update_result->get_error_message(), array( 'taxonomy' => $taxonomy, 'term_id' => $existing_term_id ) );
+                            }
+                        }
+                        $this->attribute_term_cache[ $key ] = $existing_term_id;
+                        return $existing_term_id;
+                    }
+                }
+
+                $this->log( 'error', $result->get_error_message(), array( 'taxonomy' => $taxonomy ) );
+                $this->attribute_term_cache[ $key ] = 0;
+                return 0;
+            }
+
+            $term_id = (int) $result['term_id'];
+            $this->cache_stats['attribute_term_created']++;
+            $this->attribute_term_cache[ $key ] = $term_id;
+            return $term_id;
+        }
+
+        /** @return bool */
+        protected function is_numeric_term_name( $name ) {
+            // No longer skipping numeric names; allow SoftOne numeric codes as names.
+            return false;
+        }
+
+        /** @return bool */
+        protected function is_uncategorized_term( $name ) {
+            $analysis = $this->evaluate_uncategorized_term( $name );
+            return $analysis['is_uncategorized'];
+        }
+
+        /**
+         * @return array{
+         *   is_uncategorized: bool,
+         *   match_type: string,
+         *   sanitized_name: string,
+         *   default_category_id: int,
+         *   default_category_slug: string,
+         *   default_category_name: string
+         * }
+         */
+        protected function evaluate_uncategorized_term( $name ) {
+            $name = trim( (string) $name );
+
+            $analysis = array(
+                'is_uncategorized'      => false,
+                'match_type'            => '',
+                'sanitized_name'        => '',
+                'default_category_id'   => 0,
+                'default_category_slug' => '',
+                'default_category_name' => '',
+            );
+
+            if ( '' === $name ) {
+                return $analysis;
+            }
+
+            $analysis['sanitized_name'] = function_exists( 'sanitize_title' ) ? sanitize_title( $name ) : '';
+
+            if ( 'uncategorized' === $analysis['sanitized_name'] ) {
+                $analysis['is_uncategorized'] = true;
+                $analysis['match_type']       = 'sanitized_name';
+                return $analysis;
+            }
+
+            $default_category_id = (int) get_option( 'default_product_cat', 0 );
+            if ( $default_category_id <= 0 ) {
+                return $analysis;
+            }
+
+            $analysis['default_category_id'] = $default_category_id;
+
+            $default_category = get_term( $default_category_id, 'product_cat' );
+            if ( $default_category instanceof WP_Term ) {
+                $analysis['default_category_slug'] = $default_category->slug;
+                $analysis['default_category_name'] = $default_category->name;
+
+                if ( 'uncategorized' === $default_category->slug ) {
+                    $analysis['is_uncategorized'] = true;
+                    $analysis['match_type']       = 'default_slug';
+                    return $analysis;
+                }
+
+                if ( '' !== $analysis['sanitized_name'] && $analysis['sanitized_name'] === $default_category->slug ) {
+                    $analysis['is_uncategorized'] = true;
+                    $analysis['match_type']       = 'slug_match';
+                    return $analysis;
+                }
+
+                if ( 0 === strcasecmp( $name, $default_category->name ) ) {
+                    $analysis['is_uncategorized'] = true;
+                    $analysis['match_type']       = 'name_match';
+                    return $analysis;
+                }
+
+                return $analysis;
+            }
+
+            if ( is_wp_error( $default_category ) ) {
+                $this->log( 'debug', 'Failed to fetch default product category.', array( 'error' => $default_category ) );
+            }
+
+            return $analysis;
+        }
+
+        /** @return array<string,mixed> */
+        protected function build_uncategorized_log_fields( array $analysis ) {
+            if ( empty( $analysis['is_uncategorized'] ) ) {
+                return array();
+            }
+
+            $fields = array( 'uncategorized_match_type' => $analysis['match_type'] );
+
+            if ( '' !== $analysis['sanitized_name'] ) {
+                $fields['uncategorized_sanitized_name'] = $analysis['sanitized_name'];
+            }
+            if ( ! empty( $analysis['default_category_id'] ) ) {
+                $fields['default_category_id'] = (int) $analysis['default_category_id'];
+            }
+            if ( '' !== $analysis['default_category_slug'] ) {
+                $fields['default_category_slug'] = $analysis['default_category_slug'];
+            }
+            if ( '' !== $analysis['default_category_name'] ) {
+                $fields['default_category_name'] = $analysis['default_category_name'];
+            }
+
+            return $fields;
+        }
+
+        /** @return int */
+        protected function ensure_term( $name, $tax, $parent = 0 ) {
+            $name   = trim( (string) $name );
+            $parent = (int) $parent;
+
+            $key = $this->build_term_cache_key( $tax, $name, $parent );
+
+            if ( '' === $name ) {
+                $this->log( 'debug', 'SOFTONE_CAT_SYNC_006 Empty term name provided.', array( 'taxonomy' => $tax, 'parent_id' => $parent, 'cache_key' => $key ) );
+                return 0;
+            }
+
+            if ( array_key_exists( $key, $this->term_cache ) ) {
+                $this->cache_stats['term_cache_hits']++;
+                $cached = (int) $this->term_cache[ $key ];
+                if ( 0 === $cached ) {
+                    $this->log( 'debug', 'SOFTONE_CAT_SYNC_007 Term cache contained empty identifier.', array( 'taxonomy' => $tax, 'parent_id' => $parent, 'cache_key' => $key ) );
+                }
+                return $cached;
+            }
+
+            $this->cache_stats['term_cache_misses']++;
+
+            $sanitized_name = function_exists( 'sanitize_title' ) ? sanitize_title( $name ) : '';
+
+            $term = term_exists( $name, $tax, $parent );
+            if ( ! $term && '' !== $sanitized_name ) {
+                $term = term_exists( $sanitized_name, $tax, $parent );
+            }
+            $term_id = $this->normalize_term_identifier( $term );
+            if ( $term_id > 0 ) {
+                $this->term_cache[ $key ] = $term_id;
+                return $term_id;
+            }
+
+            $existing_term = null;
+            if ( '' !== $sanitized_name ) { $existing_term = get_term_by( 'slug', $sanitized_name, $tax ); }
+            if ( ! ( $existing_term instanceof WP_Term ) ) { $existing_term = get_term_by( 'name', $name, $tax ); }
+
+            if ( $existing_term instanceof WP_Term ) {
+                $term_id = $this->maybe_update_term_parent( $existing_term, $tax, $parent );
+                $this->term_cache[ $key ] = $term_id;
+                return $term_id;
+            }
+
+            $args = array();
+            if ( $parent ) { $args['parent'] = $parent; }
+
+            $result = wp_insert_term( $name, $tax, $args );
+            if ( is_wp_error( $result ) ) {
+                $term_id    = 0;
+                $error_code = method_exists( $result, 'get_error_code' ) ? $result->get_error_code() : '';
+                $error_data = null;
+
+                if ( method_exists( $result, 'get_error_data' ) ) {
+                    $error_data = $result->get_error_data( 'term_exists' );
+                    if ( null === $error_data ) { $error_data = $result->get_error_data(); }
+                }
+
+                if ( 'term_exists' === $error_code ) {
+                    if ( is_array( $error_data ) && isset( $error_data['term_id'] ) ) {
+                        $term_id = (int) $error_data['term_id'];
+                    } elseif ( is_numeric( $error_data ) ) {
+                        $term_id = (int) $error_data;
+                    }
+
+                    if ( $term_id > 0 && function_exists( 'get_term' ) ) {
+                        $existing_term = get_term( $term_id, $tax );
+                        if ( $existing_term instanceof WP_Term && ! is_wp_error( $existing_term ) ) {
+                            $term_id = $this->maybe_update_term_parent( $existing_term, $tax, $parent );
+                            $this->term_cache[ $key ] = $term_id;
+                            $this->log( 'debug', 'SOFTONE_CAT_SYNC_013 Re-used existing term after concurrent creation.', array( 'taxonomy' => $tax, 'parent_id' => $parent, 'cache_key' => $key, 'term_id' => $term_id, 'error_code' => $error_code ) );
+                            return $term_id;
+                        }
+                    }
+                }
+
+                if ( $term_id <= 0 ) {
+                    $term     = term_exists( $name, $tax, $parent );
+                    $term_id  = $this->normalize_term_identifier( $term );
+                    $fallback = null;
+
+                    if ( $term_id <= 0 && '' !== $sanitized_name ) {
+                        $term    = term_exists( $sanitized_name, $tax, $parent );
+                        $term_id = $this->normalize_term_identifier( $term );
+                    }
+
+                    if ( $term_id <= 0 && '' !== $sanitized_name ) {
+                        $fallback = get_term_by( 'slug', $sanitized_name, $tax );
+                    }
+                    if ( ! ( $fallback instanceof WP_Term ) ) {
+                        $fallback = get_term_by( 'name', $name, $tax );
+                    }
+
+                    if ( $fallback instanceof WP_Term ) {
+                        $term_id = $this->maybe_update_term_parent( $fallback, $tax, $parent );
+                    }
+
+                    if ( $term_id > 0 ) {
+                        $this->term_cache[ $key ] = $term_id;
+                        $this->log( 'debug', 'SOFTONE_CAT_SYNC_014 Recovered term after creation error.', array( 'taxonomy' => $tax, 'parent_id' => $parent, 'cache_key' => $key, 'term_id' => $term_id, 'error_code' => $error_code, 'error_data' => $error_data ) );
+                        return $term_id;
+                    }
+                }
+
+                $this->log(
+                    'error',
+                    'SOFTONE_CAT_SYNC_003 ' . $result->get_error_message(),
+                    array( 'taxonomy' => $tax, 'parent_id' => $parent, 'cache_key' => $key, 'error_code' => $error_code, 'error_data' => $error_data )
+                );
+
+                $this->term_cache[ $key ] = 0;
+                $this->log( 'debug', 'SOFTONE_CAT_SYNC_008 Term creation failed; returning empty identifier.', array( 'taxonomy' => $tax, 'parent_id' => $parent, 'cache_key' => $key, 'error_code' => $error_code, 'error_data' => $error_data ) );
+                return 0;
+            }
+
+            $term_id = (int) $result['term_id'];
+            $this->cache_stats['term_created']++;
+            $this->term_cache[ $key ] = $term_id;
 
             return $term_id;
         }
 
-        if ( ! function_exists( 'wp_insert_term' ) ) {
+        /** @return int */
+        protected function normalize_term_identifier( $term ) {
+            if ( is_array( $term ) && isset( $term['term_id'] ) ) {
+                return (int) $term['term_id'];
+            }
+            if ( $term instanceof WP_Term ) {
+                return (int) $term->term_id;
+            }
+            if ( $term ) {
+                return (int) $term;
+            }
             return 0;
         }
 
-        $args = [];
-        if ( function_exists( 'sanitize_title' ) ) {
-            $args['slug'] = sanitize_title( $normalized_value );
+        /** @return int */
+        protected function maybe_update_term_parent( WP_Term $term, $tax, $parent ) {
+            $parent = (int) $parent;
+
+            if ( (int) $term->parent === $parent ) {
+                return (int) $term->term_id;
+            }
+
+            $result = wp_update_term( $term->term_id, $tax, array( 'parent' => max( 0, $parent ) ) );
+            if ( is_wp_error( $result ) ) {
+                $this->log( 'error', $result->get_error_message(), array( 'taxonomy' => $tax, 'term_id' => $term->term_id ) );
+                return (int) $term->term_id;
+            }
+
+            return (int) $result['term_id'];
         }
 
-        $created = wp_insert_term( $normalized_value, $taxonomy, $args );
-
-        if ( is_wp_error( $created ) ) {
-            $this->log( 'error', 'Failed to create attribute term.', [ 'taxonomy' => $taxonomy, 'value' => $normalized_value, 'error' => $created->get_error_message() ] );
-            return 0;
+        /** @return void */
+        protected function reset_caches() {
+            $this->term_cache               = array();
+            $this->attribute_term_cache     = array();
+            $this->attribute_taxonomy_cache = array();
+            $this->cache_stats              = array(
+                'term_cache_hits'                 => 0,
+                'term_cache_misses'               => 0,
+                'term_created'                    => 0,
+                'attribute_term_cache_hits'       => 0,
+                'attribute_term_cache_misses'     => 0,
+                'attribute_term_created'          => 0,
+                'attribute_taxonomy_cache_hits'   => 0,
+                'attribute_taxonomy_cache_misses' => 0,
+                'attribute_taxonomy_created'      => 0,
+            );
         }
 
-        $term_id = (int) $created['term_id'];
-
-        if ( function_exists( 'clean_term_cache' ) ) {
-            clean_term_cache( [ $term_id ], $taxonomy );
+        /** @return string */
+        protected function build_term_cache_key( $taxonomy, $term, $parent ) {
+            return strtolower( (string) $taxonomy ) . '|' . md5( strtolower( (string) $term ) ) . '|' . (int) $parent;
         }
 
-        return $term_id;
-    }
-
-    /**
-     * Prepare legacy attribute assignments.
-     */
-    protected function prepare_attribute_assignments( array $data, $product, array $fallback_attributes = array() ) {
-        $assignments = [
-            'attributes' => [],
-            'terms'      => [],
-            'values'     => [],
-            'clear'      => [],
-        ];
-
-        $colour_value = $this->normalize_colour_value( $this->first_non_empty( $data, [ 'colour_name', 'color_name', 'colour', 'color' ] ) );
-        if ( '' === $colour_value && isset( $fallback_attributes['colour'] ) ) {
-            $colour_value = $this->normalize_colour_value( $fallback_attributes['colour'] );
+        /** @return string */
+        protected function build_attribute_term_cache_key( $taxonomy, $term ) {
+            return strtolower( (string) $taxonomy ) . '|' . md5( strtolower( (string) $term ) );
         }
 
-        $colour_slug = $this->resolve_colour_attribute_slug();
-        $taxonomy    = function_exists( 'wc_attribute_taxonomy_name' ) ? wc_attribute_taxonomy_name( $colour_slug ) : '';
-
-        if ( '' !== $colour_value && '' !== $taxonomy ) {
-            $attribute_id = $this->ensure_attribute_taxonomy( $colour_slug, __( 'Colour', 'softone-woocommerce-integration' ) );
-
-            if ( $attribute_id ) {
-                $term_id = $this->ensure_attribute_term( $taxonomy, $colour_value );
-
-                if ( $term_id && class_exists( 'WC_Product_Attribute' ) ) {
-                    $attribute = new WC_Product_Attribute();
-                    $attribute->set_id( (int) $attribute_id );
-                    $attribute->set_name( $taxonomy );
-                    $attribute->set_options( [ (int) $term_id ] );
-                    $attribute->set_position( 0 );
-                    $attribute->set_visible( true );
-                    $attribute->set_variation( false );
-
-                    $assignments['attributes'][ $taxonomy ] = $attribute;
-                    $assignments['terms'][ $taxonomy ]      = [ (int) $term_id ];
-                    $assignments['values'][ $taxonomy ]     = $colour_value;
+        /** @return string */
+        protected function get_value( array $data, array $keys ) {
+            foreach ( $keys as $key ) {
+                if ( isset( $data[ $key ] ) && '' !== trim( (string) $data[ $key ] ) ) {
+                    return (string) $data[ $key ];
                 }
             }
-        } elseif ( '' === $colour_value && '' !== $taxonomy ) {
-            $assignments['clear'][] = $taxonomy;
+            return '';
         }
 
-        return $assignments;
-    }
-
-    /**
-     * Persist brand metadata and taxonomy assignments when available.
-     */
-    protected function assign_brand_term( $product_id, $brand_value ) {
-        $product_id  = (int) $product_id;
-        $brand_value = trim( (string) $brand_value );
-
-        if ( $product_id <= 0 || '' === $brand_value ) {
-            return;
-        }
-
-        update_post_meta( $product_id, self::META_BRAND, $brand_value );
-
-        if ( ! function_exists( 'taxonomy_exists' ) || ! taxonomy_exists( 'pa_brand' ) || ! function_exists( 'wp_set_object_terms' ) ) {
-            return;
-        }
-
-        $term = get_term_by( 'name', $brand_value, 'pa_brand' );
-        if ( ! $term && function_exists( 'wp_insert_term' ) ) {
-            $created = wp_insert_term( $brand_value, 'pa_brand' );
-            if ( ! is_wp_error( $created ) ) {
-                $term = get_term( (int) $created['term_id'], 'pa_brand' );
+        /** @return array */
+        protected function extend_log_context_with_item( array $context, array $item_context ) {
+            if ( empty( $item_context ) ) {
+                return $context;
             }
+            $context['item'] = $item_context;
+            return $context;
         }
 
-        if ( $term && ! is_wp_error( $term ) ) {
-            wp_set_object_terms( $product_id, [ (int) $term->term_id ], 'pa_brand', false );
+        /** @return array<string,string> */
+        protected function get_item_log_context( array $data ) {
+            $context = array();
+
+            if ( isset( $data['mtrl'] ) ) {
+                $mtrl = trim( (string) $data['mtrl'] );
+                if ( '' !== $mtrl ) {
+                    $context['mtrl'] = $mtrl;
+                }
+            }
+
+            $sku = $this->determine_sku( $data );
+            if ( '' !== $sku ) {
+                $context['sku'] = $sku;
+            }
+
+            if ( isset( $data['code'] ) ) {
+                $code = trim( (string) $data['code'] );
+                if ( '' !== $code && ( ! isset( $context['sku'] ) || $context['sku'] !== $code ) ) {
+                    $context['code'] = $code;
+                }
+            }
+
+            $name = $this->get_value(
+                $data,
+                array( 'desc', 'description', 'item_description', 'itemname', 'name' )
+            );
+            if ( '' !== $name ) {
+                $context['name'] = $this->truncate_log_value( $name );
+            }
+
+            return $context;
         }
-    }
 
-    /**
-     * Assign WooCommerce product_brand taxonomy terms when present.
-     */
-    protected function assign_product_brand_term( $product_id, $brand_value ) {
-        $product_id  = (int) $product_id;
-        $brand_value = trim( (string) $brand_value );
+        /** @return string */
+        protected function truncate_log_value( $value, $max_length = 120 ) {
+            $value = (string) $value;
 
-        if ( $product_id <= 0 || '' === $brand_value ) {
-            return;
+            if ( $max_length <= 0 ) {
+                return $value;
+            }
+
+            if ( function_exists( 'mb_strlen' ) && function_exists( 'mb_substr' ) ) {
+                if ( mb_strlen( $value ) <= $max_length ) {
+                    return $value;
+                }
+                return rtrim( mb_substr( $value, 0, $max_length - 1 ) ) . '…';
+            }
+
+            if ( strlen( $value ) <= $max_length ) {
+                return $value;
+            }
+
+            return rtrim( substr( $value, 0, $max_length - 1 ) ) . '…';
         }
 
-        if ( ! function_exists( 'taxonomy_exists' ) || ! taxonomy_exists( 'product_brand' ) || ! function_exists( 'wp_set_object_terms' ) ) {
-            return;
+        /** @return mixed */
+        protected function prepare_api_payload_for_logging( $payload, $depth = 0 ) {
+            if ( $depth >= 4 ) {
+                return '[payload truncated due to depth limits]';
+            }
+
+            if ( is_object( $payload ) ) {
+                $payload = (array) $payload;
+            }
+
+            if ( is_array( $payload ) ) {
+                $normalized = array();
+                $count      = 0;
+                $total      = count( $payload );
+
+                foreach ( $payload as $key => $value ) {
+                    if ( $count >= 50 ) {
+                        $remaining = $total - $count;
+                        if ( $remaining > 0 ) {
+                            $normalized['__truncated__'] = sprintf( '%d additional entries truncated.', $remaining );
+                        }
+                        break;
+                    }
+
+                    $normalized[ $key ] = $this->prepare_api_payload_for_logging( $value, $depth + 1 );
+                    $count++;
+                }
+
+                return $normalized;
+            }
+
+            if ( is_string( $payload ) ) {
+                return $this->truncate_log_value( $payload, 800 );
+            }
+
+            return $payload;
         }
 
-        $term = get_term_by( 'name', $brand_value, 'product_brand' );
-        if ( ! $term && function_exists( 'wp_insert_term' ) ) {
-            $created = wp_insert_term( $brand_value, 'product_brand' );
-            if ( is_wp_error( $created ) ) {
-                $this->log( 'error', 'Failed to create product_brand term.', [ 'brand' => $brand_value, 'error' => $created->get_error_message() ] );
+        /** @return void */
+        protected function log_activity( $channel, $action, $message, array $context = array() ) {
+            if ( ! $this->activity_logger || ! method_exists( $this->activity_logger, 'log' ) ) {
+                return;
+            }
+            $this->activity_logger->log( $channel, $action, $message, $context );
+        }
+
+        /** @return WC_Logger|Psr\Log\LoggerInterface|null */
+        protected function get_default_logger() {
+            if ( function_exists( 'wc_get_logger' ) ) {
+                return wc_get_logger();
+            }
+            return null;
+        }
+
+        /** @return void */
+        protected function log( $level, $message, array $context = array() ) {
+            if ( ! $this->logger || ! method_exists( $this->logger, 'log' ) ) {
                 return;
             }
 
-            $term = get_term( (int) $created['term_id'], 'product_brand' );
+            if ( class_exists( 'WC_Logger' ) && $this->logger instanceof WC_Logger ) {
+                $context['source'] = self::LOGGER_SOURCE;
+            }
+
+            $this->logger->log( $level, $message, $context );
         }
 
-        if ( $term && ! is_wp_error( $term ) ) {
-            wp_set_object_terms( $product_id, [ (int) $term->term_id ], 'product_brand', false );
+        /** @return void */
+        protected function log_category_assignment( $product_id, array $category_ids, array $context = array() ) {
+            if ( ! $this->category_logger || ! method_exists( $this->category_logger, 'log_assignment' ) ) {
+                return;
+            }
+            $this->category_logger->log_assignment( $product_id, $category_ids, $context );
         }
+
+        /**
+         * Try to attach existing Media Library images to the product by SKU.
+         * Safe no-op if nothing is found.
+         *
+         * @param WC_Product $product
+         * @param string     $sku
+         * @return void
+         */
+        protected function assign_media_library_images( $product, $sku ) {
+            $sku = trim( (string) $sku );
+            if ( '' === $sku || ! function_exists( 'get_posts' ) ) {
+                return;
+            }
+
+            $ids = get_posts( array(
+                'post_type'      => 'attachment',
+                'post_status'    => 'inherit',
+                'posts_per_page' => 10,
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+                's'              => $sku,
+                'fields'         => 'ids',
+            ) );
+
+            if ( empty( $ids ) ) {
+                global $wpdb;
+                $like  = '%' . $wpdb->esc_like( $sku ) . '%';
+                $ids   = $wpdb->get_col(
+                    $wpdb->prepare(
+                        "SELECT ID FROM {$wpdb->posts} WHERE post_type='attachment' AND post_status='inherit' AND guid LIKE %s ORDER BY post_date_gmt DESC LIMIT 10",
+                        $like
+                    )
+                );
+            }
+
+            if ( empty( $ids ) || ! is_array( $ids ) ) {
+                return;
+            }
+
+            $ids = array_values( array_unique( array_map( 'intval', $ids ) ) );
+            $thumb_id = array_shift( $ids );
+
+            if ( $thumb_id > 0 && method_exists( $product, 'set_image_id' ) ) {
+                $product->set_image_id( $thumb_id );
+            }
+
+            if ( ! empty( $ids ) && method_exists( $product, 'set_gallery_image_ids' ) ) {
+                $product->set_gallery_image_ids( $ids );
+            }
+        }
+
+       /**
+ * Ensure a Brand attribute term exists and assign it to the product (pa_brand).
+ *
+ * @param int    $product_id
+ * @param string $brand_value
+ * @return void
+ */
+protected function assign_brand_term( $product_id, $brand_value ) {
+    $brand_value = trim( (string) $brand_value );
+    if ( $product_id <= 0 || '' === $brand_value ) {
+        return;
     }
 
-    /**
-     * Lightweight logger used by legacy paths.
-     */
-    protected function log( $level, $message, array $context = [] ) {
-        if ( is_object( $this->legacy_logger ) && method_exists( $this->legacy_logger, 'log' ) ) {
-            $this->legacy_logger->log( $level, $message, $context );
-            return;
-        }
-
-        if ( class_exists( 'Softone_Sync_Activity_Logger' ) ) {
-            $logger = new Softone_Sync_Activity_Logger();
-            $logger->log( 'item_sync', (string) $level, (string) $message, $context );
-            return;
-        }
-
-        if ( function_exists( 'error_log' ) ) {
-            $encoded_context = function_exists( 'wp_json_encode' ) ? wp_json_encode( $context ) : json_encode( $context );
-            error_log( sprintf( '[softone-item-sync:%s] %s %s', $level, $message, (string) $encoded_context ) );
-        }
+    $slug    = 'brand';
+    $label   = __( 'Brand', 'softone-woocommerce-integration' );
+    $attr_id = $this->ensure_attribute_taxonomy( $slug, $label );
+    if ( ! $attr_id || ! function_exists( 'wc_attribute_taxonomy_name' ) ) {
+        return;
     }
 
-    /**
-     * Convert incoming row data to a predictable, lower-case keyed array.
-     */
-    protected function normalize_legacy_row( array $row ) : array {
-        $normalized = [];
-
-        foreach ( $row as $key => $value ) {
-            $normalized[ strtolower( (string) $key ) ] = $value;
-        }
-
-        return $normalized;
+    $taxonomy = wc_attribute_taxonomy_name( $slug );
+    if ( '' === $taxonomy || ( function_exists( 'taxonomy_exists' ) && ! taxonomy_exists( $taxonomy ) ) ) {
+        return;
     }
 
-    /**
-     * Persist cron related log entries.
-     *
-     * @param string               $action  Log action key.
-     * @param string               $message Human readable summary.
-     * @param array<string, mixed> $context Additional context for the log entry.
-     *
-     * @return void
-     */
-    protected static function log_cron_event( $action, $message, array $context = array() ) {
-        if ( ! class_exists( 'Softone_Sync_Activity_Logger' ) ) {
-            return;
-        }
-
-        $logger = new Softone_Sync_Activity_Logger();
-        $logger->log( 'item_sync', (string) $action, (string) $message, $context );
+    $term_id = $this->ensure_attribute_term( $taxonomy, $brand_value );
+    if ( $term_id > 0 && function_exists( 'wp_set_object_terms' ) ) {
+        wp_set_object_terms( $product_id, array( (int) $term_id ), $taxonomy, false );
     }
 }
 
-endif;
+/**
+ * Assign WooCommerce Brands taxonomy (product_brand) if the taxonomy exists.
+ *
+ * @param int    $product_id
+ * @param string $brand_value
+ * @return void
+ */
+protected function assign_product_brand_term( $product_id, $brand_value ) {
+    $product_id  = (int) $product_id;
+    $brand_value = trim( (string) $brand_value );
 
-// Optional bootstrap (only if your main loader *doesn't* instantiate this):
-// if ( class_exists( 'Softone_Item_Sync' ) && ! isset( $GLOBALS['softone_item_sync'] ) ) {
-//     $GLOBALS['softone_item_sync'] = new Softone_Item_Sync();
-//     $GLOBALS['softone_item_sync']->register_hooks();
-// }
+    if ( $product_id <= 0 || '' === $brand_value ) {
+        return;
+    }
+
+    // Only if WooCommerce Brands (or equivalent) is installed
+    if ( ! function_exists( 'taxonomy_exists' ) || ! taxonomy_exists( 'product_brand' ) ) {
+        return;
+    }
+
+    // Ensure term exists (create if missing)
+    $term = get_term_by( 'name', $brand_value, 'product_brand' );
+    if ( ! $term ) {
+        $created = wp_insert_term( $brand_value, 'product_brand' );
+        if ( is_wp_error( $created ) ) {
+            $this->log( 'error', 'Failed to create product_brand term', array( 'brand' => $brand_value, 'error' => $created->get_error_message() ) );
+            return;
+        }
+        $term_id = (int) $created['term_id'];
+    } else {
+        $term_id = (int) $term->term_id;
+    }
+
+    if ( $term_id > 0 ) {
+        wp_set_object_terms( $product_id, array( $term_id ), 'product_brand', false );
+    }
+}
+
+    }
+}

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.51';
+			$this->version = '1.8.47';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 
@@ -171,9 +171,6 @@ class Softone_Woocommerce_Integration {
                  * Service class for exporting WooCommerce orders to SoftOne.
                  */
                 require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-order-sync.php';
-
-				require_once __DIR__ . '/class-softone-customer-sync.php';
-
 
                 /**
                  * Helper for dynamically populating navigation menus.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.51
+ * Version:           1.8.47
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.51' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.47' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- revert the plugin files to match commit 2ae9c8e so the legacy sync logic is restored
- bump the plugin version to 1.8.47 in the bootstrap file and core integration class
- update the readme stable tag and changelog to document the 1.8.47 release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690ca2980d548327af0802c99d3cf9f1