### PR TITLE
Add variable product log viewer and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.90
+Stable tag: 1.8.91
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.91 =
+* Feature: Add a dedicated variable product activity log screen with paginated viewing and human-readable failure reasons.
+* Enhancement: Register the variable product log viewer under both the plugin and WooCommerce admin menus for easier access.
 
 = 1.8.90 =
 * Restore colour-based variation creation when the variable product handling filter is enabled, including stock, pricing, and Softone metadata.

--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -57,12 +57,19 @@ class Softone_Woocommerce_Integration_Admin {
          */
         private $category_logs_slug = 'softone-woocommerce-integration-category-logs';
 
-/**
- * Sync activity viewer submenu slug.
- *
- * @var string
- */
-private $sync_activity_slug = 'softone-woocommerce-integration-sync-activity';
+        /**
+         * Variable product log submenu slug.
+         *
+         * @var string
+         */
+        private $variable_product_logs_slug = 'softone-woocommerce-integration-variable-product-logs';
+
+        /**
+         * Sync activity viewer submenu slug.
+         *
+         * @var string
+         */
+        private $sync_activity_slug = 'softone-woocommerce-integration-sync-activity';
 
 /**
  * Process trace viewer submenu slug.
@@ -301,28 +308,37 @@ private $item_import_default_batch_size = 25;
                         array( $this, 'render_category_logs_page' )
                 );
 
-add_submenu_page(
-$this->menu_slug,
-__( 'Sync Activity', 'softone-woocommerce-integration' ),
-__( 'Sync Activity', 'softone-woocommerce-integration' ),
-$this->capability,
-$this->sync_activity_slug,
-array( $this, 'render_sync_activity_page' )
-);
+                add_submenu_page(
+                        $this->menu_slug,
+                        __( 'Variable Product Logs', 'softone-woocommerce-integration' ),
+                        __( 'Variable Product Logs', 'softone-woocommerce-integration' ),
+                        $this->capability,
+                        $this->variable_product_logs_slug,
+                        array( $this, 'render_variable_product_logs_page' )
+                );
 
-add_submenu_page(
-$this->menu_slug,
-__( 'Process Trace', 'softone-woocommerce-integration' ),
-__( 'Process Trace', 'softone-woocommerce-integration' ),
-$this->capability,
-$this->process_trace_slug,
-array( $this, 'render_process_trace_page' )
-);
+                add_submenu_page(
+                        $this->menu_slug,
+                        __( 'Sync Activity', 'softone-woocommerce-integration' ),
+                        __( 'Sync Activity', 'softone-woocommerce-integration' ),
+                        $this->capability,
+                        $this->sync_activity_slug,
+                        array( $this, 'render_sync_activity_page' )
+                );
 
-add_submenu_page(
-$this->menu_slug,
-__( 'API Tester', 'softone-woocommerce-integration' ),
-__( 'API Tester', 'softone-woocommerce-integration' ),
+                add_submenu_page(
+                        $this->menu_slug,
+                        __( 'Process Trace', 'softone-woocommerce-integration' ),
+                        __( 'Process Trace', 'softone-woocommerce-integration' ),
+                        $this->capability,
+                        $this->process_trace_slug,
+                        array( $this, 'render_process_trace_page' )
+                );
+
+                add_submenu_page(
+                        $this->menu_slug,
+                        __( 'API Tester', 'softone-woocommerce-integration' ),
+                        __( 'API Tester', 'softone-woocommerce-integration' ),
                         $this->capability,
                         $this->api_tester_slug,
                         array( $this, 'render_api_tester_page' )
@@ -346,23 +362,32 @@ __( 'API Tester', 'softone-woocommerce-integration' ),
                         array( $this, 'render_category_logs_page' )
                 );
 
-add_submenu_page(
-'woocommerce',
-__( 'Sync Activity', 'softone-woocommerce-integration' ),
-__( 'Sync Activity', 'softone-woocommerce-integration' ),
-$this->capability,
-$this->sync_activity_slug,
-array( $this, 'render_sync_activity_page' )
-);
+                add_submenu_page(
+                        'woocommerce',
+                        __( 'Variable Product Logs', 'softone-woocommerce-integration' ),
+                        __( 'Variable Product Logs', 'softone-woocommerce-integration' ),
+                        $this->capability,
+                        $this->variable_product_logs_slug,
+                        array( $this, 'render_variable_product_logs_page' )
+                );
 
-add_submenu_page(
-'woocommerce',
-__( 'Process Trace', 'softone-woocommerce-integration' ),
-__( 'Process Trace', 'softone-woocommerce-integration' ),
-$this->capability,
-$this->process_trace_slug,
-array( $this, 'render_process_trace_page' )
-);
+                add_submenu_page(
+                        'woocommerce',
+                        __( 'Sync Activity', 'softone-woocommerce-integration' ),
+                        __( 'Sync Activity', 'softone-woocommerce-integration' ),
+                        $this->capability,
+                        $this->sync_activity_slug,
+                        array( $this, 'render_sync_activity_page' )
+                );
+
+                add_submenu_page(
+                        'woocommerce',
+                        __( 'Process Trace', 'softone-woocommerce-integration' ),
+                        __( 'Process Trace', 'softone-woocommerce-integration' ),
+                        $this->capability,
+                        $this->process_trace_slug,
+                        array( $this, 'render_process_trace_page' )
+                );
 
         }
 
@@ -1571,36 +1596,83 @@ array(
 
 }
 
-        /**
-         * Prepare entries for front-end consumption by adding formatted fields.
-         *
-         * @param array<int, array<string, mixed>> $entries Raw entries from the logger.
-         *
-         * @return array<int, array<string, mixed>>
-         */
-        private function prepare_activity_entries( array $entries ) {
-                $prepared = array();
+/**
+ * Prepare entries for front-end consumption by adding formatted fields.
+ *
+ * @param array<int, array<string, mixed>> $entries Raw entries from the logger.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+	private function prepare_activity_entries( array $entries ) {
+		$prepared = array();
 
-                foreach ( $entries as $entry ) {
-                        $timestamp = isset( $entry['timestamp'] ) ? (int) $entry['timestamp'] : 0;
-                        $channel   = isset( $entry['channel'] ) ? (string) $entry['channel'] : '';
-                        $action    = isset( $entry['action'] ) ? (string) $entry['action'] : '';
-                        $message   = isset( $entry['message'] ) ? (string) $entry['message'] : '';
-                        $context   = isset( $entry['context'] ) && is_array( $entry['context'] ) ? $entry['context'] : array();
+		foreach ( $entries as $entry ) {
+			$timestamp = isset( $entry['timestamp'] ) ? (int) $entry['timestamp'] : 0;
+			$channel   = isset( $entry['channel'] ) ? (string) $entry['channel'] : '';
+			$action    = isset( $entry['action'] ) ? (string) $entry['action'] : '';
+			$message   = isset( $entry['message'] ) ? (string) $entry['message'] : '';
+			$context   = isset( $entry['context'] ) && is_array( $entry['context'] ) ? $entry['context'] : array();
 
-                        $prepared[] = array(
-                                'timestamp'       => $timestamp,
-                                'time'            => $this->format_activity_time( $timestamp ),
-                                'channel'         => $channel,
-                                'action'          => $action,
-                                'message'         => $message,
-                                'context'         => $context,
-                                'context_display' => $this->format_activity_context( $context ),
-                        );
-                }
+			$prepared[] = array(
+				'timestamp'       => $timestamp,
+				'time'            => $this->format_activity_time( $timestamp ),
+				'channel'         => $channel,
+				'action'          => $action,
+				'message'         => $message,
+				'context'         => $context,
+				'context_display' => $this->format_activity_context( $context ),
+			);
+		}
 
-                return $prepared;
-        }
+		return $prepared;
+	}
+
+/**
+ * Translate a variable product failure reason into a human-readable message.
+ *
+ * @param array<string, mixed> $context Activity context payload.
+ *
+ * @return string
+ */
+	private function describe_variable_product_reason( array $context ) {
+		$reason = isset( $context['reason'] ) ? (string) $context['reason'] : '';
+
+		if ( '' === $reason ) {
+			return '';
+		}
+
+		$messages = array(
+			'invalid_variation_arguments'        => __( 'Invalid variation parameters were supplied.', 'softone-woocommerce-integration' ),
+			'variable_product_handling_disabled' => __( 'Variable product handling is disabled in the plugin settings.', 'softone-woocommerce-integration' ),
+			'missing_wc_variation_support'       => __( 'WooCommerce variation support is unavailable on this site.', 'softone-woocommerce-integration' ),
+			'product_not_found'                  => __( 'The parent product could not be loaded.', 'softone-woocommerce-integration' ),
+			'product_not_variable'               => __( 'The parent product is not marked as variable.', 'softone-woocommerce-integration' ),
+			'term_not_found'                     => __( 'The referenced attribute term could not be found.', 'softone-woocommerce-integration' ),
+			'term_slug_empty'                    => __( 'The attribute term does not have a usable slug.', 'softone-woocommerce-integration' ),
+			'invalid_variation_object'           => __( 'The WooCommerce variation object could not be initialised.', 'softone-woocommerce-integration' ),
+			'failed_to_save_variation'           => __( 'WooCommerce reported an error while saving the variation.', 'softone-woocommerce-integration' ),
+		);
+
+		if ( 'term_not_found' === $reason && ! empty( $context['term_error'] ) ) {
+			return sprintf(
+			__( 'The referenced attribute term could not be found: %s', 'softone-woocommerce-integration' ),
+			(string) $context['term_error']
+			);
+		}
+
+		if ( 'product_not_variable' === $reason && ! empty( $context['product_type'] ) ) {
+			return sprintf(
+			__( 'The parent product is of type “%s” and not variable.', 'softone-woocommerce-integration' ),
+			(string) $context['product_type']
+			);
+		}
+
+		if ( isset( $messages[ $reason ] ) ) {
+			return $messages[ $reason ];
+		}
+
+		return $reason;
+	}
 
         /**
          * Format a sync activity timestamp according to site preferences.
@@ -2082,11 +2154,107 @@ $display_time = __( 'Unknown time', 'softone-woocommerce-integration' );
 }
 
         /**
-         * Render the file-based synchronisation activity viewer.
+         * Render the variable product activity viewer.
          *
          * @return void
          */
-        public function render_sync_activity_page() {
+        public function render_variable_product_logs_page() {
+
+               if ( ! current_user_can( $this->capability ) ) {
+                       return;
+               }
+
+               $error_state = '';
+               $entries     = array();
+
+               if ( $this->activity_logger && method_exists( $this->activity_logger, 'get_entries' ) ) {
+                       $raw_entries = $this->activity_logger->get_entries( $this->sync_activity_limit );
+
+                       foreach ( $raw_entries as $entry ) {
+                               $channel = isset( $entry['channel'] ) ? (string) $entry['channel'] : '';
+
+                               if ( 'variable_products' !== $channel ) {
+                                       continue;
+                               }
+
+                               $entries[] = $entry;
+                       }
+               } else {
+                       $error_state = __( 'The sync activity logger is not available.', 'softone-woocommerce-integration' );
+               }
+
+               $prepared_entries = $this->prepare_activity_entries( $entries );
+
+               $display_entries = array();
+
+               foreach ( $prepared_entries as $entry ) {
+                       $context = isset( $entry['context'] ) && is_array( $entry['context'] ) ? $entry['context'] : array();
+
+                       $display_entries[] = array(
+                               'timestamp'       => isset( $entry['timestamp'] ) ? (int) $entry['timestamp'] : 0,
+                               'time'            => isset( $entry['time'] ) ? (string) $entry['time'] : '',
+                               'action'          => isset( $entry['action'] ) ? (string) $entry['action'] : '',
+                               'message'         => isset( $entry['message'] ) ? (string) $entry['message'] : '',
+                               'context_display' => isset( $entry['context_display'] ) ? (string) $entry['context_display'] : '',
+                               'context'         => $context,
+                               'reason'          => $this->describe_variable_product_reason( $context ),
+                       );
+               }
+
+               $page_size = (int) apply_filters( 'softone_wc_integration_variable_logs_page_size', 20 );
+
+               if ( $page_size <= 0 ) {
+                       $page_size = 20;
+               }
+
+               wp_enqueue_script(
+                       'softone-variable-product-logs',
+                       plugin_dir_url( __FILE__ ) . 'js/softone-variable-product-logs.js',
+                       array(),
+                       $this->version,
+                       true
+               );
+
+               $localised_entries = array();
+
+               foreach ( $display_entries as $entry ) {
+                       $localised_entries[] = array(
+                               'timestamp' => (int) $entry['timestamp'],
+                               'time'      => (string) $entry['time'],
+                               'action'    => (string) $entry['action'],
+                               'message'   => (string) $entry['message'],
+                               'reason'    => (string) $entry['reason'],
+                               'context'   => (string) $entry['context_display'],
+                       );
+               }
+
+		wp_localize_script(
+			'softone-variable-product-logs',
+			'softoneVariableProductLogs',
+			array(
+				'entries'  => $localised_entries,
+				'pageSize' => $page_size,
+				'strings'  => array(
+					'noContext'     => __( 'No additional context provided.', 'softone-woocommerce-integration' ),
+					'pageIndicator' => __( 'Page %1$d of %2$d', 'softone-woocommerce-integration' ),
+					'noEntries'     => __( 'No variable product activity has been recorded yet.', 'softone-woocommerce-integration' ),
+				),
+			)
+		);
+
+               $entries_for_display = $display_entries;
+               $entries_limit       = $this->sync_activity_limit;
+               $page_size_display   = $page_size;
+
+               include plugin_dir_path( __FILE__ ) . 'partials/softone-woocommerce-integration-variable-product-logs.php';
+       }
+
+/**
+ * Render the file-based synchronisation activity viewer.
+ *
+ * @return void
+ */
+public function render_sync_activity_page() {
 
                 if ( ! current_user_can( $this->capability ) ) {
                         return;

--- a/admin/js/softone-variable-product-logs.js
+++ b/admin/js/softone-variable-product-logs.js
@@ -1,0 +1,160 @@
+(function ( window, document ) {
+'use strict';
+
+function addCell( row, text ) {
+var cell = document.createElement( 'td' );
+cell.textContent = text ? String( text ) : '';
+row.appendChild( cell );
+}
+
+document.addEventListener( 'DOMContentLoaded', function () {
+var data = window.softoneVariableProductLogs;
+
+if ( ! data ) {
+return;
+}
+
+var container = document.querySelector( '[data-softone-variable-logs]' );
+
+if ( ! container ) {
+return;
+}
+
+var body = container.querySelector( '[data-logs-body]' );
+if ( ! body ) {
+return;
+}
+
+var emptyRow = container.querySelector( '[data-logs-empty]' );
+if ( emptyRow && emptyRow.parentNode ) {
+emptyRow.parentNode.removeChild( emptyRow );
+}
+
+var pagination = container.querySelector( '[data-logs-pagination]' );
+var prevButton = container.querySelector( '[data-logs-prev]' );
+var nextButton = container.querySelector( '[data-logs-next]' );
+var indicator = container.querySelector( '[data-logs-page-indicator]' );
+
+var entries = Array.isArray( data.entries ) ? data.entries.slice() : [];
+var pageSize = parseInt( data.pageSize, 10 );
+
+if ( ! pageSize || pageSize <= 0 ) {
+pageSize = 20;
+}
+
+var strings = data.strings || {};
+var noContextText = strings.noContext || '—';
+var noEntriesText = strings.noEntries || '';
+var pageIndicatorTemplate = strings.pageIndicator || 'Page %1$d of %2$d';
+
+var currentPage = 1;
+var emptyTemplate = emptyRow || null;
+
+function render() {
+while ( body.firstChild ) {
+body.removeChild( body.firstChild );
+}
+
+if ( entries.length === 0 ) {
+if ( emptyTemplate ) {
+emptyTemplate.hidden = false;
+body.appendChild( emptyTemplate );
+} else {
+var fallbackRow = document.createElement( 'tr' );
+var fallbackCell = document.createElement( 'td' );
+fallbackCell.colSpan = 5;
+fallbackCell.textContent = noEntriesText;
+fallbackRow.appendChild( fallbackCell );
+body.appendChild( fallbackRow );
+}
+
+if ( pagination ) {
+pagination.hidden = true;
+}
+
+return;
+}
+
+if ( emptyTemplate ) {
+emptyTemplate.hidden = true;
+}
+
+var totalPages = Math.ceil( entries.length / pageSize );
+
+if ( currentPage > totalPages ) {
+currentPage = totalPages;
+}
+
+if ( currentPage < 1 ) {
+currentPage = 1;
+}
+
+var start = ( currentPage - 1 ) * pageSize;
+var end = Math.min( start + pageSize, entries.length );
+
+for ( var i = start; i < end; i++ ) {
+var entry = entries[ i ] || {};
+var row = document.createElement( 'tr' );
+
+addCell( row, entry.time );
+addCell( row, entry.action );
+addCell( row, entry.message );
+addCell( row, entry.reason );
+
+var contextCell = document.createElement( 'td' );
+contextCell.className = 'softone-variable-logs__context';
+
+if ( entry.context ) {
+var pre = document.createElement( 'pre' );
+pre.textContent = entry.context;
+contextCell.appendChild( pre );
+} else {
+contextCell.textContent = noContextText;
+}
+
+row.appendChild( contextCell );
+body.appendChild( row );
+}
+
+if ( pagination ) {
+pagination.hidden = totalPages <= 1;
+
+if ( indicator ) {
+indicator.textContent = pageIndicatorTemplate
+.replace( '%1$d', currentPage )
+.replace( '%2$d', totalPages );
+}
+
+if ( prevButton ) {
+prevButton.disabled = currentPage <= 1;
+}
+
+if ( nextButton ) {
+nextButton.disabled = currentPage >= totalPages;
+}
+}
+}
+
+if ( prevButton ) {
+prevButton.addEventListener( 'click', function () {
+if ( currentPage > 1 ) {
+currentPage--;
+render();
+}
+} );
+}
+
+if ( nextButton ) {
+nextButton.addEventListener( 'click', function () {
+var totalPages = Math.ceil( entries.length / pageSize );
+
+if ( currentPage < totalPages ) {
+currentPage++;
+render();
+}
+} );
+}
+
+render();
+} );
+})( window, document );

--- a/admin/partials/softone-woocommerce-integration-variable-product-logs.php
+++ b/admin/partials/softone-woocommerce-integration-variable-product-logs.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Variable product log viewer template.
+ *
+ * @package Softone_Woocommerce_Integration
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+$entries_for_display = isset( $entries_for_display ) && is_array( $entries_for_display ) ? $entries_for_display : array();
+$error_state         = isset( $error_state ) ? (string) $error_state : '';
+$entries_limit       = isset( $entries_limit ) ? (int) $entries_limit : 0;
+$page_size_display   = isset( $page_size_display ) ? (int) $page_size_display : 0;
+$has_entries         = ! empty( $entries_for_display );
+?>
+<div class="wrap softone-variable-product-logs">
+<h1><?php esc_html_e( 'Variable Product Sync Logs', 'softone-woocommerce-integration' ); ?></h1>
+<p class="description"><?php esc_html_e( 'Inspect variation creation attempts recorded during Softone synchronisation.', 'softone-woocommerce-integration' ); ?></p>
+
+<?php if ( '' !== $error_state ) : ?>
+<div class="notice notice-error"><p><?php echo esc_html( $error_state ); ?></p></div>
+<?php endif; ?>
+
+<p class="softone-variable-logs__summary"><?php echo esc_html( sprintf( __( 'Displaying up to %1$d recent entries in batches of %2$d.', 'softone-woocommerce-integration' ), $entries_limit, $page_size_display ) ); ?></p>
+
+<div class="softone-variable-logs" data-softone-variable-logs>
+<table class="widefat fixed striped">
+<thead>
+<tr>
+<th scope="col"><?php esc_html_e( 'Time', 'softone-woocommerce-integration' ); ?></th>
+<th scope="col"><?php esc_html_e( 'Action', 'softone-woocommerce-integration' ); ?></th>
+<th scope="col"><?php esc_html_e( 'Message', 'softone-woocommerce-integration' ); ?></th>
+<th scope="col"><?php esc_html_e( 'Failure reason', 'softone-woocommerce-integration' ); ?></th>
+<th scope="col"><?php esc_html_e( 'Context', 'softone-woocommerce-integration' ); ?></th>
+</tr>
+</thead>
+<tbody data-logs-body>
+<?php
+$empty_row_hidden = $has_entries ? ' hidden' : '';
+?>
+<tr data-logs-empty<?php echo $empty_row_hidden; ?>>
+<td colspan="5"><?php esc_html_e( 'No variable product activity has been recorded yet.', 'softone-woocommerce-integration' ); ?></td>
+</tr>
+<?php if ( $has_entries ) : ?>
+<?php foreach ( $entries_for_display as $entry ) :
+$time            = isset( $entry['time'] ) ? (string) $entry['time'] : '';
+$action          = isset( $entry['action'] ) ? (string) $entry['action'] : '';
+$message         = isset( $entry['message'] ) ? (string) $entry['message'] : '';
+$reason          = isset( $entry['reason'] ) ? (string) $entry['reason'] : '';
+$context_display = isset( $entry['context_display'] ) ? (string) $entry['context_display'] : '';
+?>
+<tr>
+<td><?php echo esc_html( $time ); ?></td>
+<td><?php echo esc_html( $action ); ?></td>
+<td><?php echo esc_html( $message ); ?></td>
+<td><?php echo '' !== $reason ? esc_html( $reason ) : esc_html__( 'Not specified', 'softone-woocommerce-integration' ); ?></td>
+<td class="softone-variable-logs__context">
+<?php if ( '' !== $context_display ) : ?>
+<pre><?php echo esc_html( $context_display ); ?></pre>
+<?php else : ?>
+<span><?php esc_html_e( 'No additional context provided.', 'softone-woocommerce-integration' ); ?></span>
+<?php endif; ?>
+</td>
+</tr>
+<?php endforeach; ?>
+<?php endif; ?>
+</tbody>
+</table>
+
+<div class="softone-variable-logs__pagination" data-logs-pagination hidden>
+<button type="button" class="button" data-logs-prev><?php esc_html_e( 'Previous', 'softone-woocommerce-integration' ); ?></button>
+<span data-logs-page-indicator></span>
+<button type="button" class="button" data-logs-next><?php esc_html_e( 'Next', 'softone-woocommerce-integration' ); ?></button>
+</div>
+</div>
+
+<noscript>
+<p><?php esc_html_e( 'JavaScript is required to paginate the log table.', 'softone-woocommerce-integration' ); ?></p>
+</noscript>
+</div>

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -95,11 +95,11 @@ class Softone_Woocommerce_Integration {
          * @since    1.0.0
          */
 	public function __construct() {
-                if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-                        $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-                } else {
-                        $this->version = '1.8.90';
-                }
+if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+} else {
+$this->version = '1.8.91';
+}
 		$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.90
+ * Version:           1.8.91
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.90' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.91' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add a dedicated variable product log submenu for the plugin and WooCommerce menu trees
- implement a variable product log screen that filters the sync activity log, exposes human readable failure reasons, and localises data for the new view
- add a template and JavaScript for paginated rendering and bump the plugin version/documentation for the release

## Testing
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l admin/partials/softone-woocommerce-integration-variable-product-logs.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l softone-woocommerce-integration.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691699b62c048327aa719198d2fc1e3d)