### PR TITLE
Ensure variable products publish after conversion

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.95
+Stable tag: 1.8.96
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.96 =
+* Fix: Publish converted variable products so Softone parents no longer remain in draft after colour variation imports.
 
 = 1.8.95 =
 * Fix: Restore variable-product conversions when colour-based imports run so Softone parents publish as WooCommerce variable products again.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -2154,18 +2154,25 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 WC_Cache_Helper::invalidate_cache_group( 'products' );
             }
 
-            if ( class_exists( 'WC_Product_Variable' ) ) {
-                $product = new WC_Product_Variable( $product_id );
-            } else {
-                $product = wc_get_product( $product_id );
-            }
-            if ( ! $product ) {
-                return false;
-            }
+		if ( class_exists( 'WC_Product_Variable' ) ) {
+			$product = new WC_Product_Variable( $product_id );
+		} else {
+			$product = wc_get_product( $product_id );
+		}
+		if ( ! $product ) {
+			return false;
+		}
 
-            if ( method_exists( $product, 'set_regular_price' ) ) {
-                $product->set_regular_price( '' );
-            }
+		if ( method_exists( $product, 'get_status' ) && method_exists( $product, 'set_status' ) ) {
+			$current_status = $product->get_status();
+			if ( 'publish' !== $current_status ) {
+				$product->set_status( 'publish' );
+			}
+		}
+
+		if ( method_exists( $product, 'set_regular_price' ) ) {
+			$product->set_regular_price( '' );
+		}
 
             if ( method_exists( $product, 'set_sale_price' ) ) {
                 $product->set_sale_price( '' );

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -97,9 +97,9 @@ class Softone_Woocommerce_Integration {
 	public function __construct() {
 		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-                } else {
-                        $this->version = '1.8.95';
-                }
+		} else {
+			$this->version = '1.8.96';
+		}
 		$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.95
+ * Version:           1.8.96
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.95' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.96' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- ensure products converted to variable have their status forced to publish during sync
- bump the plugin to version 1.8.96 and refresh the readme metadata and changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916eb7333d08327aed6874ad79553dd)