### PR TITLE
Improve attribute sync logging and bump version to 1.8.63

### DIFF
--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.62
+ * Version:           1.8.63
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.62' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.63' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add extensive debug logging around attribute preparation, taxonomy/term creation, and variation handling to aid troubleshooting
- initialize the colour taxonomy variable before use to avoid undefined notices when WooCommerce helper functions are unavailable
- update the plugin version to 1.8.63 to reflect the logging improvements and bug fix

## Testing
- php -l includes/class-softone-item-sync.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69121cb13c6c8327b306f6680618a03f)