### PR TITLE
Prevent saving Softone menu placeholders

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.11
+Stable tag: 1.10.12
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.12 =
+* Fix: Guard nav menu saves on the server side so Softone placeholder entries are stripped from the POST payload, logged, and never passed to `wp_update_nav_menu_item`.
 
 = 1.10.11 =
 * Fix: Prevent WordPress from submitting Softone placeholder menu items by disabling their form inputs on Appearance → Menus so menu saves no longer trigger “The given object ID is not that of a menu item.”.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -109,11 +109,11 @@ class Softone_Woocommerce_Integration {
          * @since    1.0.0
          */
 	public function __construct() {
-                if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-                        $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-                } else {
-                        $this->version = '1.10.11';
-                }
+if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+} else {
+$this->version = '1.10.12';
+}
 		$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();
@@ -284,7 +284,8 @@ class Softone_Woocommerce_Integration {
 		$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_process_trace_action(), $plugin_admin, 'handle_process_trace_ajax' );
 		$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_item_import_ajax_action(), $plugin_admin, 'handle_item_import_ajax' );
 		$this->loader->add_action( 'wp_ajax_' . $plugin_admin->get_delete_main_menu_ajax_action(), $plugin_admin, 'handle_delete_main_menu_ajax' );
-		$this->loader->add_filter( 'wp_get_nav_menu_items', $admin_menu_populator, 'filter_admin_menu_items', 10, 3 );
+$this->loader->add_filter( 'wp_get_nav_menu_items', $admin_menu_populator, 'filter_admin_menu_items', 10, 3 );
+$this->loader->add_filter( 'pre_wp_update_nav_menu', $admin_menu_populator, 'guard_menu_save_payload', 10, 2 );
 
 	}
 

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.11
+ * Version:           1.10.12
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.11' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.12' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- skip Softone placeholder menu items during Appearance → Menus saves by wiring the admin menu populator into `pre_wp_update_nav_menu`, trimming the POST payload, and logging any skipped entries
- extend the regression harness to exercise the new guard so `wp_update_nav_menu_item` would only run for real menu items
- bump the plugin version and changelog to 1.10.12 to capture the regression fix

## Testing
- `php tests/menu-populator-regression-test.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2ddf8a108327b46a5a261363e7b1)