### PR TITLE
Use WP nav helpers for menu population

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.14
+Stable tag: 1.10.15
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.15 =
+* Fix: Build injected Softone menu entries using WordPress navigation helpers so brand and category placeholders populate with the correct data.
 
 = 1.10.14 =
 * Fix: Treat the configured main menu name case-insensitively (including slugged variants) so Softone menu items appear in wp-admin when the saved menu label differs slightly.

--- a/includes/class-softone-menu-populator.php
+++ b/includes/class-softone-menu-populator.php
@@ -1405,43 +1405,49 @@ $products_menu_item = $this->find_placeholder_item( $menu_items, 'products' );
 	  *
 	  * @return WP_Post|object|null
 	  */
-	 private function create_menu_item_from_term( $term, $parent_item, $menu_order ) {
-	         if ( ! isset( $term->taxonomy, $term->term_id, $term->name ) ) {
-	                 return null;
-	         }
+	private function create_menu_item_from_term( $term, $parent_item, $menu_order ) {
+		if ( ! isset( $term->taxonomy, $term->term_id, $term->name ) ) {
+			return null;
+		}
 
-	         if ( ! function_exists( 'get_term_link' ) ) {
-	                 return null;
-	         }
+		if ( ! function_exists( 'get_term_link' ) || ! function_exists( 'wp_setup_nav_menu_item' ) ) {
+			return null;
+		}
 
-	         $url = get_term_link( $term );
+		$url = get_term_link( $term );
 
-	         if ( $this->is_wp_error( $url ) || ! is_string( $url ) ) {
-	                 return null;
-	         }
+		if ( $this->is_wp_error( $url ) || ! is_string( $url ) ) {
+			return null;
+		}
 
-		$item = clone $parent_item;
+		$menu_item_parent = $this->resolve_parent_menu_id( $parent_item );
 
-		$item->ID               = $this->next_id();
-		$item->db_id            = 0;
-		$item->menu_item_parent = $this->resolve_parent_menu_id( $parent_item );
-	         $item->object             = (string) $term->taxonomy;
-	         $item->object_id          = (int) $term->term_id;
-	         $item->type               = 'taxonomy';
-	         $item->type_label         = 'Taxonomy';
-	         $item->title              = (string) $term->name;
-	         $item->post_title         = (string) $term->name;
-	         $item->post_name          = $this->generate_post_name( $term );
-	         $item->url                = $url;
-	         $item->classes            = array( 'softone-dynamic-menu-item' );
-	         $item->xfn                = '';
-	         $item->target             = '';
-	         $item->attr_title         = '';
-	         $item->description        = '';
-	         $item->menu_order         = (int) $menu_order;
-	         $item->post_parent        = isset( $parent_item->post_parent ) ? (int) $parent_item->post_parent : 0;
-	         $item->post_status        = 'publish';
-		$item->post_type        = 'nav_menu_item';
+		$item_data = array(
+			'ID'               => $this->next_id(),
+			'db_id'            => 0,
+			'menu_item_parent' => $menu_item_parent,
+			'object'           => (string) $term->taxonomy,
+			'object_id'        => (int) $term->term_id,
+			'type'             => 'taxonomy',
+			'title'            => (string) $term->name,
+			'post_title'       => (string) $term->name,
+			'post_name'        => $this->generate_post_name( $term ),
+			'url'              => $url,
+			'classes'          => array( 'softone-dynamic-menu-item' ),
+			'xfn'              => '',
+			'target'           => '',
+			'attr_title'       => '',
+			'description'      => '',
+			'menu_order'       => (int) $menu_order,
+			'post_parent'      => 0,
+			'post_status'      => 'publish',
+			'post_type'        => 'nav_menu_item',
+		);
+
+		$item = wp_setup_nav_menu_item( (object) $item_data );
+
+		$item->menu_item_parent = (int) $menu_item_parent;
+		$item->menu_order       = (int) $menu_order;
 
 		return $item;
 	}

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -112,7 +112,7 @@ class Softone_Woocommerce_Integration {
 			if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 				$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 			} else {
-				$this->version = '1.10.14';
+				$this->version = '1.10.15';
 			}
 
 			$this->plugin_name = 'softone-woocommerce-integration';

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.14
+ * Version:           1.10.15
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.14' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.15' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- build dynamically injected Softone menu items with WordPress navigation helpers instead of manual clones
- bump the plugin version to 1.10.15 and update documentation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a39d9d5d48327a467d1859a2e5437)