### PR TITLE
Allow SoftOne imports to use duplicate SKUs

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.79
+Stable tag: 1.8.80
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.80 =
+* Disable WooCommerce's unique SKU enforcement so SoftOne catalogue imports can intentionally reuse identifiers.
 
 = 1.8.79 =
 * Disabled variable product creation workflows to prepare for a redesign of the sync strategy.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.79
+ * Version:           1.8.80
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.79' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.80' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';
@@ -147,6 +147,16 @@ function softone_woocommerce_integration_bootstrap_update_checker() {
 	do_action( 'softone_woocommerce_integration_update_checker_ready', $update_checker );
 }
 add_action( 'plugins_loaded', 'softone_woocommerce_integration_bootstrap_update_checker', 1 );
+
+/**
+ * Allow duplicate SKUs when synchronising products from SoftOne.
+ *
+ * WooCommerce enforces unique SKUs by default which conflicts with SoftOne
+ * catalogues that intentionally reuse identifiers across related items. The
+ * filter keeps WooCommerce from blocking updates so the plugin can manage
+ * duplicates safely.
+ */
+add_filter( 'wc_product_has_unique_sku', '__return_false', 99 );
 
 /**
  * Begins execution of the plugin.


### PR DESCRIPTION
## Summary
- disable WooCommerce's unique SKU enforcement so SoftOne imports can reuse identifiers
- bump the plugin version to 1.8.80 and document the change in the readme

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c3a832688327903e36cc95ed9606)