### PR TITLE
Handle SoftOne session expiry for operation aborted responses

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.29
+Stable tag: 1.10.30
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.30 =
+* Fix: Treat SoftOne "Operation aborted" responses as expired sessions and refresh the client ID before retrying SALDOC exports.
 
 = 1.10.29 =
 * Fix: When SoftOne reports a duplicate customer code during sync, reuse the matching SoftOne record instead of failing the export.

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -1214,7 +1214,16 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 return false;
             }
 
-            $indicators = array( 'clientid', 'client id', 'expired', 'session', 'authenticate', 'authenticat', 'not valid' );
+            $indicators = array(
+                'clientid',
+                'client id',
+                'expired',
+                'session',
+                'authenticate',
+                'authenticat',
+                'not valid',
+                'operation aborted',
+            );
 
             foreach ( $indicators as $indicator ) {
                 if ( false !== strpos( $message, $indicator ) ) {

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -119,7 +119,7 @@ public function __construct() {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.10.29';
+$this->version = '1.10.30';
 }
 
 			$this->plugin_name = 'softone-woocommerce-integration';

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.29
+ * Version:           1.10.30
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.29' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.30' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- treat SoftOne "Operation aborted" responses as authentication failures so the client session refreshes before retrying SALDOC exports
- bump plugin metadata to version 1.10.30 and update the changelog

## Testing
- php tests/minimal-configuration-defaults-test.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e17e3244c8327a03874d1b5572f28)