### PR TITLE
Fix menu populator fatal and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.3
+Stable tag: 1.10.4
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.4 =
+* Fix: Prevent fatal errors by ensuring the menu populator registers `has_processed_menu()` only once per class definition.
 
 = 1.10.3 =
 * Enhancement: Populate Softone categories and brands on the Appearance → Menus screen so the backend preview mirrors the front-end while keeping the injected entries virtual.

--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -375,27 +375,6 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	}
 
 	/**
-	 * Determine whether the provided menu already received dynamic items this request.
-	 *
-	 * @param string $menu_name Menu name identifier.
-	 *
-	 * @return bool True when the menu has already been processed.
-	 */
-	private function has_processed_menu( $menu_name ) {
-		if ( '' === $menu_name ) {
-			return false;
-		}
-
-		if ( isset( $this->processed_menus[ $menu_name ] ) ) {
-			return true;
-		}
-
-		$this->processed_menus[ $menu_name ] = true;
-
-		return false;
-	}
-
-	/**
 	 * Locate the placeholder menu item for a given dynamic item group.
 	 *
 	 * @param array<int, WP_Post|object> $menu_items Menu items.
@@ -404,70 +383,70 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	 * @return WP_Post|object|null
 	 */
 	private function find_placeholder_item( array $menu_items, $type ) {
-	        $config = $this->get_placeholder_config();
+		$config = $this->get_placeholder_config();
 
-	        if ( empty( $config[ $type ] ) || ! is_array( $config[ $type ] ) ) {
-	                return null;
-	        }
+		if ( empty( $config[ $type ] ) || ! is_array( $config[ $type ] ) ) {
+			return null;
+		}
 
-	        foreach ( $menu_items as $item ) {
-	                if ( $this->matches_placeholder_definition( $item, $config[ $type ] ) ) {
-	                        return $item;
-	                }
-	        }
+		foreach ( $menu_items as $item ) {
+			if ( $this->matches_placeholder_definition( $item, $config[ $type ] ) ) {
+				return $item;
+			}
+		}
 
-	        return null;
+		return null;
 	}
 
-/**
- * Retrieve configuration for locating placeholder menu items.
- *
- * The defaults target menu items titled "Brands" and "Products" to preserve
- * backwards compatibility. Site owners can override these values using the
- * `softone_wc_integration_menu_placeholder_titles` filter, or provide a richer
- * configuration (including CSS classes and menu item meta matching rules) via
- * the `softone_wc_integration_menu_placeholder_config` filter.
- *
- * @return array<string, array<string, mixed>>
- */
+	/**
+	 * Retrieve configuration for locating placeholder menu items.
+	 *
+	 * The defaults target menu items titled "Brands" and "Products" to preserve
+	 * backwards compatibility. Site owners can override these values using the
+	 * `softone_wc_integration_menu_placeholder_titles` filter, or provide a richer
+	 * configuration (including CSS classes and menu item meta matching rules) via
+	 * the `softone_wc_integration_menu_placeholder_config` filter.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
 	private function get_placeholder_config() {
-	        if ( null !== $this->placeholder_config ) {
-	                return $this->placeholder_config;
-	        }
+		if ( null !== $this->placeholder_config ) {
+			return $this->placeholder_config;
+		}
 
-	        $default_titles = array(
-	                'brands'   => array( 'Brands' ),
-	                'products' => array( 'Products' ),
-	        );
+		$default_titles = array(
+			'brands'   => array( 'Brands' ),
+			'products' => array( 'Products' ),
+		);
 
-	        if ( function_exists( 'apply_filters' ) ) {
-	                $filtered_titles = apply_filters( 'softone_wc_integration_menu_placeholder_titles', $default_titles );
-	                $default_titles  = $this->merge_placeholder_titles( $default_titles, $filtered_titles );
-	        }
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered_titles = apply_filters( 'softone_wc_integration_menu_placeholder_titles', $default_titles );
+			$default_titles  = $this->merge_placeholder_titles( $default_titles, $filtered_titles );
+		}
 
-	        $config = array(
-	                'brands'   => array(
-	                        'titles'  => $default_titles['brands'],
-	                        'classes' => array(),
-	                        'meta'    => array(),
-	                ),
-	                'products' => array(
-	                        'titles'  => $default_titles['products'],
-	                        'classes' => array(),
-	                        'meta'    => array(),
-	                ),
-	        );
+		$config = array(
+			'brands'   => array(
+				'titles'  => $default_titles['brands'],
+				'classes' => array(),
+				'meta'    => array(),
+			),
+			'products' => array(
+				'titles'  => $default_titles['products'],
+				'classes' => array(),
+				'meta'    => array(),
+			),
+		);
 
-	        if ( function_exists( 'apply_filters' ) ) {
-	                $filtered_config = apply_filters( 'softone_wc_integration_menu_placeholder_config', $config, $default_titles );
-	                if ( is_array( $filtered_config ) ) {
-	                        $config = $this->merge_placeholder_config( $config, $filtered_config );
-	                }
-	        }
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered_config = apply_filters( 'softone_wc_integration_menu_placeholder_config', $config, $default_titles );
+			if ( is_array( $filtered_config ) ) {
+				$config = $this->merge_placeholder_config( $config, $filtered_config );
+			}
+		}
 
-	        $this->placeholder_config = $config;
+		$this->placeholder_config = $config;
 
-	        return $this->placeholder_config;
+		return $this->placeholder_config;
 	}
 
 	/**

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -112,7 +112,7 @@ class Softone_Woocommerce_Integration {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.10.3';
+$this->version = '1.10.4';
 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.3
+ * Version:           1.10.4
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.3' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.4' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- remove the duplicate `has_processed_menu()` definition so the menu populator class no longer triggers a fatal error
- tidy the placeholder configuration helpers and keep their docblocks consistently indented
- bump the plugin version to 1.10.4 and document the fix in the readme

## Testing
- `php -l includes/class-softone-menu-populator.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a04a4fe188327bee78bc53b27dd65)