### PR TITLE
Handle main menu name matching flexibly

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.13
+Stable tag: 1.10.14
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.14 =
+* Fix: Treat the configured main menu name case-insensitively (including slugged variants) so Softone menu items appear in wp-admin when the saved menu label differs slightly.
 
 = 1.10.13 =
 * Fix: Correct the injected Softone menu hierarchy so generated category and brand placeholders nest under the intended parents before saves.

--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -296,13 +296,33 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	 /**
 	  * Determine whether the current menu is the main menu.
 	  *
-	  * @param stdClass|array $args Menu arguments.
-	  *
-	  * @return bool
-	  */
-	 private function is_main_menu( $args ) {
-	         return softone_wc_integration_get_main_menu_name() === $this->get_menu_name( $args );
-	 }
+         * @param stdClass|array $args Menu arguments.
+         *
+         * @return bool
+         */
+	private function is_main_menu( $args ) {
+		$target_name = softone_wc_integration_get_main_menu_name();
+		$menu_name   = $this->get_menu_name( $args );
+
+		if ( '' === $target_name || '' === $menu_name ) {
+			return false;
+		}
+
+		if ( 0 === strcasecmp( $target_name, $menu_name ) ) {
+			return true;
+		}
+
+		if ( function_exists( 'sanitize_title' ) ) {
+			$target_slug = sanitize_title( $target_name );
+			$menu_slug   = sanitize_title( $menu_name );
+
+			if ( '' !== $target_slug && $target_slug === $menu_slug ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 
 	 /**
 	  * Determine the current menu name based on filter arguments.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -112,7 +112,7 @@ class Softone_Woocommerce_Integration {
 			if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 				$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 			} else {
-				$this->version = '1.10.13';
+				$this->version = '1.10.14';
 			}
 
 			$this->plugin_name = 'softone-woocommerce-integration';

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.13
+ * Version:           1.10.14
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.13' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.14' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- allow the menu populator to match the configured main menu name case-insensitively and via sanitized slugs so admin previews populate when labels vary
- bump the plugin version to 1.10.14 and update the readme changelog

## Testing
- php tests/menu-populator-regression-test.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3654aa5883278c189b0cfe1051b4)