### PR TITLE
Fix WooCommerce attribute taxonomy flagging and bump plugin version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.66
+Stable tag: 1.8.67
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.67 =
+* Mark SoftOne-managed product attributes as taxonomy-backed so WooCommerce exposes selectable terms instead of raw IDs in the product editor.
 
 = 1.8.66 =
 * Queue colour variation synchronisation for parent products as soon as related SoftOne children are linked so new shades appear without a second import.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -1339,6 +1339,7 @@ protected function import_row( array $data, $run_timestamp ) {
                     $name = $attribute->get_name();
                     if ( $name === $colour_taxonomy || $name === $normalized_key ) {
                         $attribute->set_variation( true );
+                        $this->set_attribute_taxonomy_flag( $attribute, true );
                         $this->log(
                             'debug',
                             'Marked colour attribute for variation usage on parent product.',
@@ -1822,6 +1823,7 @@ protected function import_row( array $data, $run_timestamp ) {
                         }
 
                         $attribute->set_variation( true );
+                        $this->set_attribute_taxonomy_flag( $attribute, true );
                         $this->log(
                             'debug',
                             'Enabled variation usage for existing colour attribute during related sync.',
@@ -1853,6 +1855,7 @@ protected function import_row( array $data, $run_timestamp ) {
                         $attribute_object->set_position( isset( $attribute['position'] ) ? (int) $attribute['position'] : 0 );
                         $attribute_object->set_visible( true );
                         $attribute_object->set_variation( true );
+                        $this->set_attribute_taxonomy_flag( $attribute_object, true );
                         $this->log(
                             'debug',
                             'Converted legacy attribute array to WC_Product_Attribute for colour variations.',
@@ -1887,6 +1890,7 @@ protected function import_row( array $data, $run_timestamp ) {
                 $attribute_object->set_position( 0 );
                 $attribute_object->set_visible( true );
                 $attribute_object->set_variation( true );
+                $this->set_attribute_taxonomy_flag( $attribute_object, true );
                 $this->log(
                     'debug',
                     'Added colour attribute for related variation synchronisation.',
@@ -1902,6 +1906,7 @@ protected function import_row( array $data, $run_timestamp ) {
                 if ( $attribute_object instanceof WC_Product_Attribute ) {
                     $attribute_object->set_options( $combined_term_ids );
                     $attribute_object->set_variation( true );
+                    $this->set_attribute_taxonomy_flag( $attribute_object, true );
                     $this->log(
                         'debug',
                         'Updated existing colour attribute options during related sync.',
@@ -1999,6 +2004,7 @@ protected function import_row( array $data, $run_timestamp ) {
                             }
                         }
                         $attribute->set_variation( true );
+                        $this->set_attribute_taxonomy_flag( $attribute, true );
                         $attributes[ $key ] = $attribute;
                     } elseif ( is_array( $attribute ) ) {
                         $existing_term_ids = array();
@@ -2016,6 +2022,7 @@ protected function import_row( array $data, $run_timestamp ) {
                         $attribute_object->set_position( isset( $attribute['position'] ) ? (int) $attribute['position'] : 0 );
                         $attribute_object->set_visible( true );
                         $attribute_object->set_variation( true );
+                        $this->set_attribute_taxonomy_flag( $attribute_object, true );
                         $attributes[ $key ] = $attribute_object;
                     }
 
@@ -2115,12 +2122,14 @@ protected function import_row( array $data, $run_timestamp ) {
                 $attribute_object->set_position( 0 );
                 $attribute_object->set_visible( true );
                 $attribute_object->set_variation( true );
+                $this->set_attribute_taxonomy_flag( $attribute_object, true );
                 $attributes[] = $attribute_object;
             } else {
                 $attribute_object = $attributes[ $attribute_key ];
                 if ( $attribute_object instanceof WC_Product_Attribute ) {
                     $attribute_object->set_options( $final_term_ids );
                     $attribute_object->set_variation( true );
+                    $this->set_attribute_taxonomy_flag( $attribute_object, true );
                     $attributes[ $attribute_key ] = $attribute_object;
                 } elseif ( is_array( $attribute_object ) ) {
                     $attribute_object['options']   = $final_term_ids;
@@ -2353,6 +2362,7 @@ protected function import_row( array $data, $run_timestamp ) {
             $attribute_object->set_options( $sorted_children );
             $attribute_object->set_visible( false );
             $attribute_object->set_variation( false );
+            $this->set_attribute_taxonomy_flag( $attribute_object, false );
 
             if ( null === $related_key ) {
                 $attributes['related_item_mtrl'] = $attribute_object;
@@ -2905,6 +2915,7 @@ protected function prepare_attribute_assignments( array $data, $product, array $
             $attr->set_options( array( $mtrl_value ) );
             $attr->set_visible( false );
             $attr->set_variation( false );
+            $this->set_attribute_taxonomy_flag( $attr, false );
             $assignments['attributes'][] = $attr;
 
             $this->log(
@@ -2937,6 +2948,7 @@ protected function prepare_attribute_assignments( array $data, $product, array $
             $attr->set_options( empty( $related_mtrl_tokens ) ? array( $related_mtrl ) : $related_mtrl_tokens );
             $attr->set_visible( false );
             $attr->set_variation( false );
+            $this->set_attribute_taxonomy_flag( $attr, false );
             $assignments['attributes'][] = $attr;
 
             $this->log(
@@ -3047,6 +3059,7 @@ protected function prepare_attribute_assignments( array $data, $product, array $
             $attr->set_position( (int) $position );
             $attr->set_visible( true );
             $attr->set_variation( (bool) $is_variation );
+            $this->set_attribute_taxonomy_flag( $attr, true );
 
             $assignments['attributes'][]      = $attr;
             $assignments['terms'][ $taxonomy ] = array( (int) $term_id );
@@ -3159,6 +3172,28 @@ protected function resolve_colour_attribute_slug() {
         }
 
         return $value;
+    }
+
+    /**
+     * Configure the taxonomy flag on a product attribute when supported.
+     *
+     * @param WC_Product_Attribute $attribute  Attribute instance.
+     * @param bool                 $is_taxonomy Whether the attribute references a taxonomy.
+     * @return void
+     */
+    protected function set_attribute_taxonomy_flag( $attribute, $is_taxonomy ) {
+        if ( ! $attribute instanceof WC_Product_Attribute ) {
+            return;
+        }
+
+        if ( method_exists( $attribute, 'set_taxonomy' ) ) {
+            $attribute->set_taxonomy( (bool) $is_taxonomy );
+            return;
+        }
+
+        if ( method_exists( $attribute, 'set_is_taxonomy' ) ) {
+            $attribute->set_is_taxonomy( (bool) $is_taxonomy );
+        }
     }
 
         /**

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.66
+ * Version:           1.8.67
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.66' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.67' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- ensure SoftOne-managed attributes are marked as taxonomy-backed so WooCommerce shows selectable terms when editing products
- add a helper to consistently toggle the taxonomy flag for both taxonomy and custom attributes during sync
- bump the plugin version to 1.8.67 and document the change in the readme

## Testing
- php -l includes/class-softone-item-sync.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913880bb57483279e218f475a2da939)