### PR TITLE
Adjust Specifications heading size and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.22
+Stable tag: 1.10.23
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.23 =
+* Tweak: Increase the Specifications heading font size to 36px so the section title remains prominent in product descriptions.
 
 = 1.10.22 =
 * Change: Raise the Specifications heading to an H2 when building product descriptions so specification details stand out more clearly.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -988,7 +988,7 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
 
     if ( '' !== $specifications ) {
         $description_lines[] = sprintf(
-            '<h2>%s</h2>',
+            '<h2 class="softone-specifications-heading">%s</h2>',
             esc_html__( 'Specifications', 'softone-woocommerce-integration' )
         );
         $description_lines[] = $specifications;

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -112,16 +112,16 @@ class Softone_Woocommerce_Integration {
 		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 		} else {
-			$this->version = '1.10.22';
+			$this->version = '1.10.23';
 		}
 
 		$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();
-                $this->set_locale();
-                $this->define_admin_hooks();
-                $this->define_public_hooks();
-        }
+		$this->set_locale();
+		$this->define_admin_hooks();
+		$this->define_public_hooks();
+	}
 
 	/**
 	 * Load the required dependencies for this plugin.

--- a/public/css/softone-woocommerce-integration-public.css
+++ b/public/css/softone-woocommerce-integration-public.css
@@ -2,3 +2,7 @@
  * All of the CSS for your public-facing functionality should be
  * included in this file.
  */
+
+.softone-specifications-heading {
+	font-size: 36px;
+}

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.22
+ * Version:           1.10.23
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.22' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.23' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add a dedicated class to the Specifications heading in generated product descriptions and style it at 36px
- bump the plugin version to 1.10.23 and update the accompanying README stable tag and changelog entry

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5a8151f08327b7e854dd9052bd7d)