### PR TITLE
Handle colour tokens from SoftOne related item lists

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.69
+Stable tag: 1.8.72
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.72 =
+* Capture SoftOne `softone_related_item_mtrll` lists when preparing related material attributes so colour variations queue every linked MTRL during full imports.
 
 = 1.8.71 =
 * Group process trace entries into per-product blocks with product metadata so debugging actions stay bundled per catalogue item.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -3061,9 +3061,53 @@ protected function prepare_attribute_assignments( array $data, $product, array $
     }
 
     // ---------------- Hidden custom attribute: related_item_mtrl ----------------
-    $related_mtrl = (string) $this->get_value( $data, array( 'related_item_mtrl', 'related_mtrl', 'rel_mtrl' ) );
+    $related_mtrl = (string) $this->get_value(
+        $data,
+        array( 'softone_related_item_mtrl', 'related_item_mtrl', 'related_mtrl', 'rel_mtrl' )
+    );
     $related_mtrl = trim( $related_mtrl );
-    $related_mtrl_tokens = $this->parse_related_item_mtrls( $related_mtrl );
+
+    $related_mtrl_tokens = array();
+    $related_list_keys   = array(
+        'softone_related_item_mtrls',
+        'softone_related_item_mtrll',
+        'related_item_mtrls',
+        'related_item_mtrll',
+    );
+
+    foreach ( $related_list_keys as $list_key ) {
+        if ( isset( $data[ $list_key ] ) && '' !== trim( (string) $data[ $list_key ] ) ) {
+            $raw_value = $data[ $list_key ];
+
+            if ( is_array( $raw_value ) ) {
+                foreach ( $raw_value as $token_value ) {
+                    $related_mtrl_tokens = array_merge(
+                        $related_mtrl_tokens,
+                        $this->parse_related_item_mtrls( (string) $token_value )
+                    );
+                }
+            } else {
+                $related_mtrl_tokens = array_merge(
+                    $related_mtrl_tokens,
+                    $this->parse_related_item_mtrls( (string) $raw_value )
+                );
+            }
+        }
+    }
+
+    if ( empty( $related_mtrl_tokens ) ) {
+        $related_mtrl_tokens = $this->parse_related_item_mtrls( $related_mtrl );
+    }
+
+    if ( '' !== $related_mtrl ) {
+        $related_mtrl_tokens[] = $related_mtrl;
+    }
+
+    $related_mtrl_tokens = array_values(
+        array_unique(
+            array_filter( array_map( 'strval', $related_mtrl_tokens ) )
+        )
+    );
     if ( $related_mtrl !== '' && class_exists( 'WC_Product_Attribute' ) ) {
         try {
             $attr = new WC_Product_Attribute();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.71
+ * Version:           1.8.72
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.71' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.72' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- parse `softone_related_item_mtrl`/`softone_related_item_mtrll` payload values when preparing related material attributes so colour variation syncs capture every linked item
- bumped the plugin version and changelog entry to 1.8.72

## Testing
- php -l includes/class-softone-item-sync.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913bec99b5c8327b675142f389b91cb)