### PR TITLE
Bump version to 1.10.13

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.12
+Stable tag: 1.10.13
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.13 =
+* Fix: Correct the injected Softone menu hierarchy so generated category and brand placeholders nest under the intended parents before saves.
 
 = 1.10.12 =
 * Fix: Guard nav menu saves on the server side so Softone placeholder entries are stripped from the POST payload, logged, and never passed to `wp_update_nav_menu_item`.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -108,19 +108,20 @@ class Softone_Woocommerce_Integration {
          *
          * @since    1.0.0
          */
-	public function __construct() {
-if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-} else {
-$this->version = '1.10.12';
-}
-		$this->plugin_name = 'softone-woocommerce-integration';
+		public function __construct() {
+			if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+				$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+			} else {
+				$this->version = '1.10.13';
+			}
 
-		$this->load_dependencies();
-		$this->set_locale();
-		$this->define_admin_hooks();
-		$this->define_public_hooks();
-	}
+			$this->plugin_name = 'softone-woocommerce-integration';
+
+			$this->load_dependencies();
+			$this->set_locale();
+			$this->define_admin_hooks();
+			$this->define_public_hooks();
+		}
 
 	/**
 	 * Load the required dependencies for this plugin.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.12
+ * Version:           1.10.13
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.12' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.13' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- bump the plugin header version and version constant to 1.10.13 with matching fallback
- update the README stable tag and changelog with the latest menu hierarchy correction details

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a341422408327ab00a73b8de0157a)