### PR TITLE
Remove warehouse envelope from SALDOC payload

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.45
+Stable tag: 1.10.46
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.46 =
+* Change: Remove the MTRDOC warehouse envelope from SALDOC exports so SoftOne receives only the core document and item lines.
 
 = 1.10.45 =
 * Fix: Correct SALDOC payload ordering so exported requests follow the SoftOne sequence expected by the API.

--- a/Softone_PT_Kids_Interface.md
+++ b/Softone_PT_Kids_Interface.md
@@ -327,25 +327,22 @@ Use `setData` to insert/modify records for native or custom objects. Only includ
   "service": "setData",
   "clientID": "[REDACTED_CLIENT_ID]",
   "AppID": 1000,
-  "object": "SALDOC",
-  "data": {
-    "SALDOC": [
-      {
-        "SERIES": 3000,
-        "TRDR": 2937,
-        "VARCHAR01": 1234567,
-        "TRNDATE": "2024-08-05 00:00:00",
-        "COMMENTS": "No comment"
-      }
-    ],
-    "MTRDOC": [
-      { "WHOUSE": 101 }
-    ],
-    "ITELINES": [
-      { "MTRL": 328, "QTY1": 2, "COMMENTS1": "test" },
-      { "MTRL": 329, "QTY1": 1, "COMMENTS1": "" },
-      { "MTRL": 331, "QTY1": 1, "COMMENTS1": "" }
-    ]
+    "object": "SALDOC",
+    "data": {
+      "SALDOC": [
+        {
+          "SERIES": 3000,
+          "TRDR": 2937,
+          "VARCHAR01": 1234567,
+          "TRNDATE": "2024-08-05 00:00:00",
+          "COMMENTS": "No comment"
+        }
+      ],
+      "ITELINES": [
+        { "MTRL": 328, "QTY1": 2, "COMMENTS1": "test" },
+        { "MTRL": 329, "QTY1": 1, "COMMENTS1": "" },
+        { "MTRL": 331, "QTY1": 1, "COMMENTS1": "" }
+      ]
   }
 }
 ```
@@ -358,12 +355,11 @@ Use `setData` to insert/modify records for native or custom objects. Only includ
 **What it means:**
 - `object: "SALDOC"`: Sales document header table.  
 - `SERIES`: Document series (defines numbering rules/doctype).  
-- `TRDR`: Customer id (**must match** an existing `TRDR`, e.g., “2937” created above).  
-- `VARCHAR01`: Free text/auxiliary field — in your usage this stores the **OpenCart Order ID** mapping.  
-- `TRNDATE`: Transaction date/time.  
-- `COMMENTS`: Header comments.  
-- `MTRDOC`: Movement/warehouse context (e.g., `WHOUSE` 101).  
-- `ITELINES`: Line items with `MTRL` (item id), `QTY1` (quantity), optional `COMMENTS1`.  
+- `TRDR`: Customer id (**must match** an existing `TRDR`, e.g., “2937” created above).
+- `VARCHAR01`: Free text/auxiliary field — in your usage this stores the **OpenCart Order ID** mapping.
+- `TRNDATE`: Transaction date/time.
+- `COMMENTS`: Header comments.
+- `ITELINES`: Line items with `MTRL` (item id), `QTY1` (quantity), optional `COMMENTS1`.
 - Response `id`: The created sales document id.
 
 ---

--- a/docs/Functional-Overview.md
+++ b/docs/Functional-Overview.md
@@ -128,11 +128,10 @@ This document explains the plugin’s functionality based exclusively on the sou
   - `_softone_trdr` (copied if determined during export)
 - Determine TRDR:
   - Prefer order meta; else use customer meta via `Softone_Customer_Sync::ensure_customer_trdr()`; for guests, may create a SoftOne customer using billing/shipping data (requires country mappings).
-- Payload:
-  - `SALDOC` header: includes `SERIES` (default from settings), `TRDR`, `VARCHAR01` (Woo order id), `TRNDATE` (order date), `COMMENTS` (compiled from payment/shipping methods, transaction and shipping ids, shipping/billing country).
-  - `ITELINES`: collects order line items with `MTRL` from product meta `_softone_mtrl_id`, `QTY1`, and `COMMENTS1` line name. Skips lines without a known SoftOne `MTRL`.
-  - `MTRDOC`: included when default `warehouse` is configured.
-  - Filter: `softone_wc_integration_order_payload` to customize before transmission.
+  - Payload:
+    - `SALDOC` header: includes `SERIES` (default from settings), `TRDR`, `VARCHAR01` (Woo order id), `TRNDATE` (order date), `COMMENTS` (compiled from payment/shipping methods, transaction and shipping ids, shipping/billing country).
+    - `ITELINES`: collects order line items with `MTRL` from product meta `_softone_mtrl_id`, `QTY1`, and `COMMENTS1` line name. Skips lines without a known SoftOne `MTRL`.
+    - Filter: `softone_wc_integration_order_payload` to customize before transmission.
 - Transmission and retry:
   - Calls `set_data('SALDOC', $payload)` with retries. Filters: `softone_wc_integration_order_sync_max_attempts`, `softone_wc_integration_order_sync_retry_delay`.
   - On success, stores `_softone_document_id` and adds private order notes.

--- a/includes/class-softone-order-sync.php
+++ b/includes/class-softone-order-sync.php
@@ -609,12 +609,6 @@ $trdr = (string) $order->get_meta( self::ORDER_META_TRDR, true );
 				'SALDOC' => array( $header ),
 			);
 
-			if ( '' !== $warehouse ) {
-				$payload['MTRDOC'] = array(
-					array( 'WHOUSE' => $warehouse ),
-				);
-			}
-
 			$payload['ITELINES'] = $this->build_item_lines( $order );
 
 			$payload = apply_filters( 'softone_wc_integration_order_payload', $payload, $order, $trdr, $this );

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -119,7 +119,7 @@ public function __construct() {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.10.45';
+$this->version = '1.10.46';
 }
 
 			$this->plugin_name = 'softone-woocommerce-integration';

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.45
+ * Version:           1.10.46
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.45' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.46' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- remove the MTRDOC warehouse block from SALDOC payload generation and documentation
- bump plugin metadata and changelog to version 1.10.46

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926accecfec8327b075291128d16de6)