### PR TITLE
Handle colour variations as WooCommerce variable products

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.54
+Stable tag: 1.8.55
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.55 =
+* Normalise SoftOne colour placeholders so derived shades (for example `| black`) populate the WooCommerce `pa_colour` taxonomy before the suffix is stripped from product names.
+* Convert items with colour attributes into variable products and maintain a dedicated variation per colour with synced price, stock, and SKU metadata.
 
 = 1.8.54 =
 * Re-release the plugin using the codebase from commit 5ff7c3d to undo later changes while continuing the version sequence.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.54';
+                        $this->version = '1.8.55';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.54
+ * Version:           1.8.55
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.54' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.55' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- normalise SoftOne colour values so placeholder entries fall back to the derived shade and register the `pa_colour` attribute for variation use
- convert items with colour information into WooCommerce variable products while syncing price, stock, SKU, and SoftOne MTRL meta on dedicated colour variations
- update the documented plugin version and changelog for 1.8.55

## Testing
- php -l includes/class-softone-item-sync.php
- php -l softone-woocommerce-integration.php
- php -l includes/class-softone-woocommerce-integration.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df4a0de9c83279c946171277e2154)