### PR TITLE
Add settings toggle for variable product handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.87
+Stable tag: 1.8.88
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -46,7 +46,7 @@ The settings screen groups related options into three sections:
 
 * **Softone API Credentials** – Provide the connection details returned by SoftOne: Endpoint URL, Username, Password, App ID, Company, Branch, Module, Ref ID, Default SALDOC Series, Default Warehouse, Default AREAS, Default SOCURRENCY, Default TRDCATEGORY, and Country Mappings. All credential fields accept alphanumeric strings. The endpoint URL is normalised without trailing slashes. Passwords are stored with minimal filtering so special characters are preserved.
 * **Country Mappings** – Map WooCommerce ISO 3166-1 alpha-2 country codes to the numeric identifiers expected by SoftOne. Enter one mapping per line using the `GR:123` format; blank lines and malformed entries are ignored. Filters `softone_wc_integration_country_mappings` and `softone_wc_integration_country_id` let developers adjust mappings programmatically.
-* **Stock Behaviour** – Choose between treating zero SoftOne stock as “1” to keep items purchasable, or marking depleted items as backorderable. Only one mode can be active at a time.
+* **Stock Behaviour** – Choose between treating zero SoftOne stock as “1” to keep items purchasable, or marking depleted items as backorderable. Only one mode can be active at a time, and you can also enable colour-driven variable product handling from the same section so related SoftOne items publish as WooCommerce variations.
 
 After saving credentials, visit the **API Tester** submenu to validate connectivity and inspect sample item and order payloads. The tester records results per user and supports retrying requests without leaving the page.
 
@@ -78,6 +78,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.88 =
+* Feature: Add a settings toggle that enables colour-based variable product handling without requiring a code snippet filter.
+* Change: Honour the new setting in the variable product handling filter so variation queues and creation run when the checkbox is selected.
 
 = 1.8.87 =
 * Restore variable product conversion when `softone_wc_integration_enable_variable_product_handling` is enabled so colour-linked Softone items publish as WooCommerce variations with synced price, stock, and metadata.

--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -419,6 +419,12 @@ array( $this, 'render_process_trace_page' )
                 );
 
                 $this->add_checkbox_field(
+                        'enable_variable_product_handling',
+                        __( 'Enable variable product handling', 'softone-woocommerce-integration' ),
+                        __( 'Allow the importer to create colour-based WooCommerce variations when related Softone items are detected.', 'softone-woocommerce-integration' )
+                );
+
+                $this->add_checkbox_field(
                         'zero_stock_quantity_fallback',
                         __( 'Treat zero Softone stock as one', 'softone-woocommerce-integration' ),
                         __( 'When Softone reports zero quantity the product will be saved with a quantity of one.', 'softone-woocommerce-integration' )
@@ -466,8 +472,9 @@ array( $this, 'render_process_trace_page' )
                 $sanitized['trdcategory']           = isset( $settings['trdcategory'] ) ? $this->sanitize_text_value( $settings['trdcategory'] ) : '';
                 $sanitized['country_mappings']      = isset( $settings['country_mappings'] ) ? $this->sanitize_country_mappings( $settings['country_mappings'] ) : array();
 
-                $zero_stock_fallback = $this->sanitize_checkbox_flag( $settings, 'zero_stock_quantity_fallback' );
-                $backorder_out_stock = $this->sanitize_checkbox_flag( $settings, 'backorder_out_of_stock_products' );
+                $zero_stock_fallback       = $this->sanitize_checkbox_flag( $settings, 'zero_stock_quantity_fallback' );
+                $backorder_out_stock       = $this->sanitize_checkbox_flag( $settings, 'backorder_out_of_stock_products' );
+                $variable_product_handling = $this->sanitize_checkbox_flag( $settings, 'enable_variable_product_handling' );
 
                 if ( 'yes' === $zero_stock_fallback && 'yes' === $backorder_out_stock ) {
                         $backorder_out_stock = 'no';
@@ -480,8 +487,9 @@ array( $this, 'render_process_trace_page' )
                         );
                 }
 
-                $sanitized['zero_stock_quantity_fallback']    = $zero_stock_fallback;
-                $sanitized['backorder_out_of_stock_products'] = $backorder_out_stock;
+                $sanitized['zero_stock_quantity_fallback']     = $zero_stock_fallback;
+                $sanitized['backorder_out_of_stock_products']  = $backorder_out_stock;
+                $sanitized['enable_variable_product_handling'] = $variable_product_handling;
 
                 return $sanitized;
 

--- a/docs/manual-variable-product-test.md
+++ b/docs/manual-variable-product-test.md
@@ -3,10 +3,7 @@
 Follow these steps to confirm that enabling variable product handling now produces colour-based variations during an import run.
 
 1. **Enable the feature flag**
-   * Add the following snippet to a site-specific plugin or your theme's `functions.php`:
-     ```php
-     add_filter( 'softone_wc_integration_enable_variable_product_handling', '__return_true' );
-     ```
+   * Navigate to **Softone Integration → Settings**, open the **Stock Behaviour** section, check **Enable variable product handling**, and save the settings.
 2. **Prepare sample catalogue data**
    * Ensure Softone exposes at least two related items that share a `related_item_mtrl` relationship and distinct colour attribute values.
    * Confirm each item reports price, stock quantity, SKU, and the Softone material identifier (`MTRL`).

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.81';
+                        $this->version = '1.8.88';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 
@@ -114,8 +114,30 @@ class Softone_Woocommerce_Integration {
 	 *
 	 * @return void
 	 */
-	private function define_shared_hooks() {
-		$this->loader->add_action( 'init', $this, 'maybe_register_brand_taxonomy' );
+        private function define_shared_hooks() {
+                $this->loader->add_action( 'init', $this, 'maybe_register_brand_taxonomy' );
+                $this->loader->add_filter(
+                        'softone_wc_integration_enable_variable_product_handling',
+                        $this,
+                        'enable_variable_product_handling_from_settings'
+                );
+        }
+
+        /**
+         * Enable variable product handling when toggled in the plugin settings.
+         *
+         * @param bool $enabled Whether variable product handling is currently enabled.
+         *
+         * @return bool
+         */
+        public function enable_variable_product_handling_from_settings( $enabled ) {
+                $setting = softone_wc_integration_get_setting( 'enable_variable_product_handling', 'no' );
+
+                if ( 'yes' === $setting ) {
+                        return true;
+                }
+
+                return (bool) $enabled;
         }
 
 	/**

--- a/includes/softone-woocommerce-integration-settings.php
+++ b/includes/softone-woocommerce-integration-settings.php
@@ -50,6 +50,7 @@ if ( ! function_exists( 'softone_wc_integration_get_settings' ) ) {
             'client_id_ttl'         => Softone_API_Client::DEFAULT_CLIENT_ID_TTL,
             'zero_stock_quantity_fallback'    => 'no',
             'backorder_out_of_stock_products' => 'no',
+            'enable_variable_product_handling' => 'no',
         );
 
         $settings = wp_parse_args( $stored, $defaults );

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.87
+ * Version:           1.8.88
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.87' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.88' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add a persisted `enable_variable_product_handling` default and normalise it through existing sanitisation helpers
- surface an admin checkbox that toggles the variation workflow and wire it into the shared filter hooks
- update documentation and version metadata to reflect the new UI-driven control

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f2a850848327846fa2ac743de820)