### PR TITLE
Bump version to 1.8.94

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.93
+Stable tag: 1.8.94
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,7 +79,7 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 
 == Changelog ==
 
-= 1.8.93 =
+= 1.8.94 =
 * Change: Always convert imported products into colour variations so every Softone item publishes as a WooCommerce variation.
 
 = 1.8.92 =

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -95,11 +95,11 @@ class Softone_Woocommerce_Integration {
          * @since    1.0.0
          */
 	public function __construct() {
-if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-} else {
-$this->version = '1.8.93';
-}
+		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+		} else {
+			$this->version = '1.8.94';
+		}
 		$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.93
+ * Version:           1.8.94
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.93' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.94' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- update the plugin header version and runtime constant to 1.8.94
- refresh the stable tag and changelog heading in the readme for the 1.8.94 release
- ensure the runtime fallback version matches 1.8.94

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916b5ca744083278b6bc7fb7a9e918c)