### PR TITLE
Raise specification heading and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.21
+Stable tag: 1.10.22
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.22 =
+* Change: Raise the Specifications heading to an H2 when building product descriptions so specification details stand out more clearly.
 
 = 1.10.21 =
 * Change: Insert a “Specifications” heading between imported long descriptions and specification details in WooCommerce product descriptions.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -988,7 +988,7 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
 
     if ( '' !== $specifications ) {
         $description_lines[] = sprintf(
-            '<h4>%s</h4>',
+            '<h2>%s</h2>',
             esc_html__( 'Specifications', 'softone-woocommerce-integration' )
         );
         $description_lines[] = $specifications;

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -108,16 +108,16 @@ class Softone_Woocommerce_Integration {
          *
          * @since    1.0.0
          */
-        public function __construct() {
-                if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-                        $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-                } else {
-                        $this->version = '1.10.21';
-                }
+	public function __construct() {
+		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+		} else {
+			$this->version = '1.10.22';
+		}
 
-                $this->plugin_name = 'softone-woocommerce-integration';
+		$this->plugin_name = 'softone-woocommerce-integration';
 
-                $this->load_dependencies();
+		$this->load_dependencies();
                 $this->set_locale();
                 $this->define_admin_hooks();
                 $this->define_public_hooks();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.21
+ * Version:           1.10.22
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.21' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.22' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- elevate the imported Specifications heading to H2 in product descriptions
- bump plugin version references to 1.10.22 and document the change in the changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b58779d048327be85c266a547c599)