### PR TITLE
Bump plugin version to 1.10.45

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.44
+Stable tag: 1.10.45
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.45 =
+* Fix: Correct SALDOC payload ordering so exported requests follow the SoftOne sequence expected by the API.
 
 = 1.10.40 =
 * Change: Log SoftOne customer lookups in the order export log and carry customer context (TRDR/branch) into SALDOC payloads to match the documented request shape.

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -119,7 +119,7 @@ public function __construct() {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.10.44';
+$this->version = '1.10.45';
 }
 
 			$this->plugin_name = 'softone-woocommerce-integration';

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.44
+ * Version:           1.10.45
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.44' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.45' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- bump plugin version to 1.10.45 across metadata and bootstrap
- update stable tag and changelog with SALDOC payload ordering fix

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217b64cfc08327866e9d067a6e0515)