### PR TITLE
Ensure nav menu guard works in Customizer

### DIFF
--- a/admin/class-softone-woocommerce-integration-admin.php
+++ b/admin/class-softone-woocommerce-integration-admin.php
@@ -4557,15 +4557,9 @@ array(
 )
 );
 
-if ( 'nav-menus.php' === $hook_suffix ) {
-        wp_enqueue_script(
-                'softone-nav-menu-guard',
-                plugin_dir_url( __FILE__ ) . 'js/softone-nav-menu-guard.js',
-                array(),
-                $this->version,
-                true
-        );
-}
+		if ( 'nav-menus.php' === $hook_suffix ) {
+			$this->enqueue_nav_menu_guard_scripts();
+		}
 
 $current_page = '';
 if ( isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
@@ -4640,6 +4634,22 @@ if ( $current_page === $this->process_trace_slug ) {
 }
 
 }
+
+	/**
+	 * Enqueues the navigation menu guard script wherever menu items may be edited.
+	 *
+	 * @return void
+	 */
+	public function enqueue_nav_menu_guard_scripts() {
+		wp_enqueue_script(
+			'softone-nav-menu-guard',
+			plugin_dir_url( __FILE__ ) . 'js/softone-nav-menu-guard.js',
+			array( 'jquery' ),
+			$this->version,
+			true
+		);
+	}
+
 
 }
 

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -272,6 +272,7 @@ class Softone_Woocommerce_Integration {
 
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+		$this->loader->add_action( 'customize_controls_enqueue_scripts', $plugin_admin, 'enqueue_nav_menu_guard_scripts' );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu' );
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
                 $this->loader->add_action( 'admin_post_softone_wc_integration_api_tester', $plugin_admin, 'handle_api_tester_request' );


### PR DESCRIPTION
## Summary
- load the Softone navigation menu guard script via a reusable helper so it runs on both the nav menu screen and the Customizer
- refactor the guard JavaScript to watch the entire document, respond to Ajax refreshes, and keep Softone placeholder inputs disabled in all contexts

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2bf11f0c8327b8245c2e87123bf9)