### PR TITLE
Bump plugin version to 1.10.27

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.26
+Stable tag: 1.10.27
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.27 =
+* Maintenance: Bump the plugin version for the next release.
 
 = 1.10.26 =
 * Tweak: Log each SoftOne SALDOC export attempt, including successes and failures, so administrators can trace retries and last errors from the Order Export Logs screen.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -115,14 +115,14 @@ protected $order_export_logger;
          *
          * @since    1.0.0
          */
-	public function __construct() {
-		if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
-			$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
-		} else {
-			$this->version = '1.10.26';
-		}
+		public function __construct() {
+			if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
+				$this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
+			} else {
+				$this->version = '1.10.27';
+			}
 
-		$this->plugin_name = 'softone-woocommerce-integration';
+			$this->plugin_name = 'softone-woocommerce-integration';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.26
+ * Version:           1.10.27
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.26' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.27' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- bump the plugin header and internal constants to version 1.10.27
- update the readme stable tag and add a changelog entry for the maintenance release

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dec6a0cac8327b4598192aa422305)