### PR TITLE
Group SoftOne products by SKU into variable colour products

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.8.98
+Stable tag: 1.8.99
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
 
 == Changelog ==
+
+= 1.8.99 =
+* Feature: Group Softone items that share a SKU into WooCommerce variable products and populate colour variations for every MTRL.
+* Enhancement: Synchronise related-item metadata across grouped products and draft redundant single-product sources once their variations are created.
 
 = 1.8.98 =
 * Fix: Detect existing variations by matching WooCommerce attribute values so Softone materials sharing a colour or size no longer create duplicates.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.8.98
+ * Version:           1.8.99
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.98' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.8.99' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- collect Softone import entries sharing a SKU and persist them for deferred grouped processing
- convert grouped products into variable parents with colour variations, updated related-item metadata, and drafted single-product sources
- carry SKU grouping state across async batches and bump the plugin version/changelog to 1.8.99

## Testing
- php -l includes/class-softone-item-sync.php
- php -l softone-woocommerce-integration.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917187bdde483278d9c6ee375066654)