### PR TITLE
Add process trace diagnostics admin screen

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Changelog ==
 
+= 1.8.70 =
+* Introduce a process trace diagnostics screen that streams detailed logging for authentication, item imports, and variation decisions in real time.
+
 = 1.8.69 =
 * Keep colourable SoftOne items as simple products until a related material exists so standalone products retain their SKUs.
 

--- a/admin/css/softone-woocommerce-integration-admin.css
+++ b/admin/css/softone-woocommerce-integration-admin.css
@@ -4,143 +4,143 @@
  */
 
 .softone-api-tester .notice {
-        margin-top: 16px;
+		margin-top: 16px;
 }
 
 .softone-api-layout {
-        display: grid;
-        gap: 24px;
-        margin-top: 24px;
+		display: grid;
+		gap: 24px;
+		margin-top: 24px;
 }
 
 .softone-api-card {
-        background: #fff;
-        border: 1px solid #dcdcde;
-        border-radius: 6px;
-        padding: 24px;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+		background: #fff;
+		border: 1px solid #dcdcde;
+		border-radius: 6px;
+		padding: 24px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
 .softone-api-card h2 {
-        margin-top: 0;
+		margin-top: 0;
 }
 
 .softone-api-card__intro {
-        color: #50575e;
-        margin-bottom: 16px;
-        margin-top: 0;
+		color: #50575e;
+		margin-bottom: 16px;
+		margin-top: 0;
 }
 
 .softone-api-settings-summary {
-        display: grid;
-        gap: 12px;
-        margin: 0;
+		display: grid;
+		gap: 12px;
+		margin: 0;
 }
 
 .softone-api-settings-summary__row {
-        display: grid;
-        gap: 4px;
+		display: grid;
+		gap: 4px;
 }
 
 .softone-api-settings-summary__row dt {
-        font-weight: 600;
-        color: #1d2327;
+		font-weight: 600;
+		color: #1d2327;
 }
 
 .softone-api-settings-summary__row dd {
-        margin: 0;
-        color: #50575e;
-        word-break: break-all;
+		margin: 0;
+		color: #50575e;
+		word-break: break-all;
 }
 
 .softone-api-form {
-        display: flex;
-        flex-direction: column;
-        gap: 24px;
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
 }
 
 .softone-api-form-grid {
-        display: grid;
-        gap: 16px;
+		display: grid;
+		gap: 16px;
 }
 
 .softone-api-field {
-        border: 1px solid #dcdcde;
-        border-radius: 4px;
-        padding: 16px;
-        background: #fbfbfc;
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
+		border: 1px solid #dcdcde;
+		border-radius: 4px;
+		padding: 16px;
+		background: #fbfbfc;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
 }
 
 .softone-api-field label,
 .softone-api-field__label {
-        font-weight: 600;
-        color: #1d2327;
+		font-weight: 600;
+		color: #1d2327;
 }
 
 .softone-api-field select,
 .softone-api-field input[type="text"],
 .softone-api-textarea {
-        width: 100%;
-        max-width: 100%;
-        box-sizing: border-box;
+		width: 100%;
+		max-width: 100%;
+		box-sizing: border-box;
 }
 
 .softone-api-field .description {
-        margin: 0;
-        color: #50575e;
+		margin: 0;
+		color: #50575e;
 }
 
 .softone-api-field--checkbox {
-        justify-content: center;
+		justify-content: center;
 }
 
 .softone-api-checkbox {
-        display: flex;
-        gap: 8px;
-        align-items: flex-start;
+		display: flex;
+		gap: 8px;
+		align-items: flex-start;
 }
 
 .softone-api-field--full {
-        grid-column: 1 / -1;
+		grid-column: 1 / -1;
 }
 
 .softone-api-form__actions {
-        display: flex;
-        justify-content: flex-end;
+		display: flex;
+		justify-content: flex-end;
 }
 
 .softone-api-card--response h4 {
-        margin-bottom: 8px;
-        margin-top: 24px;
+		margin-bottom: 8px;
+		margin-top: 24px;
 }
 
 .softone-api-card--response h4:first-of-type {
-        margin-top: 16px;
+		margin-top: 16px;
 }
 
 .softone-api-response__code {
-        background: #f6f7f7;
-        border-radius: 4px;
-        border: 1px solid #dcdcde;
-        padding: 16px;
-        margin: 0;
-        overflow-x: auto;
-        font-family: Menlo, Consolas, monospace;
-        font-size: 13px;
-        line-height: 1.4;
+		background: #f6f7f7;
+		border-radius: 4px;
+		border: 1px solid #dcdcde;
+		padding: 16px;
+		margin: 0;
+		overflow-x: auto;
+		font-family: Menlo, Consolas, monospace;
+		font-size: 13px;
+		line-height: 1.4;
 }
 
 .softone-api-response__subtitle {
-        margin-bottom: 8px;
+		margin-bottom: 8px;
 }
 
 .softone-api-field--highlight {
-        border-color: #2271b1;
-        box-shadow: 0 0 0 1px rgba(34, 113, 177, 0.2);
-        background: #f0f6fc;
+		border-color: #2271b1;
+		box-shadow: 0 0 0 1px rgba(34, 113, 177, 0.2);
+		background: #f0f6fc;
 }
 
 .softone-progress,
@@ -197,138 +197,307 @@ cursor: wait;
 }
 
 @media (min-width: 782px) {
-        .softone-api-form-grid {
-                grid-template-columns: repeat(2, minmax(0, 1fr));
-        }
+		.softone-api-form-grid {
+				grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
 
-        .softone-api-field--checkbox {
-                align-self: stretch;
-        }
+		.softone-api-field--checkbox {
+				align-self: stretch;
+		}
 }
 
 @media (min-width: 960px) {
-        .softone-api-layout {
-                grid-template-columns: minmax(260px, 1fr) minmax(0, 2fr);
-                align-items: start;
-        }
+		.softone-api-layout {
+				grid-template-columns: minmax(260px, 1fr) minmax(0, 2fr);
+				align-items: start;
+		}
 
-        .softone-api-card--credentials {
-                position: sticky;
-                top: 32px;
-                align-self: start;
-        }
+		.softone-api-card--credentials {
+				position: sticky;
+				top: 32px;
+				align-self: start;
+		}
 
-        .softone-api-card--request,
-        .softone-api-card--response {
-                grid-column: 2;
-        }
+		.softone-api-card--request,
+		.softone-api-card--response {
+				grid-column: 2;
+		}
 
 .softone-api-card--response {
-        margin-bottom: 0;
+		margin-bottom: 0;
 }
 }
 
 .softone-category-logs .softone-log-section {
-        margin-top: 24px;
+		margin-top: 24px;
 }
 
 .softone-category-logs .softone-log-section__intro {
-        margin: 0 0 16px;
-        color: #50575e;
+		margin: 0 0 16px;
+		color: #50575e;
 }
 
 .softone-log-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        display: grid;
-        gap: 16px;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: grid;
+		gap: 16px;
 }
 
 .softone-log-entry {
-        background: #fff;
-        border: 1px solid #dcdcde;
-        border-radius: 6px;
-        padding: 16px;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+		background: #fff;
+		border: 1px solid #dcdcde;
+		border-radius: 6px;
+		padding: 16px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
 .softone-log-entry__header {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-        margin-bottom: 8px;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		margin-bottom: 8px;
 }
 
 .softone-log-entry__timestamp {
-        font-weight: 600;
-        color: #1d2327;
+		font-weight: 600;
+		color: #1d2327;
 }
 
 .softone-log-entry__level {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 2px 8px;
-        border-radius: 999px;
-        font-size: 11px;
-        letter-spacing: 0.05em;
-        text-transform: uppercase;
-        background: #dcdcde;
-        color: #1d2327;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 2px 8px;
+		border-radius: 999px;
+		font-size: 11px;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		background: #dcdcde;
+		color: #1d2327;
 }
 
 .softone-log-entry--warning .softone-log-entry__level {
-        background: #f0b849;
-        color: #1d2327;
+		background: #f0b849;
+		color: #1d2327;
 }
 
 .softone-log-entry--error .softone-log-entry__level {
-        background: #d63638;
-        color: #fff;
+		background: #d63638;
+		color: #fff;
 }
 
 .softone-log-entry--debug .softone-log-entry__level {
-        background: #1d2327;
-        color: #fff;
+		background: #1d2327;
+		color: #fff;
 }
 
 .softone-log-entry__message {
-        margin: 0;
-        color: #1d2327;
-        word-break: break-word;
+		margin: 0;
+		color: #1d2327;
+		word-break: break-word;
 }
 
 .softone-log-entry__context {
-        margin: 12px 0 0;
-        background: #f6f7f7;
-        border: 1px solid #dcdcde;
-        border-radius: 4px;
-        padding: 12px;
-        overflow-x: auto;
-        font-family: Menlo, Consolas, monospace;
-        font-size: 13px;
-        line-height: 1.4;
-        white-space: pre-wrap;
-        word-break: break-word;
+		margin: 12px 0 0;
+		background: #f6f7f7;
+		border: 1px solid #dcdcde;
+		border-radius: 4px;
+		padding: 12px;
+		overflow-x: auto;
+		font-family: Menlo, Consolas, monospace;
+		font-size: 13px;
+		line-height: 1.4;
+		white-space: pre-wrap;
+		word-break: break-word;
 }
 
 .softone-log-entry__meta {
-        margin-top: 12px;
-        color: #50575e;
-        font-size: 12px;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 12px;
+		margin-top: 12px;
+		color: #50575e;
+		font-size: 12px;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 12px;
 }
 
 .softone-log-footnote {
-        margin-top: 24px;
-        color: #50575e;
+		margin-top: 24px;
+		color: #50575e;
 }
 
 .softone-log-footnote p {
-        margin: 0 0 8px;
+		margin: 0 0 8px;
+}
+
+.softone-process-trace {
+max-width: 960px;
+}
+
+.softone-process-trace__panel {
+background: #fff;
+border: 1px solid #dcdcde;
+border-radius: 6px;
+padding: 24px;
+margin-bottom: 24px;
+box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.softone-process-trace__controls {
+display: flex;
+flex-wrap: wrap;
+gap: 16px;
+align-items: flex-start;
+}
+
+.softone-process-trace__options {
+display: grid;
+gap: 12px;
+flex: 1 1 320px;
+margin-right: auto;
+}
+
+.softone-process-trace__option {
+display: grid;
+gap: 4px;
+font-weight: 600;
+color: #1d2327;
+}
+
+.softone-process-trace__option input[type="checkbox"] {
+margin-right: 8px;
+}
+
+.softone-process-trace__option-label {
+display: inline-block;
+}
+
+.softone-process-trace__status {
+margin-top: 16px;
+font-weight: 600;
+color: #1d2327;
+}
+
+.softone-process-trace__status--success {
+color: #1f6b3b;
+}
+
+.softone-process-trace__status--error {
+color: #b32d2e;
+}
+
+.softone-process-trace__summary {
+background: #fff;
+border: 1px solid #dcdcde;
+border-radius: 6px;
+padding: 24px;
+margin-bottom: 24px;
+}
+
+.softone-process-trace__summary-grid {
+display: grid;
+gap: 12px;
+grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+margin: 0;
+}
+
+.softone-process-trace__summary-grid dt {
+font-weight: 600;
+color: #1d2327;
+}
+
+.softone-process-trace__summary-grid dd {
+margin: 0;
+color: #50575e;
+}
+
+.softone-process-trace__log {
+background: #fff;
+border: 1px solid #dcdcde;
+border-radius: 6px;
+padding: 24px;
+}
+
+.softone-process-trace__entries {
+list-style: none;
+margin: 0;
+padding: 0;
+display: flex;
+flex-direction: column;
+gap: 16px;
+}
+
+.softone-process-trace__entry {
+border-left: 4px solid #2271b1;
+padding-left: 16px;
+}
+
+.softone-process-trace__entry--level-error {
+border-left-color: #b32d2e;
+}
+
+.softone-process-trace__entry--level-warning {
+border-left-color: #dba617;
+}
+
+.softone-process-trace__entry--level-info {
+border-left-color: #2271b1;
+}
+
+.softone-process-trace__entry-header {
+display: flex;
+flex-wrap: wrap;
+gap: 8px;
+align-items: center;
+font-size: 13px;
+color: #50575e;
+}
+
+.softone-process-trace__entry-time {
+font-weight: 600;
+color: #1d2327;
+}
+
+.softone-process-trace__entry-level {
+text-transform: uppercase;
+font-size: 11px;
+letter-spacing: 0.08em;
+padding: 2px 6px;
+border-radius: 999px;
+background: #edf2f7;
+color: #1d2327;
+}
+
+.softone-process-trace__entry-message {
+margin: 8px 0 0 0;
+color: #1d2327;
+}
+
+.softone-process-trace__entry-context {
+margin-top: 12px;
+}
+
+.softone-process-trace__entry-context pre {
+background: #f6f7f7;
+border-radius: 4px;
+border: 1px solid #dcdcde;
+padding: 12px;
+overflow-x: auto;
+font-family: Menlo, Consolas, monospace;
+font-size: 12px;
+line-height: 1.5;
+margin-top: 8px;
+}
+
+.softone-process-trace__copy {
+margin-top: 8px;
+padding: 0;
+}
+
+.softone-process-trace__empty {
+margin: 0;
+color: #50575e;
 }

--- a/admin/js/softone-process-trace.js
+++ b/admin/js/softone-process-trace.js
@@ -1,0 +1,411 @@
+(function (window, document) {
+'use strict';
+
+var config = window.softoneProcessTrace;
+
+if (!config) {
+return;
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+var container = document.querySelector('[data-softone-process-trace]');
+
+if (!container) {
+return;
+}
+
+initialise(container);
+});
+
+function initialise(container) {
+var elements = {
+container: container,
+trigger: container.querySelector('[data-trace-trigger]'),
+spinner: container.querySelector('[data-trace-spinner]'),
+status: container.querySelector('[data-trace-status]'),
+summary: container.querySelector('[data-trace-summary]'),
+summaryFields: container.querySelectorAll('[data-trace-summary]'),
+emptyState: container.querySelector('[data-trace-empty]'),
+entries: container.querySelector('[data-trace-output]'),
+options: container.querySelectorAll('[data-trace-option]'),
+};
+
+var state = {
+running: false,
+};
+
+if (elements.trigger) {
+elements.trigger.addEventListener('click', function () {
+runTrace(elements, state);
+});
+}
+}
+
+function runTrace(elements, state) {
+if (!config || !elements.trigger || state.running) {
+return;
+}
+
+state.running = true;
+elements.trigger.disabled = true;
+setSpinner(elements.spinner, true);
+setStatus(elements.status, config.strings && config.strings.running ? config.strings.running : '');
+clearEntries(elements);
+toggleSummary(elements.summary, false);
+
+var formData = new window.FormData();
+formData.append('action', config.action);
+formData.append('nonce', config.nonce);
+
+if (elements.options && elements.options.length) {
+elements.options.forEach(function (option) {
+if (!option || !option.getAttribute) {
+return;
+}
+var key = option.getAttribute('data-trace-option');
+if (!key) {
+return;
+}
+formData.append(key, option.checked ? '1' : '0');
+});
+}
+
+fetch(config.ajaxUrl, {
+method: 'POST',
+credentials: 'same-origin',
+body: formData,
+}).then(function (response) {
+return response.json().then(function (payload) {
+return {
+success: response.ok && payload && payload.success === true,
+payload: payload,
+};
+}).catch(function () {
+return {
+success: false,
+payload: null,
+};
+});
+}).then(function (result) {
+if (!result || !result.success) {
+var errorPayload = result && result.payload ? result.payload : null;
+handleTraceFailure(elements, errorPayload);
+return;
+}
+
+handleTraceSuccess(elements, result.payload);
+}).catch(function (error) {
+handleTraceFailure(elements, null, error);
+}).finally(function () {
+state.running = false;
+setSpinner(elements.spinner, false);
+elements.trigger.disabled = false;
+});
+}
+
+function handleTraceSuccess(elements, payload) {
+if (!payload || !payload.data) {
+handleTraceFailure(elements, payload);
+return;
+}
+
+var data = payload.data;
+
+if (Array.isArray(data.entries)) {
+renderEntries(elements, data.entries);
+}
+
+if (data.summary) {
+renderSummary(elements.summary, data.summary);
+}
+
+if (elements.summary && data.summary) {
+toggleSummary(elements.summary, true);
+}
+
+var message = config.strings && config.strings.completed ? config.strings.completed : '';
+setStatus(elements.status, message, 'success');
+}
+
+function handleTraceFailure(elements, payload, error) {
+var entries = payload && payload.data && Array.isArray(payload.data.entries) ? payload.data.entries : [];
+
+if (entries.length) {
+renderEntries(elements, entries);
+}
+
+if (payload && payload.data && payload.data.summary) {
+renderSummary(elements.summary, payload.data.summary);
+toggleSummary(elements.summary, true);
+}
+
+var message = config.strings && config.strings.failed ? config.strings.failed : '';
+if (payload && payload.data && payload.data.message) {
+message = payload.data.message;
+}
+if (error && error.message && !message) {
+message = error.message;
+}
+
+setStatus(elements.status, message, 'error');
+}
+
+function clearEntries(elements) {
+if (elements.entries) {
+elements.entries.innerHTML = '';
+}
+
+if (elements.emptyState) {
+elements.emptyState.hidden = false;
+}
+}
+
+function renderEntries(elements, entries) {
+if (!elements.entries) {
+return;
+}
+
+elements.entries.innerHTML = '';
+
+if (!entries || !entries.length) {
+if (elements.emptyState) {
+elements.emptyState.hidden = false;
+}
+return;
+}
+
+if (elements.emptyState) {
+elements.emptyState.hidden = true;
+}
+
+entries.forEach(function (entry) {
+var item = document.createElement('li');
+item.className = 'softone-process-trace__entry';
+
+var type = entry && entry.type ? String(entry.type) : '';
+if (type) {
+item.className += ' softone-process-trace__entry--' + type.replace(/[^a-z0-9_-]+/gi, '-');
+}
+
+var level = entry && entry.level ? String(entry.level).toLowerCase() : 'info';
+item.className += ' softone-process-trace__entry--level-' + level.replace(/[^a-z0-9_-]+/gi, '-');
+
+var header = document.createElement('header');
+header.className = 'softone-process-trace__entry-header';
+
+var time = document.createElement('time');
+time.className = 'softone-process-trace__entry-time';
+time.textContent = entry && entry.time ? String(entry.time) : '';
+time.dateTime = entry && entry.timestamp ? new Date(entry.timestamp * 1000).toISOString() : '';
+header.appendChild(time);
+
+if (type) {
+var typeEl = document.createElement('span');
+typeEl.className = 'softone-process-trace__entry-type';
+typeEl.textContent = type;
+header.appendChild(typeEl);
+}
+
+var levelEl = document.createElement('span');
+levelEl.className = 'softone-process-trace__entry-level';
+levelEl.textContent = level.toUpperCase();
+header.appendChild(levelEl);
+
+if (entry && entry.action) {
+var actionEl = document.createElement('span');
+actionEl.className = 'softone-process-trace__entry-action';
+actionEl.textContent = entry.action;
+header.appendChild(actionEl);
+}
+
+item.appendChild(header);
+
+if (entry && entry.message) {
+var message = document.createElement('p');
+message.className = 'softone-process-trace__entry-message';
+message.textContent = entry.message;
+item.appendChild(message);
+}
+
+if (entry && entry.context && Object.keys(entry.context).length) {
+var details = document.createElement('details');
+details.className = 'softone-process-trace__entry-context';
+var summary = document.createElement('summary');
+summary.textContent = config.strings && config.strings.details ? config.strings.details : 'Details';
+details.appendChild(summary);
+
+var pre = document.createElement('pre');
+pre.textContent = safeStringify(entry.context);
+pre.setAttribute('data-trace-context', '');
+details.appendChild(pre);
+
+var copyButton = document.createElement('button');
+copyButton.type = 'button';
+copyButton.className = 'button-link softone-process-trace__copy';
+copyButton.textContent = config.strings && config.strings.copyContext ? config.strings.copyContext : 'Copy context';
+copyButton.addEventListener('click', function (event) {
+event.preventDefault();
+copyContext(pre, copyButton);
+});
+details.appendChild(copyButton);
+
+item.appendChild(details);
+}
+
+elements.entries.appendChild(item);
+});
+}
+
+function renderSummary(summaryContainer, summary) {
+if (!summaryContainer) {
+return;
+}
+
+var statusField = summaryContainer.querySelector('[data-trace-summary="status"]');
+var startedField = summaryContainer.querySelector('[data-trace-summary="started_at"]');
+var finishedField = summaryContainer.querySelector('[data-trace-summary="finished_at"]');
+var durationField = summaryContainer.querySelector('[data-trace-summary="duration"]');
+var processedField = summaryContainer.querySelector('[data-trace-summary="processed"]');
+var createdField = summaryContainer.querySelector('[data-trace-summary="created"]');
+var updatedField = summaryContainer.querySelector('[data-trace-summary="updated"]');
+var skippedField = summaryContainer.querySelector('[data-trace-summary="skipped"]');
+var staleField = summaryContainer.querySelector('[data-trace-summary="stale_processed"]');
+
+if (statusField) {
+var success = !!summary.success;
+statusField.textContent = success ? (config.strings && config.strings.successStatus ? config.strings.successStatus : 'Success') : (config.strings && config.strings.failureStatus ? config.strings.failureStatus : 'Failed');
+}
+
+if (startedField) {
+startedField.textContent = summary.started_at_formatted || '';
+}
+
+if (finishedField) {
+finishedField.textContent = summary.finished_at_formatted || '';
+}
+
+if (durationField) {
+var durationText = summary.duration_human || (config.strings && config.strings.durationFallback ? config.strings.durationFallback : '');
+if (summary.duration_seconds && summary.duration_seconds > 0) {
+durationText += ' (' + summary.duration_seconds + 's)';
+}
+durationField.textContent = durationText;
+}
+
+if (processedField) {
+processedField.textContent = formatNumber(summary.processed);
+}
+if (createdField) {
+createdField.textContent = formatNumber(summary.created);
+}
+if (updatedField) {
+updatedField.textContent = formatNumber(summary.updated);
+}
+if (skippedField) {
+skippedField.textContent = formatNumber(summary.skipped);
+}
+if (staleField) {
+staleField.textContent = formatNumber(summary.stale_processed);
+}
+}
+
+function toggleSummary(summaryContainer, show) {
+if (!summaryContainer) {
+return;
+}
+
+summaryContainer.hidden = !show;
+}
+
+function setStatus(element, message, level) {
+if (!element) {
+return;
+}
+
+element.textContent = message || '';
+element.className = 'softone-process-trace__status';
+
+if (level) {
+element.className += ' softone-process-trace__status--' + level;
+}
+}
+
+function setSpinner(spinner, active) {
+if (!spinner) {
+return;
+}
+
+if (active) {
+spinner.classList.add('is-active');
+} else {
+spinner.classList.remove('is-active');
+}
+}
+
+function safeStringify(value) {
+try {
+return JSON.stringify(value, null, 2);
+} catch (error) {
+return String(value);
+}
+}
+
+function copyContext(element, button) {
+if (!element) {
+return;
+}
+
+var text = element.textContent || '';
+
+if (!window.navigator || !window.navigator.clipboard) {
+fallbackCopy(text, button);
+return;
+}
+
+window.navigator.clipboard.writeText(text).then(function () {
+showCopyFeedback(button, true);
+}).catch(function () {
+fallbackCopy(text, button);
+});
+}
+
+function fallbackCopy(text, button) {
+var textarea = document.createElement('textarea');
+textarea.value = text;
+textarea.setAttribute('readonly', 'readonly');
+textarea.style.position = 'absolute';
+textarea.style.left = '-9999px';
+document.body.appendChild(textarea);
+textarea.select();
+
+try {
+var succeeded = document.execCommand('copy');
+showCopyFeedback(button, succeeded);
+} catch (error) {
+showCopyFeedback(button, false);
+}
+
+document.body.removeChild(textarea);
+}
+
+function showCopyFeedback(button, success) {
+if (!button) {
+return;
+}
+
+var original = button.textContent;
+button.textContent = success ? (config.strings && config.strings.copied ? config.strings.copied : 'Copied!') : (config.strings && config.strings.copyFailed ? config.strings.copyFailed : 'Copy failed');
+window.setTimeout(function () {
+button.textContent = original;
+}, 2000);
+}
+
+function formatNumber(value) {
+var number = parseInt(value, 10);
+if (isNaN(number)) {
+return '0';
+}
+return number.toLocaleString();
+}
+
+})(window, document);

--- a/admin/partials/softone-woocommerce-integration-process-trace.php
+++ b/admin/partials/softone-woocommerce-integration-process-trace.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Process trace diagnostic page markup.
+ *
+ * @package Softone_Woocommerce_Integration
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+?>
+<div class="wrap softone-process-trace" data-softone-process-trace>
+<h1><?php esc_html_e( 'Process Trace', 'softone-woocommerce-integration' ); ?></h1>
+<p class="description"><?php esc_html_e( 'Run a detailed Softone synchronisation trace to observe authentication, product import, and variation decisions step by step.', 'softone-woocommerce-integration' ); ?></p>
+
+<div class="softone-process-trace__panel">
+<div class="softone-process-trace__controls">
+<div class="softone-process-trace__options" data-trace-options>
+<label class="softone-process-trace__option">
+<input type="checkbox" value="1" data-trace-option="force_full_import" />
+<span class="softone-process-trace__option-label"><?php esc_html_e( 'Force full import', 'softone-woocommerce-integration' ); ?></span>
+<span class="description"><?php esc_html_e( 'Ignore incremental syncing and request the complete catalogue.', 'softone-woocommerce-integration' ); ?></span>
+</label>
+<label class="softone-process-trace__option">
+<input type="checkbox" value="1" data-trace-option="force_taxonomy_refresh" />
+<span class="softone-process-trace__option-label"><?php esc_html_e( 'Refresh taxonomy assignments', 'softone-woocommerce-integration' ); ?></span>
+<span class="description"><?php esc_html_e( 'Rebuild attribute and category relationships during the trace.', 'softone-woocommerce-integration' ); ?></span>
+</label>
+</div>
+<button type="button" class="button button-primary" data-trace-trigger><?php esc_html_e( 'Run process trace', 'softone-woocommerce-integration' ); ?></button>
+<span class="spinner" data-trace-spinner aria-hidden="true"></span>
+</div>
+<div class="softone-process-trace__status" data-trace-status role="status" aria-live="polite"></div>
+</div>
+
+<section class="softone-process-trace__summary" data-trace-summary hidden>
+<h2><?php esc_html_e( 'Summary', 'softone-woocommerce-integration' ); ?></h2>
+<dl class="softone-process-trace__summary-grid">
+<div>
+<dt><?php esc_html_e( 'Status', 'softone-woocommerce-integration' ); ?></dt>
+<dd data-trace-summary="status"></dd>
+</div>
+<div>
+<dt><?php esc_html_e( 'Started at', 'softone-woocommerce-integration' ); ?></dt>
+<dd data-trace-summary="started_at"></dd>
+</div>
+<div>
+<dt><?php esc_html_e( 'Finished at', 'softone-woocommerce-integration' ); ?></dt>
+<dd data-trace-summary="finished_at"></dd>
+</div>
+<div>
+<dt><?php esc_html_e( 'Duration', 'softone-woocommerce-integration' ); ?></dt>
+<dd data-trace-summary="duration"></dd>
+</div>
+<div>
+<dt><?php esc_html_e( 'Processed', 'softone-woocommerce-integration' ); ?></dt>
+<dd data-trace-summary="processed"></dd>
+</div>
+<div>
+<dt><?php esc_html_e( 'Created', 'softone-woocommerce-integration' ); ?></dt>
+<dd data-trace-summary="created"></dd>
+</div>
+<div>
+<dt><?php esc_html_e( 'Updated', 'softone-woocommerce-integration' ); ?></dt>
+<dd data-trace-summary="updated"></dd>
+</div>
+<div>
+<dt><?php esc_html_e( 'Skipped', 'softone-woocommerce-integration' ); ?></dt>
+<dd data-trace-summary="skipped"></dd>
+</div>
+<div>
+<dt><?php esc_html_e( 'Stale products updated', 'softone-woocommerce-integration' ); ?></dt>
+<dd data-trace-summary="stale_processed"></dd>
+</div>
+</dl>
+</section>
+
+<section class="softone-process-trace__log" aria-label="<?php esc_attr_e( 'Trace output', 'softone-woocommerce-integration' ); ?>">
+<p class="softone-process-trace__empty" data-trace-empty><?php esc_html_e( 'Run a trace to see step-by-step activity.', 'softone-woocommerce-integration' ); ?></p>
+<ul class="softone-process-trace__entries" data-trace-output></ul>
+</section>
+</div>

--- a/includes/class-softone-process-trace.php
+++ b/includes/class-softone-process-trace.php
@@ -1,0 +1,556 @@
+<?php
+/**
+ * Helpers for capturing detailed process traces during manual sync runs.
+ *
+ * @package Softone_Woocommerce_Integration
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'Softone_Process_Trace' ) ) {
+	/**
+	 * Collects structured trace entries for display in the admin UI.
+	 */
+	class Softone_Process_Trace {
+
+		/**
+		 * Recorded trace entries.
+		 *
+		 * @var array<int,array<string,mixed>>
+		 */
+		protected $entries = array();
+
+		/**
+		 * Add a new entry to the trace log.
+		 *
+		 * @param string               $type    Entry type identifier (e.g. api, log, activity, note).
+		 * @param string               $action  Short action key describing the event.
+		 * @param string               $message Human readable summary of the event.
+		 * @param array<string,mixed>  $context Additional context values.
+		 * @param string               $level   Severity level (info, warning, error).
+		 *
+		 * @return void
+		 */
+		public function add_event( $type, $action, $message, array $context = array(), $level = 'info' ) {
+			$timestamp = time();
+
+			$this->entries[] = array(
+				'timestamp' => $timestamp,
+				'type'      => (string) $type,
+				'action'    => (string) $action,
+				'level'     => (string) $level,
+				'message'   => (string) $message,
+				'context'   => $this->sanitize_context( $context ),
+			);
+		}
+
+		/**
+		 * Retrieve the recorded entries.
+		 *
+		 * @return array<int,array<string,mixed>>
+		 */
+		public function get_entries() {
+			return $this->entries;
+		}
+
+		/**
+		 * Mask sensitive identifiers before display.
+		 *
+		 * @param string $value Raw identifier.
+		 *
+		 * @return string
+		 */
+		public function mask_identifier( $value ) {
+			$value = (string) $value;
+
+			if ( '' === $value ) {
+				return '';
+			}
+
+			if ( strlen( $value ) <= 4 ) {
+				return str_repeat( '•', strlen( $value ) );
+			}
+
+			return str_repeat( '•', max( 0, strlen( $value ) - 4 ) ) . substr( $value, -4 );
+		}
+
+		/**
+		 * Recursively sanitise context data for safe output.
+		 *
+		 * @param mixed $context Raw context value.
+		 * @param int   $depth   Current recursion depth.
+		 *
+		 * @return mixed
+		 */
+		protected function sanitize_context( $context, $depth = 0 ) {
+			if ( $depth > 5 ) {
+				return '…';
+			}
+
+			if ( is_array( $context ) ) {
+				$sanitized = array();
+
+				foreach ( $context as $key => $value ) {
+					$key_string = is_scalar( $key ) ? (string) $key : (string) maybe_serialize( $key );
+
+					if ( $this->is_sensitive_key( $key_string ) ) {
+						$sanitized[ $key_string ] = '••••';
+						continue;
+					}
+
+					$sanitized[ $key_string ] = $this->sanitize_context( $value, $depth + 1 );
+				}
+
+				return $sanitized;
+			}
+
+			if ( is_object( $context ) ) {
+				if ( method_exists( $context, '__toString' ) ) {
+					return (string) $context;
+				}
+
+				if ( $context instanceof WP_Error ) {
+					return array(
+						'code'    => $context->get_error_code(),
+						'message' => $context->get_error_message(),
+						'data'    => $this->sanitize_context( $context->get_error_data(), $depth + 1 ),
+					);
+				}
+
+				return (string) maybe_serialize( $context );
+			}
+
+			if ( is_bool( $context ) ) {
+				return $context;
+			}
+
+			if ( is_scalar( $context ) || null === $context ) {
+				return $context;
+			}
+
+			return (string) maybe_serialize( $context );
+		}
+
+		/**
+		 * Determine whether a context key is sensitive.
+		 *
+		 * @param string $key Context key.
+		 *
+		 * @return bool
+		 */
+		protected function is_sensitive_key( $key ) {
+			$key = strtolower( (string) $key );
+
+			$sensitive = array( 'password', 'pass', 'secret', 'token', 'authorization', 'auth', 'clientsecret' );
+
+			return in_array( $key, $sensitive, true );
+		}
+	}
+}
+
+if ( ! class_exists( 'Softone_Process_Trace_Stream_Logger' ) ) {
+	/**
+	 * Minimal logger that forwards messages to the trace buffer.
+	 */
+	class Softone_Process_Trace_Stream_Logger {
+
+		/**
+		 * Trace collector instance.
+		 *
+		 * @var Softone_Process_Trace
+		 */
+		protected $trace;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param Softone_Process_Trace $trace Trace collector.
+		 */
+		public function __construct( Softone_Process_Trace $trace ) {
+			$this->trace = $trace;
+		}
+
+		/**
+		 * Record a log entry in the trace.
+		 *
+		 * @param string               $level   Severity level.
+		 * @param string               $message Log message.
+		 * @param array<string,mixed>  $context Additional context values.
+		 *
+		 * @return void
+		 */
+		public function log( $level, $message, $context = array() ) {
+			if ( ! is_array( $context ) ) {
+				$context = array();
+			}
+
+			$this->trace->add_event( 'log', 'log_' . strtolower( (string) $level ), (string) $message, $context, (string) $level );
+		}
+	}
+}
+
+if ( ! class_exists( 'Softone_Process_Trace_Activity_Logger' ) && class_exists( 'Softone_Sync_Activity_Logger' ) ) {
+	/**
+	 * Activity logger proxy that records entries for the process trace.
+	 */
+	class Softone_Process_Trace_Activity_Logger extends Softone_Sync_Activity_Logger {
+
+		/**
+		 * Trace collector instance.
+		 *
+		 * @var Softone_Process_Trace
+		 */
+		protected $trace;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param Softone_Process_Trace $trace Trace collector.
+		 */
+		public function __construct( Softone_Process_Trace $trace ) {
+			$this->trace = $trace;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function log( $channel, $action, $message, array $context = array() ) {
+			$this->trace->add_event(
+				'activity',
+				(string) $action,
+				(string) $message,
+				array_merge(
+					array( 'channel' => (string) $channel ),
+					$context
+				),
+				'info'
+			);
+
+			parent::log( $channel, $action, $message, $context );
+		}
+	}
+}
+
+if ( ! class_exists( 'Softone_Process_Trace_Api_Client' ) && class_exists( 'Softone_API_Client' ) ) {
+	/**
+	 * API client that emits detailed trace events while communicating with SoftOne.
+	 */
+	class Softone_Process_Trace_Api_Client extends Softone_API_Client {
+
+		/**
+		 * Trace collector instance.
+		 *
+		 * @var Softone_Process_Trace
+		 */
+		protected $trace;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param Softone_Process_Trace $trace    Trace collector.
+		 * @param array<string,mixed>   $settings Optional client settings.
+		 * @param mixed                 $logger   Optional logger instance.
+		 */
+		public function __construct( Softone_Process_Trace $trace, array $settings = array(), $logger = null ) {
+			$this->trace = $trace;
+
+			parent::__construct( $settings, $logger );
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function login() {
+			$this->trace->add_event( 'api', 'login_start', __( 'Authenticating with SoftOne via login service.', 'softone-woocommerce-integration' ) );
+
+			try {
+				$response = parent::login();
+
+				$client_id = isset( $response['clientID'] ) ? (string) $response['clientID'] : '';
+
+				$this->trace->add_event(
+					'api',
+					'login_success',
+					__( 'SoftOne login succeeded.', 'softone-woocommerce-integration' ),
+					array(
+						'client_id' => $this->trace->mask_identifier( $client_id ),
+					)
+				);
+
+				return $response;
+			} catch ( Exception $exception ) {
+				$this->trace->add_event(
+					'api',
+					'login_failed',
+					__( 'SoftOne login request failed.', 'softone-woocommerce-integration' ),
+					array( 'message' => $exception->getMessage() ),
+					'error'
+				);
+
+				throw $exception;
+			}
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function authenticate( $client_id ) {
+			$this->trace->add_event(
+				'api',
+				'authenticate_start',
+				__( 'Authenticating session with SoftOne.', 'softone-woocommerce-integration' ),
+				array( 'client_id' => $this->trace->mask_identifier( $client_id ) )
+			);
+
+			try {
+				$response = parent::authenticate( $client_id );
+
+				$this->trace->add_event(
+					'api',
+					'authenticate_success',
+					__( 'Softone authentication confirmed.', 'softone-woocommerce-integration' ),
+					array( 'client_id' => $this->trace->mask_identifier( isset( $response['clientID'] ) ? $response['clientID'] : '' ) )
+				);
+
+				return $response;
+			} catch ( Exception $exception ) {
+				$this->trace->add_event(
+					'api',
+					'authenticate_failed',
+					__( 'SoftOne authentication request failed.', 'softone-woocommerce-integration' ),
+					array( 'message' => $exception->getMessage() ),
+					'error'
+				);
+
+				throw $exception;
+			}
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function get_client_id( $force_refresh = false ) {
+			if ( ! $force_refresh ) {
+				$client_id = get_transient( self::TRANSIENT_CLIENT_ID_KEY );
+
+				if ( ! empty( $client_id ) ) {
+					$this->trace->add_event(
+						'api',
+						'client_id_reused_transient',
+						__( 'Re-using cached SoftOne client ID from transient cache.', 'softone-woocommerce-integration' ),
+						array( 'client_id' => $this->trace->mask_identifier( $client_id ) )
+					);
+
+					return (string) $client_id;
+				}
+
+				$meta = $this->get_client_meta();
+
+				if ( ! empty( $meta['client_id'] ) && ! empty( $meta['expires_at'] ) && time() < (int) $meta['expires_at'] ) {
+					$remaining = (int) $meta['expires_at'] - time();
+
+					if ( $remaining > 0 ) {
+						set_transient( self::TRANSIENT_CLIENT_ID_KEY, $meta['client_id'], $remaining );
+					}
+
+					$this->trace->add_event(
+						'api',
+						'client_id_reused_meta',
+						__( 'Re-using cached Softone client ID from options store.', 'softone-woocommerce-integration' ),
+						array(
+							'client_id'  => $this->trace->mask_identifier( $meta['client_id'] ),
+							'expires_in' => max( 0, $remaining ),
+						)
+					);
+
+					return (string) $meta['client_id'];
+				}
+			}
+
+			$this->trace->add_event(
+				'api',
+				'client_id_refresh',
+				__( 'Cached Softone client ID unavailable – requesting a new session.', 'softone-woocommerce-integration' ),
+				array( 'force_refresh' => (bool) $force_refresh )
+			);
+
+			return parent::get_client_id( $force_refresh );
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		protected function bootstrap_client_session() {
+			$this->trace->add_event( 'api', 'session_start', __( 'Starting new Softone session.', 'softone-woocommerce-integration' ) );
+
+			try {
+				$client_id = parent::bootstrap_client_session();
+
+				$this->trace->add_event(
+					'api',
+					'session_ready',
+					__( 'Softone session established.', 'softone-woocommerce-integration' ),
+					array( 'client_id' => $this->trace->mask_identifier( $client_id ) )
+				);
+
+				return $client_id;
+			} catch ( Exception $exception ) {
+				$this->trace->add_event(
+					'api',
+					'session_failed',
+					__( 'Failed to establish Softone session.', 'softone-woocommerce-integration' ),
+					array( 'message' => $exception->getMessage() ),
+					'error'
+				);
+
+				throw $exception;
+			}
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		protected function cache_client_id( $client_id, $ttl = 0 ) {
+			parent::cache_client_id( $client_id, $ttl );
+
+			$this->trace->add_event(
+				'api',
+				'client_id_cached',
+				__( 'Stored Softone client ID for reuse.', 'softone-woocommerce-integration' ),
+				array(
+					'client_id' => $this->trace->mask_identifier( $client_id ),
+					'ttl'       => (int) $ttl,
+				)
+			);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function clear_cached_client_id() {
+			parent::clear_cached_client_id();
+
+			$this->trace->add_event(
+				'api',
+				'client_id_cleared',
+				__( 'Cleared cached Softone client identifiers.', 'softone-woocommerce-integration' )
+			);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function call_service( $service, array $data = array(), $requires_client_id = true, $retry_on_authentication = true ) {
+			$this->trace->add_event(
+				'api',
+				'call_service',
+				sprintf( /* translators: %s: Softone service name. */ __( 'Calling Softone service: %s.', 'softone-woocommerce-integration' ), $service ),
+				array(
+					'requires_client_id'      => (bool) $requires_client_id,
+					'retry_on_authentication' => (bool) $retry_on_authentication,
+					'payload_overview'        => $this->summarise_payload( $data ),
+				)
+			);
+
+			try {
+				$response = parent::call_service( $service, $data, $requires_client_id, $retry_on_authentication );
+
+				$this->trace->add_event(
+					'api',
+					'call_service_completed',
+					__( 'Softone service responded successfully.', 'softone-woocommerce-integration' ),
+					$this->summarise_response( $response )
+				);
+
+				return $response;
+			} catch ( Exception $exception ) {
+				$this->trace->add_event(
+					'api',
+					'call_service_failed',
+					__( 'Softone service call failed.', 'softone-woocommerce-integration' ),
+					array(
+						'error'   => $exception->getMessage(),
+						'service' => (string) $service,
+					),
+					'error'
+				);
+
+				throw $exception;
+			}
+		}
+
+		/**
+		 * Generate a light-weight summary of the outbound payload.
+		 *
+		 * @param array<string,mixed> $payload Raw payload.
+		 *
+		 * @return array<string,mixed>
+		 */
+		protected function summarise_payload( array $payload ) {
+			$summary = array();
+
+			foreach ( $payload as $key => $value ) {
+				$key_string = is_scalar( $key ) ? (string) $key : (string) maybe_serialize( $key );
+
+				if ( $this->is_sensitive_key( $key_string ) ) {
+					$summary[ $key_string ] = '••••';
+					continue;
+				}
+
+				if ( is_array( $value ) ) {
+					$summary[ $key_string ] = array(
+						'type'  => 'array',
+						'count' => count( $value ),
+					);
+				} elseif ( is_scalar( $value ) || null === $value ) {
+					$summary[ $key_string ] = (string) $value;
+				} else {
+					$summary[ $key_string ] = (string) maybe_serialize( $value );
+				}
+			}
+
+			return $summary;
+		}
+
+		/**
+		 * Generate a concise summary of the Softone response payload.
+		 *
+		 * @param array<string,mixed> $response Raw response.
+		 *
+		 * @return array<string,mixed>
+		 */
+		protected function summarise_response( array $response ) {
+			$summary = array(
+				'keys'    => array_keys( $response ),
+				'success' => isset( $response['success'] ) ? $response['success'] : null,
+			);
+
+			if ( isset( $response['rows'] ) && is_array( $response['rows'] ) ) {
+				$summary['row_count'] = count( $response['rows'] );
+			}
+
+			if ( isset( $response['clientID'] ) ) {
+				$summary['client_id'] = $this->trace->mask_identifier( (string) $response['clientID'] );
+			}
+
+			return $summary;
+		}
+
+		/**
+		 * Identify sensitive payload keys.
+		 *
+		 * @param string $key Payload key name.
+		 *
+		 * @return bool
+		 */
+		protected function is_sensitive_key( $key ) {
+			$key = strtolower( (string) $key );
+
+			$sensitive = array( 'password', 'authorization', 'auth', 'token' );
+
+			return in_array( $key, $sensitive, true );
+		}
+	}
+}

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.65';
+                        $this->version = '1.8.70';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 
@@ -116,7 +116,7 @@ class Softone_Woocommerce_Integration {
 	 */
 	private function define_shared_hooks() {
 		$this->loader->add_action( 'init', $this, 'maybe_register_brand_taxonomy' );
-	}
+        }
 
 	/**
 	 * Load the required dependencies for this plugin.
@@ -156,6 +156,11 @@ class Softone_Woocommerce_Integration {
                  * File-based synchronisation activity logger.
                  */
                 require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-sync-activity-logger.php';
+
+                /**
+                 * Helpers for generating detailed process trace output.
+                 */
+                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-process-trace.php';
 
                 /**
                  * Service class for synchronising items from SoftOne into WooCommerce.
@@ -239,23 +244,24 @@ class Softone_Woocommerce_Integration {
 	 * @access   private
 	 */
 	private function define_admin_hooks() {
-	
-        $plugin_admin = new Softone_Woocommerce_Integration_Admin( $this->get_plugin_name(), $this->get_version(), $this->item_sync, $this->activity_logger );
 
-        $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
-        $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
-        $this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu' );
-        $this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
-        $this->loader->add_action( 'admin_post_softone_wc_integration_api_tester', $plugin_admin, 'handle_api_tester_request' );
-        $this->loader->add_action( 'admin_post_softone_wc_integration_test_connection', $plugin_admin, 'handle_test_connection' );
-        $this->loader->add_action( 'admin_post_' . Softone_Item_Sync::ADMIN_ACTION, $plugin_admin, 'handle_item_import' );
-        $this->loader->add_action( 'admin_post_softone_wc_integration_clear_sync_activity', $plugin_admin, 'handle_clear_sync_activity' );
-$this->loader->add_action( 'admin_post_' . $plugin_admin->get_delete_main_menu_action(), $plugin_admin, 'handle_delete_main_menu' );
-$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_sync_activity_action(), $plugin_admin, 'handle_sync_activity_ajax' );
-$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_item_import_ajax_action(), $plugin_admin, 'handle_item_import_ajax' );
-$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_delete_main_menu_ajax_action(), $plugin_admin, 'handle_delete_main_menu_ajax' );
+                $plugin_admin = new Softone_Woocommerce_Integration_Admin( $this->get_plugin_name(), $this->get_version(), $this->item_sync, $this->activity_logger );
 
-}
+                $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+                $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+                $this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu' );
+                $this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
+                $this->loader->add_action( 'admin_post_softone_wc_integration_api_tester', $plugin_admin, 'handle_api_tester_request' );
+                $this->loader->add_action( 'admin_post_softone_wc_integration_test_connection', $plugin_admin, 'handle_test_connection' );
+                $this->loader->add_action( 'admin_post_' . Softone_Item_Sync::ADMIN_ACTION, $plugin_admin, 'handle_item_import' );
+                $this->loader->add_action( 'admin_post_softone_wc_integration_clear_sync_activity', $plugin_admin, 'handle_clear_sync_activity' );
+                $this->loader->add_action( 'admin_post_' . $plugin_admin->get_delete_main_menu_action(), $plugin_admin, 'handle_delete_main_menu' );
+                $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_sync_activity_action(), $plugin_admin, 'handle_sync_activity_ajax' );
+                $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_process_trace_action(), $plugin_admin, 'handle_process_trace_ajax' );
+                $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_item_import_ajax_action(), $plugin_admin, 'handle_item_import_ajax' );
+                $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_delete_main_menu_ajax_action(), $plugin_admin, 'handle_delete_main_menu_ajax' );
+
+        }
 
 	/**
 	 * Register all of the hooks related to the public-facing functionality

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.69
+ * Version:           1.8.70
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.69' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.70' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add a Softone process trace helper stack that captures API, log, and activity events while masking sensitive values
- expose a new admin diagnostics screen, enqueue assets, and wire an AJAX endpoint to stream trace output
- style and script the interface for readable summaries, plus document and bump the plugin version

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913ade1eb8c8327adbb004061a59b92)