### PR TITLE
Queue colour variation sync when refreshing related children

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.65
+Stable tag: 1.8.66
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.66 =
+* Queue colour variation synchronisation for parent products as soon as related SoftOne children are linked so new shades appear without a second import.
 
 = 1.8.65 =
 * Capture colour options from related Softone materials even when their WooCommerce records are stored as product variations.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.65
+ * Version:           1.8.66
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.65' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.66' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- queue colour variation synchronisation whenever `refresh_related_item_children()` discovers child materials so parents pick up new shades
- normalise the collected child material list and merge the parent material before queuing
- add a regression test covering parent/child imports and stub missing WooCommerce helpers, plus bump the plugin version and changelog

## Testing
- php tests/force-taxonomy-refresh-regression-test.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691383806bf48327a9221ef0572d220a)