### PR TITLE
Preserve related item metadata when SoftOne omits relationship fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.72
+Stable tag: 1.8.73
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.73 =
+* Preserve related SoftOne material references when SoftOne omits relationship fields so previously imported items retain their `_softone_related_item_mtrl` values.
 
 = 1.8.72 =
 * Capture SoftOne `softone_related_item_mtrll` lists when preparing related material attributes so colour variations queue every linked MTRL during full imports.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.72
+ * Version:           1.8.73
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.72' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.73' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- avoid clearing stored SoftOne related material metadata when the API payload omits relationship fields
- add a helper to detect related-field presence and only run relationship sync when payload data is supplied
- bump the plugin to version 1.8.73 and document the change in the changelog

## Testing
- php -l includes/class-softone-item-sync.php
- php -l softone-woocommerce-integration.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691443441fac832782c8d1aa7395599d)