### PR TITLE
Add asynchronous item import UI and expand variation logging

### DIFF
--- a/admin/css/softone-woocommerce-integration-admin.css
+++ b/admin/css/softone-woocommerce-integration-admin.css
@@ -143,17 +143,20 @@
         background: #f0f6fc;
 }
 
+.softone-progress,
 .softone-delete-menu-progress {
 margin-top: 12px;
-display: none;
+display: flex;
 flex-direction: column;
 gap: 8px;
 }
 
+.softone-progress[hidden],
 .softone-delete-menu-progress[hidden] {
 display: none;
 }
 
+.softone-progress__bar,
 .softone-delete-menu-progress__bar {
 background: #dcdcde;
 border-radius: 999px;
@@ -162,6 +165,7 @@ overflow: hidden;
 position: relative;
 }
 
+.softone-progress__bar-fill,
 .softone-delete-menu-progress__bar-fill {
 background: #2271b1;
 height: 100%;
@@ -169,21 +173,25 @@ width: 0;
 transition: width 0.3s ease;
 }
 
+.softone-progress__text,
 .softone-delete-menu-progress__text {
 margin: 0;
 color: #50575e;
 }
 
-.softone-delete-menu-status {
+.softone-delete-menu-status,
+.softone-item-import-status {
 margin-top: 12px;
 padding: 12px 16px;
 }
 
-.softone-delete-menu-status[hidden] {
+.softone-delete-menu-status[hidden],
+.softone-item-import-status[hidden] {
 display: none;
 }
 
-.softone-delete-menu-form .button[disabled] {
+.softone-delete-menu-form .button[disabled],
+.softone-item-import__trigger[disabled] {
 opacity: 0.7;
 cursor: wait;
 }

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -252,6 +252,7 @@ class Softone_Woocommerce_Integration {
         $this->loader->add_action( 'admin_post_softone_wc_integration_clear_sync_activity', $plugin_admin, 'handle_clear_sync_activity' );
 $this->loader->add_action( 'admin_post_' . $plugin_admin->get_delete_main_menu_action(), $plugin_admin, 'handle_delete_main_menu' );
 $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_sync_activity_action(), $plugin_admin, 'handle_sync_activity_ajax' );
+$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_item_import_ajax_action(), $plugin_admin, 'handle_item_import_ajax' );
 $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_delete_main_menu_ajax_action(), $plugin_admin, 'handle_delete_main_menu_ajax' );
 
 }

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.61
+ * Version:           1.8.62
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.61' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.62' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- replace the manual item import forms with an AJAX-driven workflow that batches imports, streams progress updates, and surfaces a progress bar
- add backend handlers, transient state management, and localized script data to support asynchronous item imports and show updated "last run" information
- expand colour variation and attribute logging within the sync service to capture queued work, attribute usage, and saved variations, and bump the plugin version

## Testing
- php -l includes/class-softone-item-sync.php
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l softone-woocommerce-integration.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691214e2b12c83279dd2c141e03cba71)