### PR TITLE
Revert to 1.10.31 codebase and bump version to 1.10.37

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.31
+Stable tag: 1.10.37
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.37 =
+* Maintenance: Revert the codebase to the 1.10.31 release while preparing a new package version.
 
 = 1.10.31 =
 * Fix: Send the SoftOne AppID using consistent casing across all payloads and documentation references.

--- a/includes/class-softone-customer-sync.php
+++ b/includes/class-softone-customer-sync.php
@@ -665,14 +665,14 @@ $this->api_client->set_data( 'CUSTOMER', $payload );
                 'ADDRESS2'    => $address_2,
                 'CITY'        => $city,
                 'ZIP'         => $postcode,
-                'COUNTRY'     => (int) $softone_country,
-                'AREAS'       => (int) $this->api_client->get_areas(),
-                'SOCURRENCY'  => (int) $this->api_client->get_socurrency(),
-                'TRDCATEGORY' => (int) $this->api_client->get_trdcategory(),
+                'COUNTRY'     => $softone_country,
+                'AREAS'       => $this->api_client->get_areas(),
+                'SOCURRENCY'  => $this->api_client->get_socurrency(),
+                'TRDCATEGORY' => $this->api_client->get_trdcategory(),
             );
 
             if ( null !== $trdr ) {
-                $record['TRDR'] = (int) $trdr;
+                $record['TRDR'] = (string) $trdr;
             }
 
             $record = array_filter( $record, array( $this, 'filter_empty_value' ) );
@@ -685,7 +685,7 @@ $this->api_client->set_data( 'CUSTOMER', $payload );
                 return array();
             }
 
-            $payload = array(
+            return array(
                 'CUSTOMER' => array( $record ),
                 'CUSEXTRA' => array(
                     array(
@@ -693,37 +693,6 @@ $this->api_client->set_data( 'CUSTOMER', $payload );
                     ),
                 ),
             );
-
-            $this->validate_payload( $payload );
-
-            return $payload;
-        }
-
-        /**
-         * Validate the CUSTOMER payload for type correctness.
-         *
-         * @param array $payload The constructed payload.
-         * @return void
-         */
-        protected function validate_payload( $payload ) {
-            if ( ! isset( $payload['CUSTOMER'][0] ) ) {
-                return;
-            }
-
-            $record = $payload['CUSTOMER'][0];
-            $issues = array();
-
-            $int_fields = array( 'COUNTRY', 'AREAS', 'SOCURRENCY', 'TRDCATEGORY', 'TRDR' );
-
-            foreach ( $int_fields as $field ) {
-                if ( isset( $record[ $field ] ) && ! is_int( $record[ $field ] ) ) {
-                    $issues[] = sprintf( '%s is %s (expected int)', $field, gettype( $record[ $field ] ) );
-                }
-            }
-
-            if ( ! empty( $issues ) ) {
-                $this->log( 'warning', '[SO-VAL-002] Customer payload validation warnings detected.', array( 'issues' => $issues ) );
-            }
         }
 
         /**

--- a/includes/class-softone-order-sync.php
+++ b/includes/class-softone-order-sync.php
@@ -456,8 +456,8 @@ array(
             }
 
             $header    = array(
-                'SERIES'    => '' !== $series ? (int) $series : null,
-                'TRDR'      => (int) $trdr,
+                'SERIES'    => '' !== $series ? $series : null,
+                'TRDR'      => (string) $trdr,
                 'VARCHAR01' => (string) $order_id,
                 'TRNDATE'   => $this->format_order_date( $order ),
                 'COMMENTS'  => $this->build_order_comments( $order ),
@@ -472,82 +472,13 @@ array(
 
             if ( '' !== $warehouse ) {
                 $payload['MTRDOC'] = array(
-                    array( 'WHOUSE' => (int) $warehouse ),
+                    array( 'WHOUSE' => $warehouse ),
                 );
             }
 
             $payload = apply_filters( 'softone_wc_integration_order_payload', $payload, $order, $trdr, $this );
-            
-            $this->validate_payload( $payload );
 
             return $payload;
-        }
-
-        /**
-         * Validate the SALDOC payload for type correctness.
-         *
-         * @param array $payload The constructed payload.
-         * @return void
-         */
-        protected function validate_payload( $payload ) {
-            if ( ! isset( $payload['SALDOC'][0] ) ) {
-                return;
-            }
-
-            $header = $payload['SALDOC'][0];
-            $issues = array();
-
-            if ( isset( $header['SERIES'] ) && ! is_int( $header['SERIES'] ) ) {
-                $issues[] = sprintf( 'SERIES is %s (expected int)', gettype( $header['SERIES'] ) );
-            }
-            if ( isset( $header['TRDR'] ) && ! is_int( $header['TRDR'] ) ) {
-                $issues[] = sprintf( 'TRDR is %s (expected int)', gettype( $header['TRDR'] ) );
-            }
-
-            if ( isset( $payload['MTRDOC'][0]['WHOUSE'] ) && ! is_int( $payload['MTRDOC'][0]['WHOUSE'] ) ) {
-                $issues[] = sprintf( 'WHOUSE is %s (expected int)', gettype( $payload['MTRDOC'][0]['WHOUSE'] ) );
-            }
-
-            if ( isset( $payload['ITELINES'] ) && is_array( $payload['ITELINES'] ) ) {
-                foreach ( $payload['ITELINES'] as $index => $line ) {
-                    if ( isset( $line['MTRL'] ) && ! is_int( $line['MTRL'] ) ) {
-                        $issues[] = sprintf( 'Item %d MTRL is %s (expected int)', $index, gettype( $line['MTRL'] ) );
-                    }
-                }
-            }
-
-            if ( ! empty( $issues ) ) {
-                $this->log( 'warning', '[SO-VAL-001] Payload validation warnings detected.', array( 'issues' => $issues ) );
-            }
-        }
-
-        /**
-         * Verify that an item exists in SoftOne.
-         *
-         * @param int $mtrl The SoftOne item ID.
-         * @return bool True if exists, false otherwise.
-         */
-        protected function verify_item_exists( $mtrl ) {
-            try {
-                $response = $this->api_client->sql_data( 'getItems', array( 'MTRL' => $mtrl ) );
-                $rows = isset( $response['rows'] ) && is_array( $response['rows'] ) ? $response['rows'] : array();
-                
-                foreach ( $rows as $row ) {
-                    if ( isset( $row['MTRL'] ) && (int) $row['MTRL'] === $mtrl ) {
-                        return true;
-                    }
-                }
-            } catch ( Exception $e ) {
-                $this->log( 'warning', 'Failed to verify item existence.', array( 'mtrl' => $mtrl, 'error' => $e->getMessage() ) );
-                // Assume true on error to avoid blocking valid items due to transient API issues? 
-                // Or false? User wants to "see that items are correct". 
-                // If API fails, we can't verify. Let's return false to be safe if we want strictness, 
-                // but maybe true to be lenient. 
-                // Given the user's request, strictness seems preferred.
-                return false;
-            }
-
-            return false;
         }
 
         /**
@@ -638,17 +569,8 @@ array(
                     continue;
                 }
 
-                if ( ! $this->verify_item_exists( (int) $mtrl ) ) {
-                    $this->log( 'error', __( '[SO-ORD-012] Order line skipped because the SoftOne item (MTRL) does not exist.', 'softone-woocommerce-integration' ), array(
-                        'order_id'   => $order->get_id(),
-                        'item_id'    => $item->get_id(),
-                        'mtrl'       => $mtrl,
-                    ) );
-                    continue;
-                }
-
                 $line = array(
-                    'MTRL'     => (int) $mtrl,
+                    'MTRL'     => (string) $mtrl,
                     'QTY1'     => $this->format_quantity( $quantity ),
                     'COMMENTS1'=> $item->get_name(),
                 );

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -119,7 +119,7 @@ public function __construct() {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.10.31';
+$this->version = '1.10.37';
 }
 
 			$this->plugin_name = 'softone-woocommerce-integration';

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.36
+ * Version:           1.10.37
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.36' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.37' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- revert the plugin files to the 1.10.31 codebase baseline
- bump the plugin metadata and version constants to 1.10.37
- update the readme stable tag and changelog to reflect the rollback release

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3034ace48327ac25262acffa8c86)