### PR TITLE
Fix async item sync pagination handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.81
+Stable tag: 1.8.82
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.82 =
+* Ensure asynchronous item imports resume partially processed pages so SoftOne responses with more rows than the batch size create every product.
 
 = 1.8.81 =
 * Record SoftOne item import successes, skips, and errors in the sync activity log so skipped products explain their outcome.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -425,7 +425,7 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 }
 
                 $hash = $this->hash_item_rows( $rows );
-                if ( isset( $hashes[ $hash ] ) ) {
+                if ( 0 === $index && isset( $hashes[ $hash ] ) ) {
                     $warnings[] = __( 'Detected repeated page payload while fetching Softone items. Import halted to prevent an infinite loop.', 'softone-woocommerce-integration' );
                     $this->log(
                         'warning',

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.81
+ * Version:           1.8.82
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.81' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.82' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';

--- a/tests/async-batch-pagination-check.php
+++ b/tests/async-batch-pagination-check.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * Regression check ensuring async item sync resumes pages across batches.
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+    define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+if ( ! function_exists( '__' ) ) {
+    function __( $text ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+    function apply_filters( $tag, $value ) {
+        return $value;
+    }
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+    function wp_json_encode( $data ) {
+        return json_encode( $data );
+    }
+}
+
+if ( ! function_exists( 'wp_parse_args' ) ) {
+    function wp_parse_args( $args, $defaults = array() ) {
+        if ( is_object( $args ) ) {
+            $args = get_object_vars( $args );
+        }
+
+        if ( ! is_array( $args ) ) {
+            $args = array();
+        }
+
+        if ( ! is_array( $defaults ) ) {
+            $defaults = array();
+        }
+
+        return array_merge( $defaults, $args );
+    }
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+    function get_option( $option, $default = false ) {
+        return $default ?: 0;
+    }
+}
+
+if ( ! class_exists( 'WC_Product' ) ) {
+    class WC_Product {}
+}
+
+if ( ! class_exists( 'WC_Product_Simple' ) ) {
+    class WC_Product_Simple extends WC_Product {}
+}
+
+if ( ! class_exists( 'Softone_Category_Sync_Logger' ) ) {
+    class Softone_Category_Sync_Logger {
+        public function __construct( $logger ) {}
+    }
+}
+
+if ( ! class_exists( 'Softone_Sync_Activity_Logger' ) ) {
+    class Softone_Sync_Activity_Logger {}
+}
+
+if ( ! class_exists( 'Softone_API_Client' ) ) {
+    class Softone_API_Client {
+        /**
+         * @var array<int, array<int, array<string, mixed>>>
+         */
+        protected $pages = array();
+
+        /**
+         * @param array<int, array<int, array<string, mixed>>> $pages
+         */
+        public function __construct( array $pages = array() ) {
+            $this->pages = $pages;
+        }
+
+        /**
+         * Simulate the SoftOne SqlData API response.
+         *
+         * @param string $endpoint Endpoint name.
+         * @param array  $data     Request data.
+         * @param array  $extra    Extra data including the page number.
+         *
+         * @return array<string, mixed>
+         */
+        public function sql_data( $endpoint, array $data, array $extra ) {
+            $page = isset( $extra['pPage'] ) ? (int) $extra['pPage'] : 1;
+
+            if ( isset( $this->pages[ $page ] ) ) {
+                return array(
+                    'rows'  => $this->pages[ $page ],
+                    'total' => count( $this->pages[1] ),
+                );
+            }
+
+            return array( 'rows' => array(), 'total' => count( $this->pages[1] ) );
+        }
+    }
+}
+
+class Softone_Item_Sync_Logger {
+    /**
+     * @var array<int, array{level:string,message:string,context:array}>
+     */
+    public $entries = array();
+
+    /**
+     * Record a log entry.
+     *
+     * @param string $level   Log level.
+     * @param string $message Log message.
+     * @param array  $context Additional context.
+     */
+    public function log( $level, $message, array $context = array() ) {
+        $this->entries[] = array(
+            'level'   => (string) $level,
+            'message' => (string) $message,
+            'context' => $context,
+        );
+    }
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-softone-item-sync.php';
+
+class Softone_Item_Sync_Async_Test extends Softone_Item_Sync {
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public $imported = array();
+
+    /**
+     * @var array<int, array{level:string,message:string,context:array}>
+     */
+    public $logs = array();
+
+    /**
+     * @param array<string, mixed> $row
+     * @param int                  $run_timestamp
+     *
+     * @return string
+     */
+    protected function import_row( array $row, $run_timestamp ) {
+        $this->imported[] = $row;
+        return 'created';
+    }
+
+    /** @return void */
+    protected function reset_caches() {}
+
+    /** @return void */
+    protected function maybe_adjust_memory_limits() {}
+
+    /** @return void */
+    protected function process_pending_single_product_variations() {}
+
+    /** @return void */
+    protected function process_pending_colour_variation_syncs() {}
+
+    /**
+     * @param int $run_timestamp
+     * @return int
+     */
+    protected function handle_stale_products( $run_timestamp ) {
+        return 0;
+    }
+
+    /**
+     * @param string $level
+     * @param string $message
+     * @param array  $context
+     * @return void
+     */
+    protected function log( $level, $message, array $context = array() ) {
+        $this->logs[] = array(
+            'level'   => (string) $level,
+            'message' => (string) $message,
+            'context' => $context,
+        );
+    }
+
+    /** @return void */
+    protected function log_activity( $channel, $action, $message, array $context = array() ) {}
+}
+
+$rows = array();
+for ( $i = 1; $i <= 49; $i++ ) {
+    $rows[] = array(
+        'id'   => $i,
+        'name' => 'Product ' . $i,
+    );
+}
+
+$pages = array(
+    1 => $rows,
+    2 => array(),
+);
+
+$logger = new Softone_Item_Sync_Logger();
+$api    = new Softone_API_Client( $pages );
+$sync   = new Softone_Item_Sync_Async_Test( $api, $logger );
+
+try {
+    $state = $sync->begin_async_import();
+} catch ( Exception $exception ) {
+    fwrite( STDERR, 'Failed to initialise async import: ' . $exception->getMessage() . "\n" );
+    exit( 1 );
+}
+
+$result1 = $sync->run_async_import_batch( $state, 25 );
+$state   = $result1['state'];
+
+if ( $result1['complete'] ) {
+    fwrite( STDERR, "Import reported complete after first batch.\n" );
+    exit( 1 );
+}
+
+if ( 25 !== (int) $result1['batch']['processed'] ) {
+    fwrite( STDERR, 'Unexpected first batch count: ' . $result1['batch']['processed'] . "\n" );
+    exit( 1 );
+}
+
+$result2 = $sync->run_async_import_batch( $state, 25 );
+
+if ( ! $result2['complete'] ) {
+    fwrite( STDERR, "Import did not complete after second batch.\n" );
+    exit( 1 );
+}
+
+if ( 24 !== (int) $result2['batch']['processed'] ) {
+    fwrite( STDERR, 'Unexpected second batch count: ' . $result2['batch']['processed'] . "\n" );
+    exit( 1 );
+}
+
+if ( 49 !== (int) $result2['stats']['processed'] ) {
+    fwrite( STDERR, 'Processed count mismatch: ' . $result2['stats']['processed'] . "\n" );
+    exit( 1 );
+}
+
+foreach ( $result2['warnings'] as $warning ) {
+    if ( false !== strpos( $warning, 'repeated page payload' ) ) {
+        fwrite( STDERR, "Duplicate page warning triggered unexpectedly.\n" );
+        exit( 1 );
+    }
+}
+
+echo "Async import batches completed successfully.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- allow async item batches to resume partially processed SoftOne pages without tripping duplicate-page detection
- add a regression test covering SoftOne payloads that exceed the batch size and require multiple batches
- bump the plugin version to 1.8.82 and document the fix in the readme

## Testing
- php tests/repeated-page-detection-check.php
- php tests/async-batch-pagination-check.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c839facc8327ad7d614d955ae2a6)