### PR TITLE
Fix Softone menu placeholder IDs

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.7
+Stable tag: 1.10.8
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.8 =
+* Fix: Prevent the “The given object ID is not that of a menu item.” error when saving menus by marking the previewed Softone entries as unsaved placeholders.
 
 = 1.10.7 =
 * Change: Stop injecting Softone menu items on the storefront now that the admin preview populates the menu tree, ensuring the public menu reflects the saved structure.

--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -1109,11 +1109,11 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	                 return null;
 	         }
 
-	         $item = clone $parent_item;
+		$item = clone $parent_item;
 
-	         $item->ID                 = $this->next_id();
-	         $item->db_id              = $item->ID;
-	         $item->menu_item_parent   = isset( $parent_item->db_id ) ? (int) $parent_item->db_id : ( isset( $parent_item->ID ) ? (int) $parent_item->ID : 0 );
+		$item->ID               = $this->next_id();
+		$item->db_id            = 0;
+		$item->menu_item_parent = $this->resolve_parent_menu_id( $parent_item );
 	         $item->object             = (string) $term->taxonomy;
 	         $item->object_id          = (int) $term->term_id;
 	         $item->type               = 'taxonomy';
@@ -1130,10 +1130,29 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	         $item->menu_order         = (int) $menu_order;
 	         $item->post_parent        = isset( $parent_item->post_parent ) ? (int) $parent_item->post_parent : 0;
 	         $item->post_status        = 'publish';
-	         $item->post_type          = 'nav_menu_item';
+		$item->post_type        = 'nav_menu_item';
 
-	         return $item;
-	 }
+		return $item;
+	}
+
+	/**
+	 * Determine the parent identifier for a generated menu item.
+	 *
+	 * @param WP_Post|object $parent_item Parent menu item reference.
+	 *
+	 * @return int
+	 */
+	private function resolve_parent_menu_id( $parent_item ) {
+		if ( isset( $parent_item->db_id ) && (int) $parent_item->db_id > 0 ) {
+			return (int) $parent_item->db_id;
+		}
+
+		if ( isset( $parent_item->ID ) ) {
+			return (int) $parent_item->ID;
+		}
+
+		return 0;
+	}
 
 	 /**
 	  * Generate a sanitized post name for the new menu item.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -109,11 +109,11 @@ class Softone_Woocommerce_Integration {
          * @since    1.0.0
          */
 	public function __construct() {
-if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-} else {
-$this->version = '1.10.7';
-}
+		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+		} else {
+			$this->version = '1.10.8';
+		}
 		$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.7
+ * Version:           1.10.8
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.7' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.8' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';

--- a/tests/menu-populator-regression-test.php
+++ b/tests/menu-populator-regression-test.php
@@ -341,6 +341,25 @@ function softone_create_menu_item( $id, $title, $parent = 0, $order = 0 ) {
 }
 
 /**
+ * Retrieve the best available identifier for a nav menu item.
+ *
+ * @param object $item Menu item reference.
+ *
+ * @return int
+ */
+function softone_get_menu_item_identifier( $item ) {
+    if ( isset( $item->db_id ) && (int) $item->db_id !== 0 ) {
+        return (int) $item->db_id;
+    }
+
+    if ( isset( $item->ID ) ) {
+        return (int) $item->ID;
+    }
+
+    return 0;
+}
+
+/**
  * Summarise dynamic menu output for assertions.
  *
  * @param array<int, object> $items              Menu items.
@@ -385,7 +404,12 @@ function softone_summarise_menu_output( array $items, $brand_parent_id, $product
                 $summary['category_tree'] = array();
             }
 
-            $category_id = (int) $item->db_id;
+            $category_id = softone_get_menu_item_identifier( $item );
+
+            if ( 0 === $category_id ) {
+                continue;
+            }
+
             $category_id_to_title[ $category_id ] = $item->title;
 
             if ( (int) $product_parent_id === (int) $item->menu_item_parent ) {


### PR DESCRIPTION
## Summary
- update the menu populator so dynamically injected Softone entries use placeholder IDs and `db_id` values that WordPress treats as new records, preventing the “The given object ID is not that of a menu item.” failure when saving menus
- expand the regression test helper to work with the new identifier handling and keep the changelog/version in sync with the fix

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a10bfcec483279ba9e85b371e18bf)