### PR TITLE
Group process trace logs by product

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Changelog ==
 
+= 1.8.71 =
+* Group process trace entries into per-product blocks with product metadata so debugging actions stay bundled per catalogue item.
+
 = 1.8.70 =
 * Introduce a process trace diagnostics screen that streams detailed logging for authentication, item imports, and variation decisions in real time.
 

--- a/admin/css/softone-woocommerce-integration-admin.css
+++ b/admin/css/softone-woocommerce-integration-admin.css
@@ -430,9 +430,58 @@ flex-direction: column;
 gap: 16px;
 }
 
-.softone-process-trace__entry {
+.softone-process-trace__entry { 
 border-left: 4px solid #2271b1;
 padding-left: 16px;
+}
+
+.softone-process-trace__entry--product-block {
+border-left-color: #2c3338;
+background: #f8f9f9;
+padding: 20px;
+border-radius: 6px;
+}
+
+.softone-process-trace__entry-header--product-block {
+margin-bottom: 12px;
+}
+
+.softone-process-trace__product-label {
+font-weight: 600;
+color: #1d2327;
+}
+
+.softone-process-trace__product-meta {
+display: grid;
+grid-template-columns: auto 1fr;
+column-gap: 12px;
+row-gap: 6px;
+margin: 12px 0 0;
+font-size: 13px;
+color: #1d2327;
+}
+
+.softone-process-trace__product-meta dt {
+font-weight: 600;
+}
+
+.softone-process-trace__product-meta dd {
+margin: 0;
+}
+
+.softone-process-trace__block-entries {
+list-style: none;
+margin: 16px 0 0;
+padding: 0;
+display: flex;
+flex-direction: column;
+gap: 12px;
+}
+
+.softone-process-trace__block-entries > .softone-process-trace__entry {
+background: #fff;
+border-radius: 4px;
+padding: 16px;
 }
 
 .softone-process-trace__entry--level-error {

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.70';
+			$this->version = '1.8.71';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.70
+ * Version:           1.8.71
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.70' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.71' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- group process trace entries into per-product blocks and enrich metadata when preparing responses
- add admin UI rendering and styles to display grouped product blocks with copyable context
- bump plugin version to 1.8.71 and document the change in the changelog

## Testing
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l softone-woocommerce-integration.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913b7a77b9483279246cc1ec3b45706)