### PR TITLE
Add runtime menu injection and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.9
+Stable tag: 1.10.10
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -23,7 +23,7 @@ Softone WooCommerce Integration keeps your catalogue, shoppers, and sales aligne
 * **Order export** – Sends WooCommerce orders to SoftOne SALDOC documents once orders reach the configured statuses and records the resulting document ID back on the order.
 * **API tester** – Provides an in-dashboard tester with sample payload presets so administrators can validate credentials, run ad-hoc calls, and inspect the raw responses returned by SoftOne.
 * **Category log viewer** – Surfaces category synchronisation entries aggregated from WooCommerce logs to make diagnosing catalogue imports easier.
-* **Menu population helpers** – Optionally extend WooCommerce menu structures to include synced SoftOne product categories, even when the site does not expose brand taxonomies. The Appearance → Menus preview injects the virtual Softone category and brand entries beneath the configured placeholders so editors can verify the tree before saving, and the storefront now reads from that persisted menu structure instead of relying on runtime injection. Placeholder menu items can be translated or retitled via the `softone_wc_integration_menu_placeholder_titles` filter, or matched via metadata using `softone_wc_integration_menu_placeholder_config`.
+* **Menu population helpers** – Optionally extend WooCommerce menu structures to include synced SoftOne product categories, even when the site does not expose brand taxonomies. The Appearance → Menus preview and the public storefront both inject the virtual Softone category and brand entries beneath the configured placeholders at runtime via the `wp_get_nav_menu_items` filter so editors can verify the tree before saving and shoppers always see the latest taxonomy structure. Placeholder menu items can be translated or retitled via the `softone_wc_integration_menu_placeholder_titles` filter, or matched via metadata using `softone_wc_integration_menu_placeholder_config`.
 
 = Prerequisites =
 
@@ -75,10 +75,13 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Authentication failures** – Recheck the endpoint URL formatting, confirm that the API user has access to the specified company/branch/module, and verify that firewalls allow outbound connections to the SoftOne server. Use the API tester to validate credentials with a simple `authenticate` request.
 * **Orders not exporting** – Ensure the Default SALDOC Series is configured, confirm that the customer synchronisation completed (look for notes on the order), and inspect the WooCommerce order notes/logs for `[SO-ORD-###]` messages indicating what failed.
 * **No categories appearing in menus** – Confirm that WooCommerce’s product categories exist and that recent item imports completed. The Category Sync Logs screen highlights any taxonomy creation issues.
-* **Verify Softone placeholders** – Visit **Appearance → Menus** and load the configured main menu to confirm the virtual Softone category and brand entries appear beneath their placeholders. The admin preview still injects those unsaved links for verification, while the public menu now reads the saved structure generated during the backend population workflow.
+* **Verify Softone placeholders** – Visit **Appearance → Menus** and load the configured main menu to confirm the virtual Softone category and brand entries appear beneath their placeholders. Both the admin preview and the public menu inject those runtime links under their placeholders, so confirming the tree here mirrors what visitors see on the storefront.
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.10 =
+* Feature: Inject Softone categories and brands on the public storefront at runtime via `wp_get_nav_menu_items` so menu placeholders always expand without saving generated items.
 
 = 1.10.9 =
 * Fix: Skip injecting virtual Softone menu items during menu save requests so WordPress no longer triggers “The given object ID is not that of a menu item.” errors.

--- a/docs/Functional-Overview.md
+++ b/docs/Functional-Overview.md
@@ -140,7 +140,7 @@ This document explains the plugin’s functionality based exclusively on the sou
 ## Public Menu Population
 
 - Class: `includes/class-softone-menu-populator.php`.
-- Hooks: filters `wp_get_nav_menu_items` inside wp-admin so the Appearance → Menus preview injects Softone entries while editors manage the tree; the storefront now relies on the saved menu structure built during that admin workflow instead of runtime injection.
+- Hooks: filters `wp_get_nav_menu_items` on both the public site and inside wp-admin so the Appearance → Menus preview and the storefront inject Softone entries beneath their placeholders at runtime.
 - Scope: only acts on the navigation menu identified by `softone_wc_integration_get_main_menu_name()` (defaults to `Main Menu`; filterable via `softone_wc_integration_main_menu_name`).
 - Behaviour:
   - Removes prior generated items marked with class `softone-dynamic-menu-item`.

--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -182,7 +182,7 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 			return $items;
 		}
 
-		$normalised_args = $this->normalise_admin_menu_args( $menu, $args );
+		$normalised_args = $this->normalise_menu_args( $menu, $args );
 		$menu_name       = $this->get_menu_name( $normalised_args );
 
 		if ( '' !== $menu_name ) {
@@ -195,14 +195,43 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	}
 
 	/**
-	 * Merge admin menu context into a standard wp_nav_menu style argument object.
+	 * Filter callback used on the public site to inject Softone menu entries at runtime.
+	 *
+	 * @param array<int, WP_Post|object>  $items Menu items retrieved via wp_get_nav_menu_items().
+	 * @param WP_Term|object|null         $menu  Menu object selected in wp_nav_menu().
+	 * @param array<string, mixed>|object $args  Arguments passed to wp_get_nav_menu_items().
+	 *
+	 * @return array<int, WP_Post|object>
+	 */
+	public function filter_public_menu_items( $items, $menu, $args ) {
+		if ( is_admin() ) {
+			return $items;
+		}
+
+		if ( ! is_array( $items ) || empty( $items ) ) {
+			return $items;
+		}
+
+		$normalised_args = $this->normalise_menu_args( $menu, $args );
+		$menu_name       = $this->get_menu_name( $normalised_args );
+
+		if ( '' !== $menu_name ) {
+			$this->reset_processed_menu( $menu_name );
+		}
+
+		return $this->filter_menu_items( $items, $normalised_args );
+	}
+
+
+	/**
+	 * Merge menu context into a standard wp_nav_menu style argument object.
 	 *
 	 * @param WP_Term|object|null         $menu Menu term currently being edited.
 	 * @param array<string, mixed>|object $args Original arguments from wp_get_nav_menu_items().
 	 *
 	 * @return array<string, mixed>|object
 	 */
-	private function normalise_admin_menu_args( $menu, $args ) {
+	private function normalise_menu_args( $menu, $args ) {
 		$menu_id = 0;
 
 		if ( is_object( $menu ) && isset( $menu->term_id ) ) {

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -112,7 +112,7 @@ class Softone_Woocommerce_Integration {
 		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 		} else {
-			$this->version = '1.10.9';
+			$this->version = '1.10.10';
 		}
 		$this->plugin_name = 'softone-woocommerce-integration';
 
@@ -296,10 +296,12 @@ class Softone_Woocommerce_Integration {
 	 */
 	private function define_public_hooks() {
 
-		$plugin_public = new Softone_Woocommerce_Integration_Public( $this->get_plugin_name(), $this->get_version() );
+		$plugin_public        = new Softone_Woocommerce_Integration_Public( $this->get_plugin_name(), $this->get_version() );
+		$public_menu_populator = new Softone_Menu_Populator( $this->activity_logger );
 
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+		$this->loader->add_filter( 'wp_get_nav_menu_items', $public_menu_populator, 'filter_public_menu_items', 10, 3 );
 
 	}
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.9
+ * Version:           1.10.10
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.9' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.10' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- inject Softone categories/brands on the public storefront by wiring `Softone_Menu_Populator::filter_public_menu_items()` to `wp_get_nav_menu_items`
- normalize the helper naming shared between admin and public flows and document the runtime behavior
- bump the plugin to version 1.10.10 and refresh the README/docs to describe the new runtime menu injection path

## Testing
- php -l includes/class-softone-menu-populator.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1e7d39d88327be6c0c1278f58120)