### PR TITLE
Enable size-aware variable products

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.88
+Stable tag: 1.8.89
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.89 =
+* Change: Enable Softone variable product handling by default so colour-linked items convert into WooCommerce variations without requiring a filter override.
+* Feature: Carry size attributes into parent products and generated variations so catalogue syncs expose both colour and size options.
 
 = 1.8.88 =
 * Feature: Add a settings toggle that enables colour-based variable product handling without requiring a code snippet filter.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.8.88';
+                        $this->version = '1.8.89';
                 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.88
+ * Version:           1.8.89
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.88' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.89' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- enable variable product handling by default and capture size attributes while importing products
- propagate size attribute metadata to queued variations and ensure parent attributes expose the collected terms
- add generic attribute term helpers and bump the plugin version to 1.8.89 with updated changelog

## Testing
- php -l includes/class-softone-item-sync.php
- php -l softone-woocommerce-integration.php
- php -l includes/class-softone-woocommerce-integration.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f64f49448327a09caf0232842069)