### PR TITLE
Preserve HTML descriptions and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.19
+Stable tag: 1.10.20
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.20 =
+* Fix: Preserve HTML markup from Softone long and short descriptions during product imports.
 
 = 1.10.19 =
 * Change: Build product descriptions using the Softone long description followed by the Softone Item Specifications field when available.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -1007,12 +1007,12 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
     }
 
     if ( '' !== $description ) {
-        $product->set_description( $description );
+        $product->set_description( $this->decode_html_value( $description ) );
     }
 
     $short_description = $this->get_value( $data, array( 'short_description', 'cccsocyshdes' ) );
     if ( '' !== $short_description ) {
-        $product->set_short_description( $short_description );
+        $product->set_short_description( $this->decode_html_value( $short_description ) );
     }
 
     // ---------- PRICE ----------
@@ -4989,6 +4989,20 @@ protected function resolve_colour_attribute_slug() {
                 }
             }
             return '';
+        }
+
+        /**
+         * Decode HTML entities so Softone-sourced markup persists in WooCommerce descriptions.
+         *
+         * @param string $value Raw value from the Softone payload.
+         * @return string
+         */
+        protected function decode_html_value( $value ) {
+            if ( '' === $value ) {
+                return '';
+            }
+
+            return html_entity_decode( (string) $value, ENT_QUOTES, 'UTF-8' );
         }
 
         /** @return array */

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -108,20 +108,20 @@ class Softone_Woocommerce_Integration {
          *
          * @since    1.0.0
          */
-			public function __construct() {
-				if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-					$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-				} else {
-$this->version = '1.10.19';
-				}
+        public function __construct() {
+                if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+                        $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+                } else {
+                        $this->version = '1.10.20';
+                }
 
-				$this->plugin_name = 'softone-woocommerce-integration';
+                $this->plugin_name = 'softone-woocommerce-integration';
 
-				$this->load_dependencies();
-				$this->set_locale();
-				$this->define_admin_hooks();
-				$this->define_public_hooks();
-			}
+                $this->load_dependencies();
+                $this->set_locale();
+                $this->define_admin_hooks();
+                $this->define_public_hooks();
+        }
 
 	/**
 	 * Load the required dependencies for this plugin.

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.19
+ * Version:           1.10.20
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.19' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.20' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- decode Softone product descriptions and short descriptions so imported HTML markup is preserved
- bump plugin version to 1.10.20 and update changelog metadata accordingly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b496cfc348327a77e6f6714e7acc6)