### PR TITLE
Mirror Softone menu items in admin

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.2
+Stable tag: 1.10.3
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -23,7 +23,7 @@ Softone WooCommerce Integration keeps your catalogue, shoppers, and sales aligne
 * **Order export** – Sends WooCommerce orders to SoftOne SALDOC documents once orders reach the configured statuses and records the resulting document ID back on the order.
 * **API tester** – Provides an in-dashboard tester with sample payload presets so administrators can validate credentials, run ad-hoc calls, and inspect the raw responses returned by SoftOne.
 * **Category log viewer** – Surfaces category synchronisation entries aggregated from WooCommerce logs to make diagnosing catalogue imports easier.
-* **Menu population helpers** – Optionally extend WooCommerce menu structures to include synced SoftOne product categories, even when the site does not expose brand taxonomies. Placeholder menu items can be translated or retitled via the `softone_wc_integration_menu_placeholder_titles` filter, or matched via metadata using `softone_wc_integration_menu_placeholder_config`.
+* **Menu population helpers** – Optionally extend WooCommerce menu structures to include synced SoftOne product categories, even when the site does not expose brand taxonomies. The Appearance → Menus preview now mirrors the front-end by injecting the same virtual Softone category and brand entries beneath the configured placeholders, and those entries remain unsaved so manual edits stay intact. Placeholder menu items can be translated or retitled via the `softone_wc_integration_menu_placeholder_titles` filter, or matched via metadata using `softone_wc_integration_menu_placeholder_config`.
 
 = Prerequisites =
 
@@ -75,9 +75,14 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Authentication failures** – Recheck the endpoint URL formatting, confirm that the API user has access to the specified company/branch/module, and verify that firewalls allow outbound connections to the SoftOne server. Use the API tester to validate credentials with a simple `authenticate` request.
 * **Orders not exporting** – Ensure the Default SALDOC Series is configured, confirm that the customer synchronisation completed (look for notes on the order), and inspect the WooCommerce order notes/logs for `[SO-ORD-###]` messages indicating what failed.
 * **No categories appearing in menus** – Confirm that WooCommerce’s product categories exist and that recent item imports completed. The Category Sync Logs screen highlights any taxonomy creation issues.
+* **Verify Softone placeholders** – Visit **Appearance → Menus** and load the configured main menu to confirm the virtual Softone category and brand entries appear beneath their placeholders. The admin preview now mirrors the front-end while keeping those injected links unsaved.
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.3 =
+* Enhancement: Populate Softone categories and brands on the Appearance → Menus screen so the backend preview mirrors the front-end while keeping the injected entries virtual.
+* Fix: Guard the menu population workflow to avoid injecting duplicate items when both admin and public filters run during the same request.
 
 = 1.10.2 =
 * Version bump and housekeeping.

--- a/docs/Functional-Overview.md
+++ b/docs/Functional-Overview.md
@@ -140,13 +140,14 @@ This document explains the plugin’s functionality based exclusively on the sou
 ## Public Menu Population
 
 - Class: `includes/class-softone-menu-populator.php`.
-- Hook: filters `wp_nav_menu_objects`.
+- Hooks: filters `wp_nav_menu_objects` on the front-end and `wp_get_nav_menu_items` inside wp-admin so the Appearance → Menus preview mirrors the storefront output.
 - Scope: only acts on the navigation menu identified by `softone_wc_integration_get_main_menu_name()` (defaults to `Main Menu`; filterable via `softone_wc_integration_main_menu_name`).
 - Behaviour:
   - Removes prior generated items marked with class `softone-dynamic-menu-item`.
   - Locates placeholder menu items (defaults to titles `Brands` and `Products`; filterable via `softone_wc_integration_menu_placeholder_titles`).
   - Adds child items under `Brands` for all `product_brand` terms (sorted by name).
   - Adds child items under `Products` for the full `product_cat` tree, excluding WooCommerce’s default “Uncategorized” (children re-parented to top-level).
+  - Guards per menu name to prevent duplicate injections when both filters fire during the same request while keeping the entries virtual (unsaved).
   - Emits activity log entries when dynamic items are injected.
   - Placeholder detection can be extended via `softone_wc_integration_menu_placeholder_config` to match menu item classes or metadata, making translations or bespoke placeholders possible without renaming the defaults.
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -109,11 +109,11 @@ class Softone_Woocommerce_Integration {
          * @since    1.0.0
          */
 	public function __construct() {
-		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-		} else {
-			$this->version = '1.10.2';
-		}
+if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+} else {
+$this->version = '1.10.3';
+}
 		$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();
@@ -267,23 +267,25 @@ class Softone_Woocommerce_Integration {
 	 */
 	private function define_admin_hooks() {
 
-                $plugin_admin = new Softone_Woocommerce_Integration_Admin( $this->get_plugin_name(), $this->get_version(), $this->item_sync, $this->activity_logger );
+		$plugin_admin        = new Softone_Woocommerce_Integration_Admin( $this->get_plugin_name(), $this->get_version(), $this->item_sync, $this->activity_logger );
+		$admin_menu_populator = new Softone_Menu_Populator( $this->activity_logger );
 
-                $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
-                $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
-                $this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu' );
-                $this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
+		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+		$this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu' );
+		$this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
                 $this->loader->add_action( 'admin_post_softone_wc_integration_api_tester', $plugin_admin, 'handle_api_tester_request' );
                 $this->loader->add_action( 'admin_post_softone_wc_integration_test_connection', $plugin_admin, 'handle_test_connection' );
                 $this->loader->add_action( 'admin_post_' . Softone_Item_Sync::ADMIN_ACTION, $plugin_admin, 'handle_item_import' );
                 $this->loader->add_action( 'admin_post_softone_wc_integration_clear_sync_activity', $plugin_admin, 'handle_clear_sync_activity' );
                 $this->loader->add_action( 'admin_post_' . $plugin_admin->get_delete_main_menu_action(), $plugin_admin, 'handle_delete_main_menu' );
                 $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_sync_activity_action(), $plugin_admin, 'handle_sync_activity_ajax' );
-                $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_process_trace_action(), $plugin_admin, 'handle_process_trace_ajax' );
-                $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_item_import_ajax_action(), $plugin_admin, 'handle_item_import_ajax' );
-                $this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_delete_main_menu_ajax_action(), $plugin_admin, 'handle_delete_main_menu_ajax' );
+		$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_process_trace_action(), $plugin_admin, 'handle_process_trace_ajax' );
+		$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_item_import_ajax_action(), $plugin_admin, 'handle_item_import_ajax' );
+		$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_delete_main_menu_ajax_action(), $plugin_admin, 'handle_delete_main_menu_ajax' );
+		$this->loader->add_filter( 'wp_get_nav_menu_items', $admin_menu_populator, 'filter_admin_menu_items', 10, 3 );
 
-        }
+	}
 
 	/**
 	 * Register all of the hooks related to the public-facing functionality

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.2
+ * Version:           1.10.3
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.2' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.3' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- populate the Appearance → Menus screen with the same virtual Softone categories/brands that appear on the storefront and guard the helper so each menu is processed once per request
- expose an admin-only `wp_get_nav_menu_items` filter, update the README/docs to describe the mirrored preview, and bump the plugin version to 1.10.3

## Testing
- php -l includes/class-softone-menu-populator.php
- php -l includes/class-softone-woocommerce-integration.php
- php -l softone-woocommerce-integration.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919fe01639c8327ba87bff6ad552026)