### PR TITLE
Update product descriptions to new Softone fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.15
+Stable tag: 1.10.16
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.16 =
+* Change: Populate WooCommerce product descriptions using `cccsocyre2` followed by `cccsocylodes` on a new line when provided by Softone.
 
 = 1.10.15 =
 * Fix: Build injected Softone menu entries using WordPress navigation helpers so brand and category placeholders populate with the correct data.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -973,10 +973,18 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
     }
 
     // ---------- DESCRIPTIONS ----------
-    $description = $this->get_value(
-        $data,
-        array( 'long_description', 'longdescription', 'cccsocylodes', 'remarks', 'remark', 'notes' )
-    );
+    $description_lines    = array();
+    $description_line_one = $this->get_value( $data, array( 'cccsocyre2' ) );
+    if ( '' !== $description_line_one ) {
+        $description_lines[] = $description_line_one;
+    }
+
+    $description_line_two = $this->get_value( $data, array( 'cccsocylodes' ) );
+    if ( '' !== $description_line_two ) {
+        $description_lines[] = $description_line_two;
+    }
+
+    $description = implode( "\n", $description_lines );
     if ( '' !== $description ) {
         $product->set_description( $description );
     }

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -112,7 +112,7 @@ class Softone_Woocommerce_Integration {
 			if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 				$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 			} else {
-				$this->version = '1.10.15';
+				$this->version = '1.10.16';
 			}
 
 			$this->plugin_name = 'softone-woocommerce-integration';

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.15
+ * Version:           1.10.16
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.15' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.16' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- build WooCommerce product descriptions from the Softone fields `cccsocyre2` and `cccsocylodes` separated by a newline
- bump the plugin version to 1.10.16 and update the changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b3b74c4f883279bd44d7125ff4341)