### PR TITLE
Use SoftOne available quantity for WooCommerce stock

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: softone, erp, woocommerce, integration, inventory, orders, api
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.10.46
+Stable tag: 1.10.47
 =======
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,9 @@ Yes. Filters such as `softone_wc_integration_order_payload`, `softone_wc_integra
 * **Cron events not running** – Verify WP-Cron execution by visiting `wp-cron.php` manually or configuring a real cron job. You can reschedule events programmatically via `Softone_Item_Cron_Manager::schedule_event()`.
 
 == Changelog ==
+
+= 1.10.47 =
+* Change: Pull WooCommerce stock quantities from the SoftOne "Available QTY" field so storefront inventory reflects sellable stock.
 
 = 1.10.46 =
 * Change: Remove the MTRDOC warehouse envelope from SALDOC exports so SoftOne receives only the core document and item lines.

--- a/includes/class-softone-item-sync.php
+++ b/includes/class-softone-item-sync.php
@@ -1073,8 +1073,8 @@ if ( ! class_exists( 'Softone_Item_Sync' ) ) {
         );
     }
 
-    // ---------- STOCK ----------
-    $stock_quantity = $this->get_value( $data, array( 'stock_qty', 'qty1' ) );
+// ---------- STOCK ----------
+$stock_quantity = $this->get_value( $data, array( 'available_qty', 'stock_qty', 'qty1' ) );
     if ( '' !== $stock_quantity ) {
         $stock_amount = wc_stock_amount( $stock_quantity );
         if ( 0 === $stock_amount && softone_wc_integration_should_force_minimum_stock() ) {

--- a/includes/class-softone-woocommerce-integration.php
+++ b/includes/class-softone-woocommerce-integration.php
@@ -119,7 +119,7 @@ public function __construct() {
 if ( defined( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION' ) ) {
 $this->version = SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION;
 } else {
-$this->version = '1.10.46';
+$this->version = '1.10.47';
 }
 
 			$this->plugin_name = 'softone-woocommerce-integration';

--- a/softone-woocommerce-integration.php
+++ b/softone-woocommerce-integration.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Softone Woocommerce Integration
  * Plugin URI:        https://www.georgenicolaou.me/plugins/softone-woocommerce-integration
  * Description:       Softone Woocommerce Integration
- * Version:           1.10.46
+ * Version:           1.10.47
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me//
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.46' );
+define( 'SOFTONE_WOOCOMMERCE_INTEGRATION_VERSION', '1.10.47' );
 
 // Load Composer autoloader when present (e.g. when installed via Composer).
 $softone_wc_integration_autoload = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- derive WooCommerce stock quantities from the SoftOne Available QTY field
- bump the plugin version metadata and changelog to 1.10.47

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692991466c0c8327bfacfa5c2965f6f8)