### PR TITLE
Preserve parent SKU when variation queues are disabled

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.85
+Stable tag: 1.8.86
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.86 =
+* Fix: Preserve parent SKUs when colour variation queues are disabled so duplicate Softone items keep their identifiers.
+* Dev: Introduce the `softone_wc_integration_enable_variable_product_handling` filter to prepare for future variation workflows.
 
 = 1.8.85 =
 * Change: Stop appending colour information to generated SKUs so identifiers stay aligned with Softone.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.85
+ * Version:           1.8.86
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.85' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.86' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add a filter-aware helper so SKU handling knows when variable product workflows are disabled
- keep parent SKUs intact when colour variation queues are inactive and guard variation helpers behind the new flag
- bump the plugin version to 1.8.86 and document the change in the readme

## Testing
- php -l includes/class-softone-item-sync.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915dc8c3dec83278a36a187eafd46aa)