### PR TITLE
Fix variation grouping fallback and bump version to 1.8.52

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.51
+Stable tag: 1.8.52
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.52 =
+* Always attach grouped variation payloads to SoftOne parent products so WooCommerce variations are generated during sync.
+* Derive colour attribute values from grouped variation metadata when explicit colour overrides are absent.
 
 = 1.8.51 =
 * Group SoftOne items connected via `related_item_mtrl` into a single variable product so Softone-defined colour siblings import as WooCommerce variations.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -663,11 +663,17 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 );
             }
 
-            if ( ! empty( $colour_values ) ) {
-                $parent_payload['__group_variations']   = array_values( $variation_records );
-                $parent_payload['__colour_values']      = array_values( $colour_values );
-                $group_context                          = isset( $primary_row['context'] ) && is_array( $primary_row['context'] ) ? $primary_row['context'] : array();
-                $parent_code                            = isset( $group_context['code'] ) ? (string) $group_context['code'] : '';
+            if ( ! empty( $variation_records ) ) {
+                $parent_payload['__group_variations'] = array_values( $variation_records );
+
+                if ( ! empty( $colour_values ) ) {
+                    $parent_payload['__colour_values'] = array_values( $colour_values );
+                }
+
+                $group_context = isset( $primary_row['context'] ) && is_array( $primary_row['context'] )
+                    ? $primary_row['context']
+                    : array();
+                $parent_code   = isset( $group_context['code'] ) ? (string) $group_context['code'] : '';
                 if ( '' === $parent_code && isset( $parent_payload['code'] ) ) {
                     $parent_code = (string) $parent_payload['code'];
                 }
@@ -1728,6 +1734,26 @@ protected function prepare_attribute_assignments( array $data, $product, array $
     if ( isset( $data['__colour_values'] ) && is_array( $data['__colour_values'] ) ) {
         foreach ( $data['__colour_values'] as $value ) {
             $normalized = $this->normalize_colour_value( (string) $value );
+            if ( '' !== $normalized ) {
+                $colour_values[] = $normalized;
+            }
+        }
+    }
+
+    if ( empty( $colour_values ) && isset( $data['__group_variations'] ) && is_array( $data['__group_variations'] ) ) {
+        foreach ( $data['__group_variations'] as $variation_payload ) {
+            if ( ! is_array( $variation_payload ) ) {
+                continue;
+            }
+
+            $label = '';
+            if ( isset( $variation_payload['colour_label'] ) ) {
+                $label = (string) $variation_payload['colour_label'];
+            } elseif ( isset( $variation_payload['color_label'] ) ) {
+                $label = (string) $variation_payload['color_label'];
+            }
+
+            $normalized = $this->normalize_colour_value( $label );
             if ( '' !== $normalized ) {
                 $colour_values[] = $normalized;
             }

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.51';
+                        $this->version = '1.8.52';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.51
+ * Version:           1.8.52
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.51' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.52' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';

--- a/tests/force-taxonomy-refresh-regression-test.php
+++ b/tests/force-taxonomy-refresh-regression-test.php
@@ -1162,5 +1162,77 @@ if ( $alias_attribute->get_options() !== array( $expected_term_id ) ) {
     throw new RuntimeException( 'Colour alias attribute options should contain the reused term identifier.' );
 }
 
+$group_attribute_sync = new Softone_Item_Sync_Attribute_Test_Double();
+
+$group_product = new WC_Product_Simple();
+$group_product->set_attributes( array() );
+
+$group_assignments = $group_attribute_sync->prepare_attribute_assignments_public(
+    array(
+        '__group_variations' => array(
+            array(
+                'colour_label' => 'Teal',
+            ),
+            array(
+                'colour_label' => 'Scarlet',
+            ),
+        ),
+    ),
+    $group_product
+);
+
+if ( ! isset( $group_assignments['variation_taxonomies'][ $colour_taxonomy ] ) ) {
+    throw new RuntimeException( 'Group variation colour labels should trigger variation taxonomy assignment.' );
+}
+
+if ( ! isset( $group_assignments['attributes'][ $colour_taxonomy ] ) ) {
+    throw new RuntimeException( 'Expected group variations to prepare colour attribute metadata.' );
+}
+
+$group_attribute = $group_assignments['attributes'][ $colour_taxonomy ];
+if ( ! $group_attribute instanceof WC_Product_Attribute ) {
+    throw new RuntimeException( 'Group variation attributes should use WC_Product_Attribute metadata.' );
+}
+
+if ( ! $group_attribute->get_variation() ) {
+    throw new RuntimeException( 'Group variation colour metadata should be flagged for variation handling.' );
+}
+
+if ( ! isset( $group_assignments['terms'][ $colour_taxonomy ] ) ) {
+    throw new RuntimeException( 'Group variations should schedule colour term assignments.' );
+}
+
+$group_term_ids = $group_assignments['terms'][ $colour_taxonomy ];
+if ( count( $group_term_ids ) !== 2 ) {
+    throw new RuntimeException( 'Expected both group colour labels to register attribute terms.' );
+}
+
+$group_term_names = array();
+foreach ( $group_term_ids as $term_id ) {
+    $term = get_term( $term_id, $colour_taxonomy );
+    if ( ! $term || is_wp_error( $term ) ) {
+        throw new RuntimeException( 'Failed to load the colour term created for group variations.' );
+    }
+    $group_term_names[] = $term->name;
+}
+
+sort( $group_term_names );
+if ( $group_term_names !== array( 'Scarlet', 'Teal' ) ) {
+    throw new RuntimeException( 'Group variation colour labels should be normalised into attribute terms.' );
+}
+
+if ( ! isset( $group_assignments['values'][ $colour_taxonomy ] ) ) {
+    throw new RuntimeException( 'Group variation attributes should include a comma-separated value summary.' );
+}
+
+if ( $group_assignments['values'][ $colour_taxonomy ] !== 'Teal, Scarlet' ) {
+    throw new RuntimeException( 'Group variation attribute values should preserve the original label order.' );
+}
+
+if ( ! isset( $group_assignments['term_slugs'][ $colour_taxonomy ]['Teal'] ) || ! isset( $group_assignments['term_slugs'][ $colour_taxonomy ]['Scarlet'] ) ) {
+    throw new RuntimeException( 'Group variation term slugs should be recorded for both colours.' );
+}
+
 echo "Taxonomy refresh regression test passed." . PHP_EOL;
 echo "Attribute term normalisation regression test passed." . PHP_EOL;
+echo "Group variation attribute fallback regression test passed." . PHP_EOL;


### PR DESCRIPTION
## Summary
- ensure grouped variation payloads are always attached so colour-based variations can be generated
- derive colour attribute values from grouped variation metadata when explicit overrides are missing and add regression coverage
- bump the plugin version to 1.8.52 and document the change in the changelog

## Testing
- php tests/force-taxonomy-refresh-regression-test.php

------
https://chatgpt.com/codex/tasks/task_e_690cb64ef6448327b53c820bca2e9780