### PR TITLE
Remove colour suffix from generated SKUs

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.84
+Stable tag: 1.8.85
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.85 =
+* Change: Stop appending colour information to generated SKUs so identifiers stay aligned with Softone.
 
 = 1.8.84 =
 * Feature: Append the product colour to generated SKUs when available for clearer catalog management.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -904,14 +904,6 @@ protected function import_row( array $data, $run_timestamp ) {
 
     $colour_value_for_variation = $anticipated_colour;
 
-    $colour_suffix_for_sku = $this->format_colour_for_sku(
-        '' !== $colour_value_for_variation ? $colour_value_for_variation : $derived_colour
-    );
-
-    if ( '' !== $sku_requested && '' !== $colour_suffix_for_sku ) {
-        $sku_requested .= '-' . $colour_suffix_for_sku;
-    }
-
     if ( '' === $mtrl && '' === $sku_requested ) {
         throw new Exception( __( 'Unable to determine a product identifier for the imported row.', 'softone-woocommerce-integration' ) );
     }
@@ -1039,9 +1031,6 @@ protected function import_row( array $data, $run_timestamp ) {
 
     // ---------- SKU (ensure unique, but if someone else owns it, we UPDATE THAT product) ----------
     $extra_suffixes = array();
-    if ( '' !== $colour_suffix_for_sku && function_exists( 'sanitize_title' ) ) {
-        $extra_suffixes[] = sanitize_title( $colour_suffix_for_sku );
-    }
 
     // If we’re updating a different product but the SKU belongs to another product, switch to that product to avoid duplicates
     if ( '' !== $sku_requested && $is_new && $existing_by_sku_id > 0 ) {

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.84
+ * Version:           1.8.85
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.84' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.85' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- stop appending colour details to generated SKUs during item import
- bump the plugin version to 1.8.85 and document the change in the readme

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d9e95d0c832794212f9a1939df52)