### PR TITLE
Refactor item sync scheduling into dedicated services

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -75,7 +75,7 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Authentication failures** – Recheck the endpoint URL formatting, confirm that the API user has access to the specified company/branch/module, and verify that firewalls allow outbound connections to the SoftOne server. Use the API tester to validate credentials with a simple `authenticate` request.
 * **Orders not exporting** – Ensure the Default SALDOC Series is configured, confirm that the customer synchronisation completed (look for notes on the order), and inspect the WooCommerce order notes/logs for `[SO-ORD-###]` messages indicating what failed.
 * **No categories appearing in menus** – Confirm that WooCommerce’s product categories exist and that recent item imports completed. The Category Sync Logs screen highlights any taxonomy creation issues.
-* **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Sync::schedule_event()`.
+* **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
 

--- a/docs/Functional-Overview.md
+++ b/docs/Functional-Overview.md
@@ -9,7 +9,7 @@ This document explains the plugin’s functionality based exclusively on the sou
   - Internationalisation: `includes/class-softone-woocommerce-integration-i18n.php` loads the `softone-woocommerce-integration` textdomain.
   - Admin UI: `admin/class-softone-woocommerce-integration-admin.php` (settings, API tester, logs, import controls).
   - Public UI: `public/class-softone-woocommerce-integration-public.php` (asset enqueues) and menu population via `includes/class-softone-menu-populator.php`.
-  - Services: `includes/class-softone-api-client.php`, `includes/class-softone-item-sync.php`, `includes/class-softone-customer-sync.php`, `includes/class-softone-order-sync.php`, `includes/class-softone-sku-image-attacher.php`, `includes/class-softone-sync-activity-logger.php`, `includes/class-softone-category-sync-logger.php`.
+  - Services: `includes/class-softone-api-client.php`, `includes/class-softone-item-sync.php`, `includes/class-softone-item-cron-manager.php`, `includes/class-softone-item-stale-handler.php`, `includes/class-softone-customer-sync.php`, `includes/class-softone-order-sync.php`, `includes/class-softone-sku-image-attacher.php`, `includes/class-softone-sync-activity-logger.php`, `includes/class-softone-category-sync-logger.php`.
   - Loader: `includes/class-softone-woocommerce-integration-loader.php` registers actions/filters.
 - Brand taxonomy: On `init`, `maybe_register_brand_taxonomy()` ensures a non-hierarchical `product_brand` taxonomy exists (slug `brand`, REST-enabled, nav menu-enabled). Filters: `softone_product_brand_taxonomy_objects`, `softone_product_brand_taxonomy_args`.
 
@@ -68,9 +68,9 @@ This document explains the plugin’s functionality based exclusively on the sou
 
 ## Item Synchronisation
 
-- Class: `includes/class-softone-item-sync.php`.
+- Classes: `includes/class-softone-item-sync.php` (core importer), `includes/class-softone-item-cron-manager.php` (scheduling), `includes/class-softone-item-stale-handler.php` (post-run cleanup).
 - Scheduling:
-  - Cron hook: `softone_wc_integration_sync_items`. Scheduled on `init` if not present; default interval `hourly` (filter `softone_wc_integration_item_sync_interval`).
+  - Cron hook: `softone_wc_integration_sync_items`. Scheduled on `init` by `Softone_Item_Cron_Manager`; default interval `hourly` (filter `softone_wc_integration_item_sync_interval`).
   - Admin action: `softone_wc_integration_run_item_import` for manual triggers.
   - Last run timestamp: option `softone_wc_integration_last_item_sync`.
 - Meta used on products/variations:
@@ -97,7 +97,7 @@ This document explains the plugin’s functionality based exclusively on the sou
     - `backorder_out_of_stock_products = yes`: marks out-of-stock items as backorderable.
   - Images: `Softone_Sku_Image_Attacher::attach_gallery_from_sku($productId, $sku)` auto-sets featured/gallery images based on media filenames that start with the SKU (supports suffixes like `_1`, `-2`, spaces).
 - Stale products handling:
-  - `handle_stale_products($run_timestamp)`: finds products managed by SoftOne that were not updated during this run and either drafts them or marks as out of stock.
+  - `Softone_Item_Stale_Handler::handle($run_timestamp)` finds products managed by SoftOne that were not updated during this run and either drafts them or marks as out of stock.
   - Filters: `softone_wc_integration_stale_item_action` (`draft` or `stock_out`, default `stock_out`), `softone_wc_integration_stale_item_batch_size`.
 - Performance/logging:
   - Caches for terms, attributes, and taxonomy lookups; optional memory limit bump via `softone_wc_integration_item_sync_memory_limit`.

--- a/includes/class-softone-item-cron-manager.php
+++ b/includes/class-softone-item-cron-manager.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Coordinates WP-Cron scheduling for the Softone item sync.
+ *
+ * @package Softone_Woocommerce_Integration
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'Softone_Item_Cron_Manager' ) ) {
+	/**
+	 * Provides scheduling helpers and cron callbacks for the item sync workflow.
+	 */
+	class Softone_Item_Cron_Manager {
+
+		/** @var Softone_Item_Sync */
+		protected $item_sync;
+
+		/** @var WC_Logger|Psr\Log\LoggerInterface|null */
+		protected $logger;
+
+		/**
+		 * @param Softone_Item_Sync                             $item_sync Item synchronisation service.
+		 * @param WC_Logger|Psr\Log\LoggerInterface|null $logger    Optional logger instance.
+		 */
+		public function __construct( Softone_Item_Sync $item_sync, $logger = null ) {
+			$this->item_sync = $item_sync;
+			$this->logger    = $logger;
+		}
+
+		/**
+		 * Register WordPress hooks for scheduling the cron event.
+		 *
+		 * @param Softone_Woocommerce_Integration_Loader $loader Hook loader.
+		 * @return void
+		 */
+		public function register_hooks( Softone_Woocommerce_Integration_Loader $loader ) {
+			$loader->add_action( 'init', $this, 'ensure_schedule' );
+			$loader->add_action( Softone_Item_Sync::CRON_HOOK, $this, 'run_scheduled_sync', 10, 0 );
+		}
+
+		/** @return void */
+		public function ensure_schedule() {
+			self::schedule_event();
+		}
+
+		/**
+		 * Schedule the Softone item sync cron event.
+		 *
+		 * @return void
+		 */
+		public static function schedule_event() {
+			if ( wp_next_scheduled( Softone_Item_Sync::CRON_HOOK ) ) {
+				return;
+			}
+
+			$interval = apply_filters( 'softone_wc_integration_item_sync_interval', Softone_Item_Sync::DEFAULT_CRON_EVENT );
+			if ( ! is_string( $interval ) || '' === $interval ) {
+				$interval = Softone_Item_Sync::DEFAULT_CRON_EVENT;
+			}
+
+			wp_schedule_event( time() + MINUTE_IN_SECONDS, $interval, Softone_Item_Sync::CRON_HOOK );
+		}
+
+		/**
+		 * Clear any scheduled Softone item sync cron events.
+		 *
+		 * @return void
+		 */
+		public static function clear_scheduled_event() {
+			if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+				wp_clear_scheduled_hook( Softone_Item_Sync::CRON_HOOK );
+				return;
+			}
+
+			$timestamp = wp_next_scheduled( Softone_Item_Sync::CRON_HOOK );
+
+			while ( false !== $timestamp ) {
+				wp_unschedule_event( $timestamp, Softone_Item_Sync::CRON_HOOK );
+				$timestamp = wp_next_scheduled( Softone_Item_Sync::CRON_HOOK );
+			}
+		}
+
+		/**
+		 * Cron callback used to trigger the item synchronisation run.
+		 *
+		 * @return void
+		 */
+		public function run_scheduled_sync() {
+			try {
+				$result = $this->item_sync->sync();
+				if ( isset( $result['processed'] ) ) {
+					$timestamp = isset( $result['started_at'] ) ? (int) $result['started_at'] : time();
+					update_option( Softone_Item_Sync::OPTION_LAST_RUN, $timestamp );
+				}
+			} catch ( Exception $exception ) {
+				$this->log( 'error', $exception->getMessage(), array( 'exception' => $exception ) );
+			}
+		}
+
+		/**
+		 * Proxy logging helper that mirrors the sync service behaviour.
+		 *
+		 * @param string $level   Log level.
+		 * @param string $message Message.
+		 * @param array  $context Context array.
+		 * @return void
+		 */
+		protected function log( $level, $message, array $context = array() ) {
+			if ( ! $this->logger || ! method_exists( $this->logger, 'log' ) ) {
+				return;
+			}
+
+			if ( class_exists( 'WC_Logger' ) && $this->logger instanceof WC_Logger ) {
+				$context['source'] = Softone_Item_Sync::LOGGER_SOURCE;
+			}
+
+			$this->logger->log( $level, $message, $context );
+		}
+	}
+}

--- a/includes/class-softone-item-stale-handler.php
+++ b/includes/class-softone-item-stale-handler.php
@@ -1,0 +1,171 @@
+<?php
+/**
+* Handles Softone-managed product stale state updates.
+*
+* @package Softone_Woocommerce_Integration
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'Softone_Item_Stale_Handler' ) ) {
+	/**
+	 * Applies post-run actions to WooCommerce products that were not touched
+	 * during the latest Softone import cycle.
+	 */
+	class Softone_Item_Stale_Handler {
+
+		/** @var WC_Logger|Psr\Log\LoggerInterface|null */
+		protected $logger;
+
+		/**
+		 * @param WC_Logger|Psr\Log\LoggerInterface|null $logger Optional logger instance.
+		 */
+		public function __construct( $logger = null ) {
+			$this->logger = $logger;
+		}
+
+		/**
+		 * Mark Softone managed products as stale when they were not processed during the run.
+		 *
+		 * @param int $run_timestamp Sync run start timestamp.
+		 * @return int Number of products processed.
+		 */
+		public function handle( $run_timestamp ) {
+			if ( ! is_numeric( $run_timestamp ) || $run_timestamp <= 0 ) {
+				return 0;
+			}
+
+			$action = apply_filters( 'softone_wc_integration_stale_item_action', 'stock_out' );
+			if ( ! in_array( $action, array( 'draft', 'stock_out' ), true ) ) {
+				$action = 'stock_out';
+			}
+
+			$batch_size = (int) apply_filters( 'softone_wc_integration_stale_item_batch_size', 50 );
+			if ( $batch_size <= 0 ) {
+				$batch_size = 50;
+			}
+
+			$processed = 0;
+
+			do {
+				$query = new WP_Query(
+					array(
+						'post_type'      => 'product',
+						'post_status'    => 'any',
+						'fields'         => 'ids',
+						'posts_per_page' => $batch_size,
+						'orderby'        => 'ID',
+						'order'          => 'ASC',
+						'meta_query'     => array(
+							'relation' => 'AND',
+							array(
+								'key'     => Softone_Item_Sync::META_MTRL,
+								'compare' => 'EXISTS',
+							),
+							array(
+								'relation' => 'OR',
+								array(
+									'key'     => Softone_Item_Sync::META_LAST_SYNC,
+									'compare' => 'NOT EXISTS',
+								),
+								array(
+									'key'     => Softone_Item_Sync::META_LAST_SYNC,
+									'value'   => (int) $run_timestamp,
+									'type'    => 'NUMERIC',
+									'compare' => '<',
+								),
+							),
+						),
+					)
+				);
+
+				if ( ! $query->have_posts() ) {
+					wp_reset_postdata();
+					break;
+				}
+
+				foreach ( $query->posts as $product_id ) {
+					$processed++;
+
+					$product = wc_get_product( $product_id );
+					if ( ! $product ) {
+						$this->log( 'warning', 'Unable to load product while marking as stale.', array( 'product_id' => $product_id ) );
+						update_post_meta( $product_id, Softone_Item_Sync::META_LAST_SYNC, (int) $run_timestamp );
+						continue;
+					}
+
+					$sku = '';
+					if ( method_exists( $product, 'get_sku' ) ) {
+						$sku = (string) $product->get_sku();
+					}
+
+					if ( 'draft' === $action ) {
+						if ( 'draft' !== $product->get_status() ) {
+							$product->set_status( 'draft' );
+						}
+					} else {
+						if ( 'publish' !== $product->get_status() ) {
+							$product->set_status( 'publish' );
+						}
+						$product->set_stock_status( 'outofstock' );
+					}
+
+					$product->save();
+
+					if ( '' !== $sku && class_exists( 'Softone_Sku_Image_Attacher' ) ) {
+						Softone_Sku_Image_Attacher::attach_gallery_from_sku( (int) $product_id, $sku );
+					}
+
+					update_post_meta( $product_id, Softone_Item_Sync::META_LAST_SYNC, (int) $run_timestamp );
+
+					$this->log(
+						'info',
+						'Marked product as stale following Softone sync run.',
+						array(
+							'product_id' => $product_id,
+							'action'     => $action,
+						)
+					);
+				}
+
+				wp_reset_postdata();
+			} while ( true );
+
+			if ( $processed > 0 ) {
+				$this->log(
+					'notice',
+					sprintf( 'Handled %d stale Softone products.', $processed ),
+					array(
+						'action'     => $action,
+						'timestamp'  => $run_timestamp,
+						'batch_size' => $batch_size,
+					)
+				);
+			}
+
+			return $processed;
+		}
+
+		/**
+		 * Proxy logging helper that mirrors the behaviour used by the sync class.
+		 *
+		 * @param string $level   Log level.
+		 * @param string $message Message.
+		 * @param array  $context Context array.
+		 * @return void
+		 */
+		protected function log( $level, $message, array $context = array() ) {
+			if ( ! $this->logger || ! method_exists( $this->logger, 'log' ) ) {
+				return;
+			}
+
+			if ( class_exists( 'WC_Logger' ) && $this->logger instanceof WC_Logger ) {
+				$context['source'] = class_exists( 'Softone_Item_Sync' ) ? Softone_Item_Sync::LOGGER_SOURCE : 'softone-item-sync';
+			}
+
+			$this->logger->log( $level, $message, $context );
+		}
+	}
+}

--- a/includes/class-softone-woocommerce-integration-activator.php
+++ b/includes/class-softone-woocommerce-integration-activator.php
@@ -32,8 +32,9 @@ class Softone_Woocommerce_Integration_Activator {
         public static function activate() {
 
                 require_once plugin_dir_path( __FILE__ ) . 'class-softone-item-sync.php';
+                require_once plugin_dir_path( __FILE__ ) . 'class-softone-item-cron-manager.php';
 
-                Softone_Item_Sync::schedule_event();
+                Softone_Item_Cron_Manager::schedule_event();
 
         }
 

--- a/includes/class-softone-woocommerce-integration-deactivator.php
+++ b/includes/class-softone-woocommerce-integration-deactivator.php
@@ -32,8 +32,9 @@ class Softone_Woocommerce_Integration_Deactivator {
         public static function deactivate() {
 
                 require_once plugin_dir_path( __FILE__ ) . 'class-softone-item-sync.php';
+                require_once plugin_dir_path( __FILE__ ) . 'class-softone-item-cron-manager.php';
 
-                Softone_Item_Sync::clear_scheduled_event();
+                Softone_Item_Cron_Manager::clear_scheduled_event();
 
         }
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -65,6 +65,13 @@ class Softone_Woocommerce_Integration {
         protected $item_sync;
 
         /**
+         * Cron manager responsible for the item sync schedule.
+         *
+         * @var Softone_Item_Cron_Manager
+         */
+        protected $item_cron_manager;
+
+        /**
          * File-based activity logger instance.
          *
          * @var Softone_Sync_Activity_Logger
@@ -165,6 +172,11 @@ class Softone_Woocommerce_Integration {
                 require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-item-sync.php';
 
                 /**
+                 * Coordinates cron scheduling for the item sync workflow.
+                 */
+                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-item-cron-manager.php';
+
+                /**
                  * Service class for synchronising WooCommerce customers with SoftOne.
                  */
                 require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-softone-customer-sync.php';
@@ -216,15 +228,16 @@ class Softone_Woocommerce_Integration {
 
 		$this->loader          = new Softone_Woocommerce_Integration_Loader();
 		$this->activity_logger = new Softone_Sync_Activity_Logger();
-		$this->item_sync       = new Softone_Item_Sync( null, null, null, $this->activity_logger );
-		$this->customer_sync   = new Softone_Customer_Sync();
-		$this->order_sync      = new Softone_Order_Sync( null, $this->customer_sync );
-		$this->shared_module   = new Softone_Woocommerce_Integration_Shared();
+                $this->item_sync       = new Softone_Item_Sync( null, null, null, $this->activity_logger );
+                $this->item_cron_manager = new Softone_Item_Cron_Manager( $this->item_sync, $this->item_sync->get_logger() );
+                $this->customer_sync   = new Softone_Customer_Sync();
+                $this->order_sync      = new Softone_Order_Sync( null, $this->customer_sync );
+                $this->shared_module   = new Softone_Woocommerce_Integration_Shared();
 
-		$this->item_sync->register_hooks( $this->loader );
-		$this->customer_sync->register_hooks( $this->loader );
-		$this->order_sync->register_hooks( $this->loader );
-		$this->shared_module->register_hooks( $this->loader );
+                $this->item_cron_manager->register_hooks( $this->loader );
+                $this->customer_sync->register_hooks( $this->loader );
+                $this->order_sync->register_hooks( $this->loader );
+                $this->shared_module->register_hooks( $this->loader );
 
         }
 

--- a/tests/async-batch-pagination-check.php
+++ b/tests/async-batch-pagination-check.php
@@ -146,7 +146,19 @@ class Softone_Item_Sync_Logger {
 
 require_once dirname( __DIR__ ) . '/includes/class-softone-item-sync.php';
 
+class Softone_Item_Stale_Handler_Stub extends Softone_Item_Stale_Handler {
+    public function __construct() {}
+
+    public function handle( $run_timestamp ) {
+        return 0;
+    }
+}
+
 class Softone_Item_Sync_Async_Test extends Softone_Item_Sync {
+    public function __construct( $api_client = null, $logger = null ) {
+        parent::__construct( $api_client, $logger, null, null, new Softone_Item_Stale_Handler_Stub() );
+    }
+
     /**
      * @var array<int, array<string, mixed>>
      */
@@ -179,14 +191,6 @@ class Softone_Item_Sync_Async_Test extends Softone_Item_Sync {
 
     /** @return void */
     protected function process_pending_colour_variation_syncs() {}
-
-    /**
-     * @param int $run_timestamp
-     * @return int
-     */
-    protected function handle_stale_products( $run_timestamp ) {
-        return 0;
-    }
 
     /**
      * @param string $level


### PR DESCRIPTION
## Summary
- add dedicated Softone_Item_Stale_Handler and Softone_Item_Cron_Manager services for stale cleanup and cron orchestration
- inject the new collaborators into Softone_Item_Sync and update the bootstrap, activator, and deactivator wiring accordingly
- refresh regression tests and documentation to cover the new structure

## Testing
- php -l includes/class-softone-item-stale-handler.php
- php -l includes/class-softone-item-cron-manager.php
- php -l includes/class-softone-item-sync.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l includes/class-softone-woocommerce-integration-activator.php
- php -l includes/class-softone-woocommerce-integration-deactivator.php
- php -l tests/async-batch-pagination-check.php
- php -l tests/stale-product-image-attachment-regression-test.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69174b73ef6883279b8df3cd5868b63e)