### PR TITLE
Delay colour variation creation until related items exist

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.68
+Stable tag: 1.8.69
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.69 =
+* Keep colourable SoftOne items as simple products until a related material exists so standalone products retain their SKUs.
 
 = 1.8.68 =
 * Recover colour attribute assignments when WooCommerce helpers are unavailable so variation creation never drops back to simple products.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.68
+ * Version:           1.8.69
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.68' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.69' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- keep SoftOne items with colour attributes as simple products unless related materials are available
- restore SKUs for single-colour products and only queue colour variation syncs when siblings exist
- bump the plugin version to 1.8.69 and document the change

## Testing
- php -l includes/class-softone-item-sync.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138fa476f48327a32acf5a1f6b0887)