### PR TITLE
Ensure Softone imports always create colour variations

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.92
+Stable tag: 1.8.93
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.93 =
+* Change: Always convert imported products into colour variations so every Softone item publishes as a WooCommerce variation.
 
 = 1.8.92 =
 * Fix: Convert related colour parents to variable products before creating variations so Softone sync no longer logs failures.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -1206,10 +1206,6 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
         );
     }
 
-    if ( empty( $related_variation_candidates ) ) {
-        $should_create_colour_variation = false;
-    }
-
     if ( ! $should_create_colour_variation && '' !== $effective_sku && '' === $product->get_sku() ) {
         $product->set_sku( $effective_sku );
         $sku_adjusted_after_save = true;

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.8.92';
+$this->version = '1.8.93';
 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.92
+ * Version:           1.8.93
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.92' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.93' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- allow single-product imports to remain eligible for colour variation conversion even when no related materials are detected
- bump the plugin version to 1.8.93 and document the behaviour change in the readme

## Testing
- php -l includes/class-softone-item-sync.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916a27992488327bc68db6ab33ddf15)