### PR TITLE
Add CUSEXTRA BOOL01 to customer payloads

### DIFF
--- a/includes/class-softone-customer-sync.php
+++ b/includes/class-softone-customer-sync.php
@@ -551,6 +551,11 @@ $this->api_client->set_data( 'CUSTOMER', $payload );
 
             return array(
                 'CUSTOMER' => array( $record ),
+                'CUSEXTRA' => array(
+                    array(
+                        'BOOL01' => '1', // SoftOne requires BOOL01=1 to expose WooCommerce customers in downstream apps.
+                    ),
+                ),
             );
         }
 

--- a/includes/class-softone-order-sync.php
+++ b/includes/class-softone-order-sync.php
@@ -405,18 +405,25 @@ array(
                 return '';
             }
 
-$payload = array( 'CUSTOMER' => array( $record ) );
+            $payload = array(
+                'CUSTOMER' => array( $record ),
+                'CUSEXTRA' => array(
+                    array(
+                        'BOOL01' => '1', // SoftOne requires BOOL01=1 to expose WooCommerce customers in downstream apps.
+                    ),
+                ),
+            );
 
-$this->log_order_event(
-'guest_customer_payload',
-__( 'Prepared SoftOne guest customer payload.', 'softone-woocommerce-integration' ),
-array(
-'order_id' => $order->get_id(),
-'payload'  => $payload,
-)
-);
+            $this->log_order_event(
+                'guest_customer_payload',
+                __( 'Prepared SoftOne guest customer payload.', 'softone-woocommerce-integration' ),
+                array(
+                    'order_id' => $order->get_id(),
+                    'payload'  => $payload,
+                )
+            );
 
-$response = $this->api_client->set_data( 'CUSTOMER', $payload );
+            $response = $this->api_client->set_data( 'CUSTOMER', $payload );
 
             if ( empty( $response['id'] ) ) {
                 return '';


### PR DESCRIPTION
## Summary
- add the SoftOne CUSEXTRA BOOL01 flag to the reusable customer payload builder
- include the same CUSEXTRA data when creating guest customers from orders so the API receives consistent payloads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de43c784083279a9ea23baab42693)