### PR TITLE
Add helper for configurable main menu name

### DIFF
--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -139,7 +139,7 @@ private $delete_main_menu_ajax_action = 'softone_wc_integration_delete_main_menu
  *
  * @var string
  */
-private $main_menu_name = 'Main Menu';
+private $main_menu_name = '';
 
 /**
  * Base transient key for storing batched menu deletion state.
@@ -266,6 +266,12 @@ private $item_import_default_batch_size = 25;
                 $this->version     = $version;
                 $this->item_sync   = $item_sync;
                 $this->activity_logger = $activity_logger ?: new Softone_Sync_Activity_Logger();
+
+                if ( function_exists( 'softone_wc_integration_get_main_menu_name' ) ) {
+                        $this->main_menu_name = softone_wc_integration_get_main_menu_name();
+                } else {
+                        $this->main_menu_name = 'Main Menu';
+                }
 
         }
 

--- a/docs/Functional-Overview.md
+++ b/docs/Functional-Overview.md
@@ -43,7 +43,7 @@ This document explains the plugin’s functionality based exclusively on the sou
     - “Run Item Import” (delta by default)
     - “Re-sync Categories & Menus” (forces full import and taxonomy refresh)
     - Progress bar and status messages (AJAX action: `softone_wc_integration_item_import`).
-  - “Delete Main Menu” tool: batches deletion of a nav menu named “Main Menu” via AJAX action `softone_wc_integration_delete_main_menu_batch` (also supports non-AJAX post to `softone_wc_integration_delete_main_menu`).
+  - “Delete Main Menu” tool: batches deletion of the nav menu returned by `softone_wc_integration_get_main_menu_name()` (default “Main Menu”) via AJAX action `softone_wc_integration_delete_main_menu_batch` (also supports non-AJAX post to `softone_wc_integration_delete_main_menu`).
 - Category Sync Logs screen: aggregates category-assignment log entries (via Woo logs and the dedicated logger).
 - Sync Activity screen: streams JSON-lines entries from the file-based logger; polls at a configurable interval.
 - API Tester screen: submits ad-hoc payloads to SoftOne; stores recent results per user in transients.
@@ -141,7 +141,7 @@ This document explains the plugin’s functionality based exclusively on the sou
 
 - Class: `includes/class-softone-menu-populator.php`.
 - Hook: filters `wp_nav_menu_objects`.
-- Scope: only acts on the navigation menu named `Main Menu`.
+- Scope: only acts on the navigation menu identified by `softone_wc_integration_get_main_menu_name()` (defaults to `Main Menu`; filterable via `softone_wc_integration_main_menu_name`).
 - Behaviour:
   - Removes prior generated items marked with class `softone-dynamic-menu-item`.
   - Finds existing menu items titled `Brands` and `Products`.

--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
         exit;
 }
 
+if ( ! function_exists( 'softone_wc_integration_get_main_menu_name' ) ) {
+        require_once __DIR__ . '/softone-menu-helpers.php';
+}
+
 if ( ! class_exists( 'Softone_Sync_Activity_Logger' ) ) {
         require_once __DIR__ . '/class-softone-sync-activity-logger.php';
 }
@@ -145,7 +149,7 @@ class Softone_Menu_Populator {
          * @return bool
          */
         private function is_main_menu( $args ) {
-                return 'Main Menu' === $this->get_menu_name( $args );
+                return softone_wc_integration_get_main_menu_name() === $this->get_menu_name( $args );
         }
 
         /**

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -174,15 +174,20 @@ class Softone_Woocommerce_Integration {
                  */
                 require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-order-sync.php';
 
-		/**
-		 * Helper for dynamically populating navigation menus.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-menu-populator.php';
+                /**
+                 * Shared helpers for working with navigation menus.
+                 */
+                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/softone-menu-helpers.php';
 
-		/**
-		 * Helper functions for accessing plugin settings.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/softone-woocommerce-integration-settings.php';
+                /**
+                 * Helper for dynamically populating navigation menus.
+                 */
+                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-menu-populator.php';
+
+                /**
+                 * Helper functions for accessing plugin settings.
+                 */
+                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/softone-woocommerce-integration-settings.php';
 
 		/**
 		 * Shared hooks used by both admin and public contexts.

--- a/includes/softone-menu-helpers.php
+++ b/includes/softone-menu-helpers.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Helper functions for Softone navigation menu integration.
+ *
+ * @package Softone_Woocommerce_Integration
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'softone_wc_integration_get_main_menu_name' ) ) {
+	/**
+	 * Retrieve the navigation menu name targeted by the integration.
+	 *
+	 * Provides a filter so site owners can override the default "Main Menu" label
+	 * while ensuring an empty or non-string value gracefully falls back to the
+	 * original default.
+	 *
+	 * @since 1.9.1
+	 *
+	 * @return string
+	 */
+	function softone_wc_integration_get_main_menu_name() {
+		$default_name = 'Main Menu';
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$menu_name = apply_filters( 'softone_wc_integration_main_menu_name', $default_name );
+		} else {
+			$menu_name = $default_name;
+		}
+
+		if ( ! is_string( $menu_name ) ) {
+			return $default_name;
+		}
+
+		$menu_name = trim( $menu_name );
+
+		if ( '' === $menu_name ) {
+			return $default_name;
+		}
+
+		return $menu_name;
+	}
+}

--- a/tests/menu-populator-regression-test.php
+++ b/tests/menu-populator-regression-test.php
@@ -129,6 +129,7 @@ if ( ! function_exists( '__' ) ) {
     }
 }
 
+require_once dirname( __DIR__ ) . '/includes/softone-menu-helpers.php';
 require_once dirname( __DIR__ ) . '/includes/class-softone-menu-populator.php';
 
 /**
@@ -209,7 +210,7 @@ $main_menu_items = array(
 
 $main_args = (object) array(
     'menu' => (object) array(
-        'name' => 'Main Menu',
+        'name' => softone_wc_integration_get_main_menu_name(),
     ),
 );
 


### PR DESCRIPTION
## Summary
- add a shared helper to expose the main menu name and filter hook
- load the helper across the plugin and replace hard-coded "Main Menu" checks
- refresh docs and the menu populator regression test to reference the helper

## Testing
- php -l includes/softone-menu-helpers.php
- php -l includes/class-softone-menu-populator.php
- php -l admin/class-softone-woocommerce-integration-admin.php
- php -l tests/menu-populator-regression-test.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691746ca05e88327aa91c0c6e69ed615)