### PR TITLE
Prevent Softone menu placeholders from breaking menu saves

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.10
+Stable tag: 1.10.11
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.11 =
+* Fix: Prevent WordPress from submitting Softone placeholder menu items by disabling their form inputs on Appearance → Menus so menu saves no longer trigger “The given object ID is not that of a menu item.”.
 
 = 1.10.10 =
 * Feature: Inject Softone categories and brands on the public storefront at runtime via `wp_get_nav_menu_items` so menu placeholders always expand without saving generated items.

--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -4557,6 +4557,16 @@ array(
 )
 );
 
+if ( 'nav-menus.php' === $hook_suffix ) {
+        wp_enqueue_script(
+                'softone-nav-menu-guard',
+                plugin_dir_url( __FILE__ ) . 'js/softone-nav-menu-guard.js',
+                array(),
+                $this->version,
+                true
+        );
+}
+
 $current_page = '';
 if ( isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
         $current_page = sanitize_key( wp_unslash( $_GET['page'] ) ); // phpcs:ignore WordPress.Security.NonceVerification

--- a/admin/js/softone-nav-menu-guard.js
+++ b/admin/js/softone-nav-menu-guard.js
@@ -1,0 +1,57 @@
+/**
+ * Prevents Softone placeholder menu items from being submitted.
+ *
+ * @package Softone_Woocommerce_Integration
+ */
+( function() {
+	'use strict';
+
+	function disableMenuItemFields( menuItem ) {
+		if ( ! menuItem ) {
+			return;
+		}
+
+		var fields = menuItem.querySelectorAll( 'input, select, textarea' );
+
+		for ( var index = 0; index < fields.length; index++ ) {
+			fields[ index ].disabled = true;
+			fields[ index ].setAttribute( 'data-softone-dynamic-disabled', '1' );
+		}
+	}
+
+	function disableDynamicMenuItems( scope ) {
+		if ( ! scope || ! scope.querySelectorAll ) {
+			return;
+		}
+
+		var menuItems = scope.querySelectorAll( '.menu-item.softone-dynamic-menu-item' );
+
+		if ( ! menuItems.length ) {
+			return;
+		}
+
+		for ( var i = 0; i < menuItems.length; i++ ) {
+			disableMenuItemFields( menuItems[ i ] );
+		}
+	}
+
+	function init() {
+		var form = document.getElementById( 'update-nav-menu' );
+
+		if ( ! form ) {
+			return;
+		}
+
+		disableDynamicMenuItems( form );
+
+		form.addEventListener( 'submit', function() {
+			disableDynamicMenuItems( form );
+		} );
+	}
+
+	if ( 'loading' === document.readyState ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -109,11 +109,11 @@ class Softone_Woocommerce_Integration {
          * @since    1.0.0
          */
 	public function __construct() {
-		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-		} else {
-			$this->version = '1.10.10';
-		}
+                if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+                        $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+                } else {
+                        $this->version = '1.10.11';
+                }
 		$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.10
+ * Version:           1.10.11
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.10' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.11' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add a small admin script that disables the Softone placeholder menu item inputs before the nav menu form submits so WordPress no longer attempts to persist them and throws “The given object ID is not that of a menu item.”
- only enqueue the guard script on nav-menus.php and bump the plugin/readme versions to 1.10.11 with a new changelog entry

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a243c78408327b080d4f675e0e3f2)