### PR TITLE
Add order export payload logging

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.24
+Stable tag: 1.10.25
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,10 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.25 =
+* Feature: Add an Order Export Logs admin screen so store owners can review when WooCommerce orders hit the SoftOne exporter alongside the recorded payloads.
+* Feature: Capture the payloads sent to SoftOne when creating customers (including guest checkouts) and SALDOC documents, making it easier to diagnose why a customer or document was not created.
 
 = 1.10.24 =
 * Fix: Read Softone stock quantities from keys such as `Stock QTY` so WooCommerce inventory matches the ERP payload casing.

--- a/admin/partials/softone-woocommerce-integration-order-export-logs.php
+++ b/admin/partials/softone-woocommerce-integration-order-export-logs.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Order export log viewer markup.
+ *
+ * @package Softone_Woocommerce_Integration
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+$order_export_entries  = isset( $order_export_entries ) ? (array) $order_export_entries : array();
+$order_export_metadata = isset( $order_export_metadata ) ? (array) $order_export_metadata : array();
+$order_export_error    = isset( $order_export_error ) ? (string) $order_export_error : '';
+$order_export_limit    = isset( $order_export_limit ) ? (int) $order_export_limit : 0;
+?>
+<div class="wrap softone-order-export-logs">
+<h1><?php esc_html_e( 'Order Export Logs', 'softone-woocommerce-integration' ); ?></h1>
+<p class="description"><?php esc_html_e( 'Track when WooCommerce orders trigger the SoftOne export workflow and inspect the payloads that were sent to the API.', 'softone-woocommerce-integration' ); ?></p>
+
+<?php if ( '' !== $order_export_error ) : ?>
+<div class="notice notice-error"><p><?php echo esc_html( $order_export_error ); ?></p></div>
+<?php endif; ?>
+
+<?php if ( $order_export_limit > 0 ) : ?>
+<p><?php printf( esc_html__( 'Displaying up to %d recent events.', 'softone-woocommerce-integration' ), (int) $order_export_limit ); ?></p>
+<?php endif; ?>
+
+<?php if ( ! empty( $order_export_metadata ) ) : ?>
+<p>
+<?php if ( ! empty( $order_export_metadata['exists'] ) ) : ?>
+<?php
+printf(
+esc_html__( 'Log file: %1$s (%2$s)', 'softone-woocommerce-integration' ),
+isset( $order_export_metadata['file_path'] ) ? esc_html( $order_export_metadata['file_path'] ) : '',
+isset( $order_export_metadata['size_display'] ) ? esc_html( $order_export_metadata['size_display'] ) : ''
+);
+?>
+<?php else : ?>
+<?php esc_html_e( 'The log file will be created automatically when the next event occurs.', 'softone-woocommerce-integration' ); ?>
+<?php endif; ?>
+</p>
+<?php endif; ?>
+
+<table class="widefat fixed striped">
+<thead>
+<tr>
+<th scope="col"><?php esc_html_e( 'Time', 'softone-woocommerce-integration' ); ?></th>
+<th scope="col"><?php esc_html_e( 'Action', 'softone-woocommerce-integration' ); ?></th>
+<th scope="col"><?php esc_html_e( 'Message', 'softone-woocommerce-integration' ); ?></th>
+<th scope="col"><?php esc_html_e( 'Context', 'softone-woocommerce-integration' ); ?></th>
+</tr>
+</thead>
+<tbody>
+<?php if ( empty( $order_export_entries ) ) : ?>
+<tr>
+<td colspan="4"><?php esc_html_e( 'No order export events have been recorded yet.', 'softone-woocommerce-integration' ); ?></td>
+</tr>
+<?php else : ?>
+<?php foreach ( $order_export_entries as $entry ) : ?>
+<tr>
+<td><?php echo isset( $entry['time'] ) ? esc_html( $entry['time'] ) : ''; ?></td>
+<td><?php echo isset( $entry['action'] ) ? esc_html( $entry['action'] ) : ''; ?></td>
+<td><?php echo isset( $entry['message'] ) ? esc_html( $entry['message'] ) : ''; ?></td>
+<td>
+<?php if ( ! empty( $entry['context_display'] ) ) : ?>
+<pre class="softone-order-export-logs__context"><code><?php echo esc_html( $entry['context_display'] ); ?></code></pre>
+<?php else : ?>
+<span><?php esc_html_e( 'No additional context provided.', 'softone-woocommerce-integration' ); ?></span>
+<?php endif; ?>
+</td>
+</tr>
+<?php endforeach; ?>
+<?php endif; ?>
+</tbody>
+</table>
+</div>

--- a/includes/class-softone-sync-activity-logger.php
+++ b/includes/class-softone-sync-activity-logger.php
@@ -25,6 +25,22 @@ if ( ! class_exists( 'Softone_Sync_Activity_Logger' ) ) {
         protected $upload_dir = null;
 
         /**
+         * Target filename inside the plugin log directory.
+         *
+         * @var string
+         */
+        protected $filename = '';
+
+        /**
+         * Constructor.
+         *
+         * @param string $filename Optional log filename override.
+         */
+        public function __construct( $filename = '' ) {
+            $this->filename = $this->normalise_filename( $filename );
+        }
+
+        /**
          * Log an activity entry.
          *
          * @param string               $channel Activity channel (e.g. product_categories).
@@ -254,7 +270,48 @@ if ( ! class_exists( 'Softone_Sync_Activity_Logger' ) ) {
             $separator = defined( 'DIRECTORY_SEPARATOR' ) ? DIRECTORY_SEPARATOR : '/';
             $base_dir  = rtrim( $base_dir, '/\\' ) . $separator . 'softone-sync-logs';
 
-            return rtrim( $base_dir, '/\\' ) . $separator . self::DEFAULT_FILENAME;
+            return rtrim( $base_dir, '/\\' ) . $separator . $this->get_filename();
+        }
+
+        /**
+         * Retrieve the active filename for the logger.
+         *
+         * @return string
+         */
+        protected function get_filename() {
+            if ( '' !== $this->filename ) {
+                return $this->filename;
+            }
+
+            return self::DEFAULT_FILENAME;
+        }
+
+        /**
+         * Normalise the filename to prevent directory traversal.
+         *
+         * @param string $filename Raw filename input.
+         *
+         * @return string
+         */
+        protected function normalise_filename( $filename ) {
+            $filename = (string) $filename;
+            $filename = trim( $filename );
+
+            if ( '' === $filename ) {
+                return self::DEFAULT_FILENAME;
+            }
+
+            if ( function_exists( 'sanitize_file_name' ) ) {
+                $sanitized = sanitize_file_name( $filename );
+            } else {
+                $sanitized = preg_replace( '/[^A-Za-z0-9\-_.]/', '', $filename );
+            }
+
+            if ( '' === $sanitized ) {
+                return self::DEFAULT_FILENAME;
+            }
+
+            return $sanitized;
         }
 
         /**

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -71,12 +71,19 @@ class Softone_Woocommerce_Integration {
          */
         protected $item_cron_manager;
 
-        /**
-         * File-based activity logger instance.
-         *
-         * @var Softone_Sync_Activity_Logger
-         */
-        protected $activity_logger;
+/**
+ * File-based activity logger instance.
+ *
+ * @var Softone_Sync_Activity_Logger
+ */
+protected $activity_logger;
+
+/**
+ * File-based logger dedicated to order export diagnostics.
+ *
+ * @var Softone_Sync_Activity_Logger
+ */
+protected $order_export_logger;
 
         /**
          * Customer synchronisation service instance.
@@ -112,7 +119,7 @@ class Softone_Woocommerce_Integration {
                 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
                         $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
                 } else {
-                        $this->version = '1.10.24';
+$this->version = '1.10.25';
                 }
 
 		$this->plugin_name = 'softone-woocommerce-integration';
@@ -227,12 +234,13 @@ class Softone_Woocommerce_Integration {
 		require_once __DIR__ . '/class-softone-sku-image-attacher.php';
 
 
-		$this->loader          = new Softone_Woocommerce_Integration_Loader();
-		$this->activity_logger = new Softone_Sync_Activity_Logger();
-                $this->item_sync       = new Softone_Item_Sync( null, null, null, $this->activity_logger );
-                $this->item_cron_manager = new Softone_Item_Cron_Manager( $this->item_sync, $this->item_sync->get_logger() );
-                $this->customer_sync   = new Softone_Customer_Sync();
-                $this->order_sync      = new Softone_Order_Sync( null, $this->customer_sync );
+$this->loader              = new Softone_Woocommerce_Integration_Loader();
+$this->activity_logger     = new Softone_Sync_Activity_Logger();
+$this->order_export_logger = new Softone_Sync_Activity_Logger( 'softone-order-export.log' );
+$this->item_sync           = new Softone_Item_Sync( null, null, null, $this->activity_logger );
+$this->item_cron_manager   = new Softone_Item_Cron_Manager( $this->item_sync, $this->item_sync->get_logger() );
+$this->customer_sync       = new Softone_Customer_Sync( null, null, $this->order_export_logger );
+$this->order_sync          = new Softone_Order_Sync( null, $this->customer_sync, null, $this->order_export_logger );
                 $this->shared_module   = new Softone_Woocommerce_Integration_Shared();
 
                 $this->item_cron_manager->register_hooks( $this->loader );
@@ -266,9 +274,9 @@ class Softone_Woocommerce_Integration {
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	private function define_admin_hooks() {
+private function define_admin_hooks() {
 
-		$plugin_admin        = new Softone_Woocommerce_Integration_Admin( $this->get_plugin_name(), $this->get_version(), $this->item_sync, $this->activity_logger );
+$plugin_admin        = new Softone_Woocommerce_Integration_Admin( $this->get_plugin_name(), $this->get_version(), $this->item_sync, $this->activity_logger, $this->order_export_logger );
 		$admin_menu_populator = new Softone_Menu_Populator( $this->activity_logger );
 
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.24
+ * Version:           1.10.25
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.24' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.25' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add an Order Export Logs admin screen that surfaces the latest order completion and payload events written by a dedicated logger
- capture and store the payloads sent to SoftOne when creating customers (including guests) and when submitting SALDOC documents so operators can debug missing records
- bump the plugin version to 1.10.25 and document the new troubleshooting tools

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dbcffa11883279dc965134f501a82)