### PR TITLE
Ensure colour variation SKUs remain unique

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.74
+Stable tag: 1.8.75
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.75 =
+* Generate unique SKUs for colour variations sourced from related Softone materials so WooCommerce accepts every variant during synchronisation.
+* Add logging around colour variation SKU adjustments to highlight when duplicates are resolved automatically.
 
 = 1.8.74 =
 * Defer parent colour aggregation and variation queuing until all related materials exist with colour terms, preventing partial colour lists when Softone omits or delays sibling imports.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.74
+ * Version:           1.8.75
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.74' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.75' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- ensure colour variations call the SKU de-duplication helper so WooCommerce accepts every generated variation
- add logging for adjusted variation SKUs and update the recorded value after saving
- bump the plugin to version 1.8.75 and document the change in the readme

## Testing
- php -l includes/class-softone-item-sync.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914938582548327b4de2c5243f9f4db)