### PR TITLE
Stop frontend menu injection and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.6
+Stable tag: 1.10.7
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -23,7 +23,7 @@ Softone WooCommerce Integration keeps your catalogue, shoppers, and sales aligne
 * **Order export** – Sends WooCommerce orders to SoftOne SALDOC documents once orders reach the configured statuses and records the resulting document ID back on the order.
 * **API tester** – Provides an in-dashboard tester with sample payload presets so administrators can validate credentials, run ad-hoc calls, and inspect the raw responses returned by SoftOne.
 * **Category log viewer** – Surfaces category synchronisation entries aggregated from WooCommerce logs to make diagnosing catalogue imports easier.
-* **Menu population helpers** – Optionally extend WooCommerce menu structures to include synced SoftOne product categories, even when the site does not expose brand taxonomies. The Appearance → Menus preview now mirrors the front-end by injecting the same virtual Softone category and brand entries beneath the configured placeholders, and those entries remain unsaved so manual edits stay intact. Placeholder menu items can be translated or retitled via the `softone_wc_integration_menu_placeholder_titles` filter, or matched via metadata using `softone_wc_integration_menu_placeholder_config`.
+* **Menu population helpers** – Optionally extend WooCommerce menu structures to include synced SoftOne product categories, even when the site does not expose brand taxonomies. The Appearance → Menus preview injects the virtual Softone category and brand entries beneath the configured placeholders so editors can verify the tree before saving, and the storefront now reads from that persisted menu structure instead of relying on runtime injection. Placeholder menu items can be translated or retitled via the `softone_wc_integration_menu_placeholder_titles` filter, or matched via metadata using `softone_wc_integration_menu_placeholder_config`.
 
 = Prerequisites =
 
@@ -75,10 +75,13 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Authentication failures** – Recheck the endpoint URL formatting, confirm that the API user has access to the specified company/branch/module, and verify that firewalls allow outbound connections to the SoftOne server. Use the API tester to validate credentials with a simple `authenticate` request.
 * **Orders not exporting** – Ensure the Default SALDOC Series is configured, confirm that the customer synchronisation completed (look for notes on the order), and inspect the WooCommerce order notes/logs for `[SO-ORD-###]` messages indicating what failed.
 * **No categories appearing in menus** – Confirm that WooCommerce’s product categories exist and that recent item imports completed. The Category Sync Logs screen highlights any taxonomy creation issues.
-* **Verify Softone placeholders** – Visit **Appearance → Menus** and load the configured main menu to confirm the virtual Softone category and brand entries appear beneath their placeholders. The admin preview now mirrors the front-end while keeping those injected links unsaved.
+* **Verify Softone placeholders** – Visit **Appearance → Menus** and load the configured main menu to confirm the virtual Softone category and brand entries appear beneath their placeholders. The admin preview still injects those unsaved links for verification, while the public menu now reads the saved structure generated during the backend population workflow.
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.7 =
+* Change: Stop injecting Softone menu items on the storefront now that the admin preview populates the menu tree, ensuring the public menu reflects the saved structure.
 
 = 1.10.x =
 * Fix: Correct the Softone Integration admin menu registration so the submenu lands on the intended settings page.

--- a/docs/Functional-Overview.md
+++ b/docs/Functional-Overview.md
@@ -140,7 +140,7 @@ This document explains the plugin’s functionality based exclusively on the sou
 ## Public Menu Population
 
 - Class: `includes/class-softone-menu-populator.php`.
-- Hooks: filters `wp_nav_menu_objects` on the front-end and `wp_get_nav_menu_items` inside wp-admin so the Appearance → Menus preview mirrors the storefront output.
+- Hooks: filters `wp_get_nav_menu_items` inside wp-admin so the Appearance → Menus preview injects Softone entries while editors manage the tree; the storefront now relies on the saved menu structure built during that admin workflow instead of runtime injection.
 - Scope: only acts on the navigation menu identified by `softone_wc_integration_get_main_menu_name()` (defaults to `Main Menu`; filterable via `softone_wc_integration_main_menu_name`).
 - Behaviour:
   - Removes prior generated items marked with class `softone-dynamic-menu-item`.

--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -161,7 +161,7 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	 }
 
 	/**
-	 * Filter callback that mirrors front-end menu injection inside wp-admin.
+	 * Filter callback that mirrors the dynamic menu injection inside wp-admin so editors can preview Softone entries.
 	 *
 	 * @param array<int, WP_Post|object> $items Menu items retrieved via wp_get_nav_menu_items().
 	 * @param WP_Term|object|null        $menu  Menu object for the current screen.
@@ -169,7 +169,7 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	 *
 	 * @return array<int, WP_Post|object>
 	 */
-		public function filter_admin_menu_items( $items, $menu, $args ) {
+	public function filter_admin_menu_items( $items, $menu, $args ) {
 			if ( ! is_admin() ) {
 				return $items;
 			}

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -112,7 +112,7 @@ class Softone_Woocommerce_Integration {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.10.6';
+$this->version = '1.10.7';
 }
 		$this->plugin_name = 'softone-woocommerce-integration';
 
@@ -297,11 +297,9 @@ $this->version = '1.10.6';
 	private function define_public_hooks() {
 
 		$plugin_public = new Softone_Woocommerce_Integration_Public( $this->get_plugin_name(), $this->get_version() );
-		$menu_populator = new Softone_Menu_Populator( $this->activity_logger );
 
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
-		$this->loader->add_filter( 'wp_nav_menu_objects', $menu_populator, 'filter_menu_items', 10, 2 );
 
 	}
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.6
+ * Version:           1.10.7
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.6' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.7' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- remove the `wp_nav_menu_objects` filter so the storefront now uses the stored menu structure built in wp-admin
- bump the plugin version to 1.10.7 and update the readme/docs to describe the new menu workflow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a0e0f951c83279313f28528975ce5)