### PR TITLE
Respect WooCommerce category menu order in menu populator

### DIFF
--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -1233,15 +1233,15 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	                 return $this->category_terms;
 	         }
 
-	         // Pull every category (even empty), ordered by name
-	         $terms = get_terms(
-	                 array(
-	                         'taxonomy'   => 'product_cat',
-	                         'hide_empty' => false,
-	                         'orderby'    => 'name',
-	                         'order'      => 'ASC',
-	                 )
-	         );
+		// Pull every category (even empty) using the WooCommerce menu order
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'product_cat',
+				'hide_empty' => false,
+				'orderby'    => 'menu_order',
+				'order'      => 'ASC',
+			)
+		);
 
 	         if ( $this->is_wp_error( $terms ) ) {
 	                 $this->category_terms = array();


### PR DESCRIPTION
## Summary
- request product categories using WooCommerce menu order so dynamic items follow configured hierarchy
- expand regression test harness to sort mock terms by menu order and cover multi-level category ordering

## Testing
- php tests/menu-populator-regression-test.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a32cbe1c883278d12598fd3b5b1ee)