### PR TITLE
Disable drafting source products and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.96
+Stable tag: 1.8.97
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.97 =
+* Fix: Stop drafting single-product sources when generating variations so converted products remain published.
 
 = 1.8.96 =
 * Fix: Publish converted variable products so Softone parents no longer remain in draft after colour variation imports.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -2747,7 +2747,8 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
                 }
 
                 if ( ! $variation_payload['source_is_variation'] && $variation_payload['source_id'] !== $product_id ) {
-                    $this->maybe_draft_single_product_source( $variation_payload['mtrl'], $product_id );
+                    // Disabled to avoid drafting the source single product when variations are generated.
+                    // $this->maybe_draft_single_product_source( $variation_payload['mtrl'], $product_id );
                 }
             }
         }

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -98,7 +98,7 @@ class Softone_Woocommerce_Integration {
 		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 		} else {
-			$this->version = '1.8.96';
+			$this->version = '1.8.97';
 		}
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.96
+ * Version:           1.8.97
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.96' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.97' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- comment out the single-product drafting call so variation imports no longer unpublish their sources
- bump the plugin version to 1.8.97 and document the change in the readme

## Testing
- php -l includes/class-softone-item-sync.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916faea195c832794a30b524b09367d)