### PR TITLE
Ensure menu populator items appear in Appearance → Menus

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.4
+Stable tag: 1.10.5
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.5 =
+* Fix: Run the menu item preparation helpers inside Appearance → Menus so the dynamically injected Softone entries mirror the public navigation preview.
 
 = 1.10.4 =
 * Fix: Prevent fatal errors by ensuring the menu populator registers `has_processed_menu()` only once per class definition.

--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -180,7 +180,9 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 
 		$normalised_args = $this->normalise_admin_menu_args( $menu, $args );
 
-		return $this->filter_menu_items( $items, $normalised_args );
+		$items = $this->filter_menu_items( $items, $normalised_args );
+
+		return $this->prepare_admin_menu_items( $items );
 	}
 
 	/**

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -112,7 +112,7 @@ class Softone_Woocommerce_Integration {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.10.4';
+$this->version = '1.10.5';
 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.4
+ * Version:           1.10.5
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.4' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.5' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- make the admin Appearance → Menus view run the same preparation logic as the public menu filter so Softone’s dynamic entries render correctly
- bump the plugin version to 1.10.5 and update the readme stable tag and changelog accordingly

## Testing
- php -l includes/class-softone-menu-populator.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a0753ceb483279b6283a277387c9e)