### PR TITLE
Handle colour variation import and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.48
+Stable tag: 1.8.49
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.49 =
+* Treat SoftOne colour placeholders such as `-` as empty so derived colours populate the `pa_colour` taxonomy.
+* Mark colour attributes as variation-enabled, convert synced products to variable products, and create a default colour variation to keep items purchasable.
 
 = 1.8.48 =
 * Ensure WooCommerce item sync detects SKU-prefixed media files even when WordPress renames uploads, promoting `_1` images to featured status and assigning remaining matches to the gallery automatically.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.48';
+                        $this->version = '1.8.49';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.48
+ * Version:           1.8.49
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.48' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.49' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';

--- a/tests/force-taxonomy-refresh-regression-test.php
+++ b/tests/force-taxonomy-refresh-regression-test.php
@@ -442,6 +442,27 @@ if ( ! function_exists( 'wp_set_object_terms' ) ) {
     }
 }
 
+if ( ! function_exists( 'wp_get_object_terms' ) ) {
+    /**
+     * Retrieve taxonomy assignments from the in-memory store.
+     *
+     * @param int    $object_id Object identifier.
+     * @param string $taxonomy  Taxonomy slug.
+     * @param array  $args      Query arguments (unused).
+     * @return array<int>
+     */
+    function wp_get_object_terms( $object_id, $taxonomy, $args = array() ) {
+        $taxonomy = (string) $taxonomy;
+        $object_id = (int) $object_id;
+
+        if ( isset( $GLOBALS['softone_object_terms'][ $taxonomy ][ $object_id ] ) ) {
+            return $GLOBALS['softone_object_terms'][ $taxonomy ][ $object_id ];
+        }
+
+        return array();
+    }
+}
+
 if ( ! function_exists( 'get_post_meta' ) ) {
     /**
      * Retrieve a value from the in-memory post meta store.
@@ -785,6 +806,15 @@ if ( ! class_exists( 'WC_Product_Attribute' ) ) {
         public function get_options() {
             return $this->options;
         }
+
+        /**
+         * Determine whether the attribute is used for variations.
+         *
+         * @return bool
+         */
+        public function get_variation() {
+            return $this->variation;
+        }
     }
 }
 
@@ -1063,6 +1093,14 @@ if ( $attribute_object->get_options() !== array( $expected_term_id ) ) {
     throw new RuntimeException( 'Prepared attribute options should include the reused colour term identifier.' );
 }
 
+if ( ! isset( $assignments['variation_taxonomies'][ $colour_taxonomy ] ) ) {
+    throw new RuntimeException( 'Colour attributes should be marked for variation handling.' );
+}
+
+if ( ! $attribute_object->get_variation() ) {
+    throw new RuntimeException( 'Colour attribute metadata should be flagged as a variation attribute.' );
+}
+
 $term = get_term( $expected_term_id, $colour_taxonomy );
 if ( ! $term || is_wp_error( $term ) ) {
     throw new RuntimeException( 'Failed to retrieve the colour term after ensuring it exists.' );
@@ -1110,6 +1148,14 @@ if ( ! isset( $alias_assignments['attributes'][ $colour_taxonomy ] ) ) {
 $alias_attribute = $alias_assignments['attributes'][ $colour_taxonomy ];
 if ( ! $alias_attribute instanceof WC_Product_Attribute ) {
     throw new RuntimeException( 'Expected a WC_Product_Attribute instance for the colour alias assignment.' );
+}
+
+if ( ! isset( $alias_assignments['variation_taxonomies'][ $colour_taxonomy ] ) ) {
+    throw new RuntimeException( 'Colour alias assignments should be marked for variation handling.' );
+}
+
+if ( ! $alias_attribute->get_variation() ) {
+    throw new RuntimeException( 'Colour alias metadata should be flagged as a variation attribute.' );
 }
 
 if ( $alias_attribute->get_options() !== array( $expected_term_id ) ) {


### PR DESCRIPTION
## Summary
- treat placeholder colour values as empty so the derived colour from the product name can populate pa_colour
- flag colour attributes for variation use, convert synced products to variable products, and create a default colour variation while updating caches
- extend regression tests and documentation, including bumping the plugin version to 1.8.49

## Testing
- php tests/force-taxonomy-refresh-regression-test.php
- php tests/menu-populator-regression-test.php
- php tests/login-handshake-test.php
- php -r "define('HOUR_IN_SECONDS', 3600); require 'tests/password-sanitization-login-test.php';"

------
https://chatgpt.com/codex/tasks/task_e_690ca6abb9c88327b7c23a454a1d0ace