### PR TITLE
Ensure AppID casing and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.30
+Stable tag: 1.10.31
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.31 =
+* Fix: Send the SoftOne AppID using consistent casing across all payloads and documentation references.
 
 = 1.10.30 =
 * Fix: Treat SoftOne "Operation aborted" responses as expired sessions and refresh the client ID before retrying SALDOC exports.

--- a/Softone_PT_Kids_Interface.md
+++ b/Softone_PT_Kids_Interface.md
@@ -49,7 +49,7 @@ The login call must always be the first call. It returns a `clientID` used for t
   "service": "login",
   "username": "[REDACTED_USER]",
   "password": "[REDACTED_PASS]",
-  "appId": 1000
+  "AppID": 1000
 }
 ```
 
@@ -79,7 +79,7 @@ The login call must always be the first call. It returns a `clientID` used for t
   "sn": "[REDACTED_SN]",
   "off": false,
   "pin": false,
-  "appid": "1000"
+  "AppID": "1000"
 }
 ```
 
@@ -90,7 +90,7 @@ The login call must always be the first call. It returns a `clientID` used for t
 - `ver`: SoftOne server version string.  
 - `sn`: Server serial number (**redacted**).  
 - `off`/`pin`: Flags related to offline/pin requirements (if any).  
-- `appid`: Application identifier used in calls.
+- `AppID`: Application identifier used in calls.
 
 ---
 
@@ -153,7 +153,7 @@ Returns the details of a **single** customer (as per the PDF example) using a st
 {
   "service": "SqlData",
   "clientid": "[REDACTED_CLIENT_ID]",
-  "appId": 1000,
+  "AppID": 1000,
   "SqlName": "getCustomers"
 }
 ```
@@ -198,7 +198,7 @@ Returns inventory/items via a stored SQL name (with optional parameters like `pM
 {
   "service": "SqlData",
   "clientid": "[REDACTED_CLIENT_ID]",
-  "appId": 1000,
+  "AppID": 1000,
   "SqlName": "getItems",
   "pMins": 99999
 }
@@ -280,7 +280,7 @@ Use `setData` to insert/modify records for native or custom objects. Only includ
 {
   "service": "setData",
   "clientID": "[REDACTED_CLIENT_ID]",
-  "appID": 1000,
+  "AppID": 1000,
   "object": "CUSTOMER",
   "data": {
     "CUSTOMER": [
@@ -326,7 +326,7 @@ Use `setData` to insert/modify records for native or custom objects. Only includ
 {
   "service": "setData",
   "clientID": "[REDACTED_CLIENT_ID]",
-  "appID": 1000,
+  "AppID": 1000,
   "object": "SALDOC",
   "data": {
     "SALDOC": [
@@ -384,7 +384,7 @@ Use `setData` to insert/modify records for native or custom objects. Only includ
 - **sn**: Server serial number (**redacted**).  
 - **off**: Offline mode flag.  
 - **pin**: Whether a pin is required.  
-- **appid**: Echo of app id used.
+- **AppID**: Echo of AppID used.
 
 ### Authenticate (`service: "authenticate"`)
 - **success**, **clientID**: As above (clientID may change).  

--- a/docs/Functional-Overview.md
+++ b/docs/Functional-Overview.md
@@ -54,9 +54,9 @@ This document explains the plugin’s functionality based exclusively on the sou
 - Class: `includes/class-softone-api-client.php`.
 - Responsibilities: wraps `wp_remote_post()` to call SoftOne services, handles login/auth/authenticated calls, request/response plumbing, and client ID caching.
 - Key methods:
-  - `login()`: POST `username`, `password`, optional `appId`; stores handshake values; requires both credentials.
+  - `login()`: POST `username`, `password`, optional `AppID`; stores handshake values; requires both credentials.
   - `authenticate($clientID)`: POST handshake fields; returns a new/validated client ID.
-  - `sql_data($sqlName, $arguments = [], $extra = [])`: calls `SqlData` with `SqlName`, optional `params` and `appId`.
+  - `sql_data($sqlName, $arguments = [], $extra = [])`: calls `SqlData` with `SqlName`, optional `params` and `AppID`.
   - `set_data($object, $data, $extra = [])`: calls `setData` with a payload like `{ OBJECT: [...], ... }`.
   - Internal client ID lifecycle: caches in transient `softone_woocommerce_integration_client_id` and persists metadata in option `softone_woocommerce_integration_client_meta`. TTL derived from responses (`EXPTIME`, `expires_in`, etc.) with fallback to `client_id_ttl`.
 - Filters:

--- a/includes/class-softone-api-client.php
+++ b/includes/class-softone-api-client.php
@@ -261,7 +261,7 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
             );
 
             if ( null !== $this->app_id && '' !== $this->app_id ) {
-                $payload['appId'] = $this->normalize_app_id( $this->app_id );
+                $payload['AppID'] = $this->normalize_app_id( $this->app_id );
             }
 
             /**
@@ -345,8 +345,8 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 $extra
             );
 
-            if ( null !== $this->app_id && '' !== $this->app_id && ! isset( $payload['appId'] ) ) {
-                $payload['appId'] = $this->normalize_app_id( $this->app_id );
+            if ( null !== $this->app_id && '' !== $this->app_id && ! isset( $payload['AppID'] ) ) {
+                $payload['AppID'] = $this->normalize_app_id( $this->app_id );
             }
 
             if ( ! empty( $arguments ) ) {
@@ -382,8 +382,8 @@ if ( ! class_exists( 'Softone_API_Client' ) ) {
                 $extra
             );
 
-            if ( null !== $this->app_id && '' !== $this->app_id && ! isset( $payload['appId'] ) ) {
-                $payload['appId'] = $this->normalize_app_id( $this->app_id );
+            if ( null !== $this->app_id && '' !== $this->app_id && ! isset( $payload['AppID'] ) ) {
+                $payload['AppID'] = $this->normalize_app_id( $this->app_id );
             }
 
             return $this->call_service( 'setData', $payload );

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -119,7 +119,7 @@ public function __construct() {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.10.30';
+$this->version = '1.10.31';
 }
 
 			$this->plugin_name = 'softone-woocommerce-integration';

--- a/includes/softone-woocommerce-integration-settings.php
+++ b/includes/softone-woocommerce-integration-settings.php
@@ -199,7 +199,7 @@ if ( ! function_exists( 'softone_wc_integration_get_password' ) ) {
 
 if ( ! function_exists( 'softone_wc_integration_get_app_id' ) ) {
     /**
-     * Retrieve the SoftOne application identifier (appId).
+     * Retrieve the SoftOne application identifier (AppID).
      *
      * Some SoftOne environments require the application identifier to be provided with
      * each request. By surfacing the value via a dedicated helper we keep consumers from

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.30
+ * Version:           1.10.31
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.30' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.31' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';

--- a/tests/login-handshake-test.php
+++ b/tests/login-handshake-test.php
@@ -282,7 +282,7 @@ foreach ( array( 'company', 'branch', 'module', 'refid' ) as $field ) {
     }
 }
 
-if ( ! isset( $login_payload['appId'] ) || '9000' !== (string) $login_payload['appId'] ) {
+if ( ! isset( $login_payload['AppID'] ) || '9000' !== (string) $login_payload['AppID'] ) {
     fwrite( STDERR, "Login payload is missing the App ID.\n" );
     exit( 1 );
 }
@@ -313,7 +313,7 @@ foreach ( array( 'company' => '555', 'branch' => '666', 'module' => '777', 'refi
     }
 }
 
-if ( isset( $authenticate_payload['appId'] ) ) {
+if ( isset( $authenticate_payload['AppID'] ) ) {
     fwrite( STDERR, "Authenticate payload must not include the App ID.\n" );
     exit( 1 );
 }
@@ -342,7 +342,7 @@ if ( isset( $sql_payload['clientID'] ) ) {
     exit( 1 );
 }
 
-if ( ! isset( $sql_payload['appId'] ) || '9000' !== (string) $sql_payload['appId'] ) {
+if ( ! isset( $sql_payload['AppID'] ) || '9000' !== (string) $sql_payload['AppID'] ) {
     fwrite( STDERR, "SqlData payload is missing the App ID.\n" );
     exit( 1 );
 }

--- a/tests/password-sanitization-login-test.php
+++ b/tests/password-sanitization-login-test.php
@@ -193,8 +193,8 @@ if ( empty( $client->captured_payload ) || $client->captured_payload['password']
     exit( 1 );
 }
 
-if ( ! isset( $client->captured_payload['appId'] ) ) {
-    fwrite( STDERR, "Login payload did not include the configured appId value.\n" );
+if ( ! isset( $client->captured_payload['AppID'] ) ) {
+    fwrite( STDERR, "Login payload did not include the configured AppID value.\n" );
     exit( 1 );
 }
 
@@ -227,8 +227,8 @@ if ( empty( $client_with_spaces->captured_payload ) || $client_with_spaces->capt
     exit( 1 );
 }
 
-if ( '0' !== $client->captured_payload['appId'] ) {
-    fwrite( STDERR, "Login payload did not preserve an appId configured as '0'.\n" );
+if ( '0' !== $client->captured_payload['AppID'] ) {
+    fwrite( STDERR, "Login payload did not preserve an AppID configured as '0'.\n" );
     exit( 1 );
 }
 
@@ -244,13 +244,13 @@ $padded_settings = $admin->sanitize_settings(
 $padded_client = new Softone_API_Client_Login_Test( $padded_settings );
 $padded_client->login();
 
-if ( empty( $padded_client->captured_payload ) || ! isset( $padded_client->captured_payload['appId'] ) ) {
-    fwrite( STDERR, "Login payload with padded appId did not include the expected value.\n" );
+if ( empty( $padded_client->captured_payload ) || ! isset( $padded_client->captured_payload['AppID'] ) ) {
+    fwrite( STDERR, "Login payload with padded AppID did not include the expected value.\n" );
     exit( 1 );
 }
 
-if ( '0010' !== $padded_client->captured_payload['appId'] ) {
-    fwrite( STDERR, "Login payload did not preserve leading zeros in appId.\n" );
+if ( '0010' !== $padded_client->captured_payload['AppID'] ) {
+    fwrite( STDERR, "Login payload did not preserve leading zeros in AppID.\n" );
     exit( 1 );
 }
 


### PR DESCRIPTION
## Summary
- enforce consistent `AppID` casing across payloads, tests, and documentation
- bump plugin metadata to version 1.10.31 and note the change in the changelog

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e1cc44db48327b66c34aeb79a43b5)