### PR TITLE
Improve colour variation resilience and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.67
+Stable tag: 1.8.68
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,12 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.68 =
+* Recover colour attribute assignments when WooCommerce helpers are unavailable so variation creation never drops back to simple products.
+* Autoload WooCommerce variation classes before ensuring colour variants so early sync runs succeed even if WooCommerce has not finished booting.
+* Derive related colour sync queues from stored relationships and existing children so sibling materials populate variations even when SoftOne omits `related_item_mtrl` data.
+* Ignore conflicting SKU matches when a variation already points at a different SoftOne material to keep updates scoped to the intended product.
 
 = 1.8.67 =
 * Mark SoftOne-managed product attributes as taxonomy-backed so WooCommerce exposes selectable terms instead of raw IDs in the product editor.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.67
+ * Version:           1.8.68
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.67' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.68' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- recover colour attribute assignments when WooCommerce helper functions are unavailable so variation sync keeps running
- expand related-item queue derivation and guard SKU reuse so sibling materials attach to the right parent
- autoload WooCommerce variation classes during sync and bump the plugin to version 1.8.68 with updated changelog

## Testing
- php -l includes/class-softone-item-sync.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138afb014883278267b0d7d946e548)