### PR TITLE
Restore product description fallback and bump version to 1.10.17

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.16
+Stable tag: 1.10.17
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.17 =
+* Fix: Restore WooCommerce product descriptions when Softone payloads omit the `cccsocyre2` and `cccsocylodes` fields by falling back to legacy description values.
 
 = 1.10.16 =
 * Change: Populate WooCommerce product descriptions using `cccsocyre2` followed by `cccsocylodes` on a new line when provided by Softone.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -985,6 +985,14 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
     }
 
     $description = implode( "\n", $description_lines );
+
+    if ( '' === $description ) {
+        $description = $this->get_value(
+            $data,
+            array( 'description', 'desc', 'item_description' )
+        );
+    }
+
     if ( '' !== $description ) {
         $product->set_description( $description );
     }

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -108,20 +108,20 @@ class Softone_Woocommerce_Integration {
          *
          * @since    1.0.0
          */
-		public function __construct() {
-			if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-				$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-			} else {
-				$this->version = '1.10.16';
+			public function __construct() {
+				if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+					$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+				} else {
+					$this->version = '1.10.17';
+				}
+
+				$this->plugin_name = 'softone-woocommerce-integration';
+
+				$this->load_dependencies();
+				$this->set_locale();
+				$this->define_admin_hooks();
+				$this->define_public_hooks();
 			}
-
-			$this->plugin_name = 'softone-woocommerce-integration';
-
-			$this->load_dependencies();
-			$this->set_locale();
-			$this->define_admin_hooks();
-			$this->define_public_hooks();
-		}
 
 	/**
 	 * Load the required dependencies for this plugin.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.16
+ * Version:           1.10.17
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.16' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.17' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- fallback to legacy Softone description fields when the new multiline fields are absent so WooCommerce product descriptions are populated again
- bump the plugin version to 1.10.17 and document the change in the readme

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b409660888327abaf4e93f265700b)